### PR TITLE
speed up the docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ build: install-tools lint
 	GOOS=linux GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o ./build/linux/aoc_linux_aarch64 ./cmd/awscollector
 	GOOS=windows GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o ./build/windows/aoc_windows_amd64 ./cmd/awscollector
 
+.PHONY: amd64-build
+amd64-build: install-tools lint
+	GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o ./build/linux/aoc_linux_x86_64 ./cmd/awscollector
+
 .PHONY: awscollector
 awscollector:
 	GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o ./bin/awscollector_$(GOOS)_$(GOARCH) ./cmd/awscollector

--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -14,20 +14,23 @@ RUN apk add --update bash git make build-base
 COPY --from=golang:1.15.3-alpine /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
 
-# copy artifacts
+# download go modules ahead to speed up the building
 WORKDIR /workspace
+COPY go.mod /workspace/go.mod
+COPY go.sum /workspace/go.sum
+RUN go mod download
+
+# copy artifacts
 COPY cmd  /workspace/cmd
 COPY config.yaml /workspace/config.yaml
 COPY pkg /workspace/pkg
 COPY tools /workspace/tools
-COPY go.mod /workspace/go.mod
-COPY go.sum /workspace/go.sum
 COPY VERSION /workspace/VERSION
 COPY .git /workspace/.git
 COPY Makefile /workspace/Makefile
 
 # build binary
-RUN make build
+RUN make amd64-build
 
 ################################
 #	Final Stage            #	


### PR DESCRIPTION
**Description:** 

Speed up the docker build,

1. use go mod download to cache the downloading libs.
2. just build amd64 binary in docker.



**Testing:** 

Manually tested.  reduce the time from 25 minutes to 14 minutes

