### PR TITLE
add EC2 resource detector to default config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,7 +25,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch, queued_retry, resourcedetection/ec2]
+      processors: [batch, resourcedetection/ec2, queued_retry]
       exporters: [awsxray]
     metrics:
       receivers: [otlp]

--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,11 @@ processors:
   batch:
     timeout: 30s
   queued_retry:
+  resourcedetection:
+  resourcedetection/ec2:
+    detectors: [env, ec2]
+    timeout: 2s
+    override: false
 
 exporters:
   awsxray:
@@ -20,7 +25,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch, queued_retry]
+      processors: [batch, queued_retry, resourcedetection/ec2]
       exporters: [awsxray]
     metrics:
       receivers: [otlp]


### PR DESCRIPTION
We would like all AWS resource metadata to be recorded in X-Ray traces by default (e.g. opt-out). This PR adds the EC2 resource detector to the default config we'll vend to customers in our distribution to accomplish just that for EC2 instances. It will record EC2 instance metadata in traces or fail fast if it does not detect that it's in an EC2 environment.