### PR TITLE
Enforce vanity import URL

### DIFF
--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package main
+package main // import "aws-observability.io/collector/cmd/awscollector"
 
 import (
 	"fmt"
@@ -23,8 +23,8 @@ import (
 	"aws-observability.io/collector/pkg/defaultcomponents"
 	"aws-observability.io/collector/pkg/logger"
 	"aws-observability.io/collector/tools/version"
-	"go.opentelemetry.io/collector/service"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/service"
 	"go.uber.org/zap/zapcore"
 )
 

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package defaultcomponents
+package defaultcomponents // import "aws-observability.io/collector/defaultcomponents
 
 import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
@@ -39,8 +39,8 @@ func Components() (component.Factories, error) {
 
 	// enable the selected receivers
 	factories.Receivers, err = component.MakeReceiverFactoryMap(
-	    prometheusreceiver.NewFactory(),
-	    otlpreceiver.NewFactory(),
+		prometheusreceiver.NewFactory(),
+		otlpreceiver.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)
@@ -48,12 +48,12 @@ func Components() (component.Factories, error) {
 
 	// enable the selected exporters
 	factories.Exporters, err = component.MakeExporterFactoryMap(
-	    awsxrayexporter.NewFactory(),
-	    awsemfexporter.NewFactory(),
-	    prometheusexporter.NewFactory(),
-	    loggingexporter.NewFactory(),
-	    fileexporter.NewFactory(),
-	    otlpexporter.NewFactory(),
+		awsxrayexporter.NewFactory(),
+		awsemfexporter.NewFactory(),
+		prometheusexporter.NewFactory(),
+		loggingexporter.NewFactory(),
+		fileexporter.NewFactory(),
+		otlpexporter.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package logger
+package logger // import "aws-observability.io/collector/logger
 
 import (
 	"fmt"


### PR DESCRIPTION
Otherwise, users can go get the binary and import the packages from the github.com URL.