### PR TITLE
Fix misspelling at "ndoes"

### DIFF
--- a/docs/developers/eks-demo.md
+++ b/docs/developers/eks-demo.md
@@ -34,7 +34,7 @@ This example will introduce how to use AWS-OTel-Collector to send application tr
 5. Choose Review policy.
 6. On the Review policy page, enter `EKS-AWSOTel` for the Name and choose Create policy.
 
-#### Attach EKS-AWSOTel IAM Role to worker ndoes
+#### Attach EKS-AWSOTel IAM Role to worker nodes
 1. Open the Amazon EC2 console at https://console.aws.amazon.com/ec2/.
 2. Select one of the worker node instances and choose the IAM role in the description.
 3. On the IAM role page, choose Attach policies.


### PR DESCRIPTION
**Description:**
The word "ndoes" was misspelled at line 37. Changed it to "nodes".
