### PR TITLE
Enhance the example sample apps to prevent unnecessary errors

### DIFF
--- a/examples/config-test.yaml
+++ b/examples/config-test.yaml
@@ -23,9 +23,9 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [awsxray, logging]
+      exporters: [awsxray]
     metrics:
       receivers: [otlp]
-      exporters: [awsemf, logging]
+      exporters: [awsemf]
 
   extensions: [pprof]

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -3,7 +3,11 @@ services:
 
   # AWS OTel Collector
   aws-ot-collector:
-    image: amazon/aws-otel-collector:latest
+  # image: amazon/aws-otel-collector:latest
+    # very slow when you build it first time locally!!!
+    build:
+      context: ../
+      dockerfile: cmd/awscollector/Dockerfile
     command: ["--config=/etc/otel-agent-config.yaml", "--log-level=DEBUG"]
     environment:
       - AWS_REGION=us-west-2
@@ -22,22 +26,26 @@ services:
     ports:
       - "1777:1777"   # pprof extension
       - "55679:55679" # zpages extension
-      - "55680:55680" # OTLP receiver
       - "13133"       # health_check
 
   # Sample web application which will generate Metrics and Traces data if the enable API is called
   ot-sample-app:
-    image: aottestbed/aws-otel-collector-sample-app:java-0.1.0
+    image: aottestbed/aws-otel-collector-java-sample-app:0.2.5
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=aws-ot-collector:55680
-      - OTEL_RESOURCE_ATTRIBUTES=service.namespace=AOCDockerDemo,service.name=AOCDockerDemoService1
-      - S3_REGION=us-west-2
+      - OTEL_RESOURCE_ATTRIBUTES=service.namespace=AOCDockerDemo,service.name=AOCDockerDemoService
+      - AWS_REGION=us-west-2
+      - LISTEN_ADDRESS=0.0.0.0:4567 # web server endpoint
+    volumes:
+      - ~/.aws:/root/.aws # test auto generated trace on S3 access
+    ports:
+      - "4567:4567"   # http sample requests
     depends_on:
       - aws-ot-collector
 
   # Traffic generator will make HTTP requests to ot-sample-app that sends OTel Metrics and Traces
   traffic-generator:
     image: ellerbrock/alpine-bash-curl-ssl:latest
-    command: [ "/bin/bash", "-c", "while :; do curl http://ot-sample-app:4567/span0 > /dev/null 1>&1; sleep 2; curl http://ot-sample-app:4567/span400 > /dev/null 2>&1; sleep 5; done" ]
+    command: [ "/bin/bash", "-c", "sleep 10; while :; do curl ot-sample-app:4567/outgoing-http-call > /dev/null 1>&1; sleep 2; curl ot-sample-app:4567/aws-sdk-call > /dev/null 2>&1; sleep 5; done" ]
     depends_on:
       - ot-sample-app

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -7,6 +7,14 @@ services:
     command: ["--config=/etc/otel-agent-config.yaml", "--log-level=DEBUG"]
     environment:
       - AWS_REGION=us-west-2
+      # Either uncomment and define these:
+      #
+      # - AWS_ACCESS_KEY_ID=<to_be_added>
+      # - AWS_SECRET_ACCESS_KEY=<to_be_added>
+      #
+      # Or define a profile available in your shared credentials file
+      #
+      # - AWS_PROFILE=myprofile
 
     volumes:
       - ../examples/config-test.yaml:/etc/otel-agent-config.yaml

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
       - "13133"       # health_check
 
   # Sample web application which will generate Metrics and Traces data if the enable API is called
+  # src - https://github.com/aws-observability/aws-otel-test-framework/tree/terraform/sample-apps/spark
   ot-sample-app:
     image: aottestbed/aws-otel-collector-java-sample-app:0.2.5
     environment:

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -7,14 +7,6 @@ services:
     command: ["--config=/etc/otel-agent-config.yaml", "--log-level=DEBUG"]
     environment:
       - AWS_REGION=us-west-2
-      # Either uncomment and define these:
-      #
-      # - AWS_ACCESS_KEY_ID=<to_be_added>
-      # - AWS_SECRET_ACCESS_KEY=<to_be_added>
-      #
-      # Or define a profile available in your shared credentials file
-      #
-      # - AWS_PROFILE=myprofile
 
     volumes:
       - ../examples/config-test.yaml:/etc/otel-agent-config.yaml
@@ -25,13 +17,19 @@ services:
       - "55680:55680" # OTLP receiver
       - "13133"       # health_check
 
-  # Metric and Trace Sample Data Generator
-  ot-metric-emitter:
+  # Sample web application which will generate Metrics and Traces data if the enable API is called
+  ot-sample-app:
     image: aottestbed/aws-otel-collector-sample-app:java-0.1.0
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=aws-ot-collector:55680
-      - OTEL_RESOURCE_ATTRIBUTES=service.namespace=AOCDockerDemo,service.name=AOCDockerDemoService
+      - OTEL_RESOURCE_ATTRIBUTES=service.namespace=AOCDockerDemo,service.name=AOCDockerDemoService1
       - S3_REGION=us-west-2
     depends_on:
       - aws-ot-collector
 
+  # Traffic generator will make HTTP requests to ot-sample-app that sends OTel Metrics and Traces
+  traffic-generator:
+    image: ellerbrock/alpine-bash-curl-ssl:latest
+    command: [ "/bin/bash", "-c", "while :; do curl http://ot-sample-app:4567/span0 > /dev/null 1>&1; sleep 2; curl http://ot-sample-app:4567/span400 > /dev/null 2>&1; sleep 5; done" ]
+    depends_on:
+      - ot-sample-app


### PR DESCRIPTION
**Description:** 
Enhance the docker compose example. 
* Make the sample app as pure Web App. It only generates Metrics and Traces data when the web APIs are called
* Add a traffic emitter which keeps calling the sample app APIs for Metrics and Traces data

** Sample App Link **
* https://github.com/aws-observability/aws-otel-test-framework/tree/terraform/sample-apps/spark

**Testing:** 
Tested on local laptop


