### PR TITLE
Fix docker shared creds

### DIFF
--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -43,6 +43,7 @@ COPY --from=build /workspace/build/linux/aoc_linux_x86_64 /awscollector
 COPY --from=build /workspace/config.yaml /etc/otel-config.yaml
 
 ENV RUN_IN_CONTAINER="True"
+ENV HOME=/root
 ENTRYPOINT ["/awscollector"]
 CMD ["--config=/etc/otel-config.yaml"]
 EXPOSE 55680 55681

--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -43,6 +43,7 @@ COPY --from=build /workspace/build/linux/aoc_linux_x86_64 /awscollector
 COPY --from=build /workspace/config.yaml /etc/otel-config.yaml
 
 ENV RUN_IN_CONTAINER="True"
+# aws-sdk-go needs $HOME to look up shared credentials
 ENV HOME=/root
 ENTRYPOINT ["/awscollector"]
 CMD ["--config=/etc/otel-config.yaml"]

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -6,9 +6,15 @@ services:
     image: amazon/aws-otel-collector:latest
     command: ["--config=/etc/otel-agent-config.yaml", "--log-level=DEBUG"]
     environment:
-      - AWS_ACCESS_KEY_ID=<to_be_added>
-      - AWS_SECRET_ACCESS_KEY=<to_be_added>
-      - AWS_REGION=<to_be_added>
+      - AWS_REGION=us-west-2
+      # Either uncomment and define these:
+      #
+      # - AWS_ACCESS_KEY_ID=<to_be_added>
+      # - AWS_SECRET_ACCESS_KEY=<to_be_added>
+      #
+      # Or define a profile available in your shared credentials file
+      #
+      # - AWS_PROFILE=myprofile
 
     volumes:
       - ../examples/config-test.yaml:/etc/otel-agent-config.yaml


### PR DESCRIPTION
**Description:** 

Since the docker-compose file in the example mounts the user's aws directory, I presume the intention was to allow the use of shared credentials in addition to environment credentials. In my own case, using shared credentials was desirable since we use aws sso so I've got a big session key as well as access & secret keys, and in any case I'd prefer that myself & other internal users have to do a lot of copy-pasting to test this out.

However, shared credentials didn't work. I eventually realized that because the collector was a golang from-scratch image, `$HOME` was undefined, and I was able to fix loading shared credentials by adding

```
      - HOME=/root
```

to my own compose file. However, it seems like it would be better to just define that in the dockerfile, so that's what I've done here.

I've also added a candidate rewrite of the example compose file. It's not required; could be cherry-picked out.

**Testing:** I have not tested it in any way

**Documentation:** None besides the comments