### PR TITLE
Update README to include new components

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,22 +21,24 @@ Use the community resources below for getting help with AWS OTel Collector.
 
 This table represents the supported components of AWS OTel Collector in 2020. The highlighted components below are developed by AWS in-house. The rest of the components in the table are the essential default components that AWS OTel Collector will support.
  
-| Receiver             | Processor                     | Exporter           | Extensions             |
-|----------------------|-------------------------------|--------------------|------------------------|
-| prometheusreceiver   | attributesprocessor           | *awsxrayexporter*  | healthcheckextension   |
-| otlpreceiver         | resourceprocessor             | *awsemfexporter*   | pprofextension         |
-| ecsmetadatareceiver  | queuedprocessor               | prometheusexporter | zpagesextension        |
-|                      | batchprocessor                | loggingexporter    |                        |
-|                      | memorylimite                  | otlpexporter       |                        |
-|                      | tailsamplingprocessor         | fileexporter       |                        |
-|                      | probabilisticsamplerprocessor |                    |                        |
-|                      | spanprocessor                 |                    |                        |
-|                      | filterprocessor               |                    |                        |
+| Receiver                        | Processor                     | Exporter           | Extensions             |
+|---------------------------------|-------------------------------|--------------------|------------------------|
+| prometheusreceiver              | attributesprocessor           | `awsxrayexporter`  | healthcheckextension   |
+| otlpreceiver                    | resourceprocessor             | `awsemfexporter`   | pprofextension         |
+| `awsecscontainermetricsreceiver`| queuedprocessor               | prometheusexporter | zpagesextension        |
+|                                 | batchprocessor                | loggingexporter    |                        |
+|                                 | memorylimite                  | otlpexporter       |                        |
+|                                 | tailsamplingprocessor         | fileexporter       |                        |
+|                                 | probabilisticsamplerprocessor |                    |                        |
+|                                 | spanprocessor                 |                    |                        |
+|                                 | filterprocessor               |                    |                        |
+|                                 | metricstransformprocessor     |                    |                        |
 
 #### AWS OTel Collector AWS Components
 * [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector/)
 * [Trace X-Ray Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/awsxrayexporter)
 * [Metrics EMF Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/awsemfexporter/README.md)
+* [ECS Container Metrics Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/receiver/awsecscontainermetricsreceiver)
 
 ### Getting Started
 #### Prerequisites


### PR DESCRIPTION
This change updates the README to include `awsecscontainermetricsreceiver` and `metricstransformprocessor`. 

In-house developed components are marked up differently to get them highlighted. Making them only `italic` doesn't make any noticeable difference (at least on my eyes- if there is a disagreement, I can take it back). 
