### PR TITLE
Fixsoaking

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -508,4 +508,18 @@ jobs:
         with:
           running_type: candidate
           opts: "-t=UploadCandidate -s=build/packages/.aoc-stack-test.yml"
+          
+      - id: file_changes
+        uses: trilom/file-changes-action@v1.2.3
+        with:
+          fileOutput: ''
+      
+      - name: Trigger soaking
+        if: contains("${{ steps.file_changes.outputs.files_modified}}", 'VERSION')
+        uses: peter-evans/repository-dispatch@v1.1.1
+        with:
+          token: "${{ secrets.REPO_WRITE_ACCESS_TOKEN }}"
+          event-type: bump-version
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -499,7 +499,7 @@ jobs:
         run: |
           TESTING_VERSION=`cat build/packages/VERSION`
           VERSION=`cat $TESTING_VERSION | awk -F "-" '{print $1}'`
-          echo $Version > build/packages/VERSION
+          echo $VERSION > build/packages/VERSION
           echo $GITHUB_SHA > build/packages/GITHUB_SHA
           echo $TESTING_VERSION > build/packages/TESTING_VERSION
 

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -14,7 +14,13 @@
 name: 'nightly soaking test'
 on:
   schedule:
-    - cron: '0 10 * * *' # every night at 10 am UTC: pst 4am
+    - cron: '0 10 * * *' # every night at 10 am UTC: pst 4amo
+      
+  # version bump from ci workflow will send dispatch event
+  # or we can manually trigger this workflow by using dispatch for debuging  
+  repository_dispatch:
+    types: [bump-version]
+        
 env:
   TF_VAR_aws_access_key_id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
   TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }} 
@@ -22,23 +28,27 @@ env:
 jobs:
   get-testing-version:
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: 'us-east-1'
     outputs: 
       testing_version: ${{ steps.get-testing-version.outputs.testing_version }}
     steps:
       - uses: actions/checkout@v2
       
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
-          aws-region: us-west-2
+      - uses: chrislennon/action-aws-cli@v1.1
       
-      - name: download packages as release candidate from s3
-        uses: aws-observability/aws-otel-collector-test-framework@deprecating
-        with:
-          running_type: candidate
-          opts: "-t=DownloadCandidate -s=.aoc-stack-test.yml -p=${{ steps.get_version.outputs.version }} -g=${{ github.sha }}"
+      - name: Download Candidate from the latest commit
+        if: github.event_name != 'repository_dispatch'
+        run: aws s3 cp "s3://aws-otel-collector-release-candidate/${{ github.sha }}.tar.gz" ./candidate.tag.gz
+      
+      - name: Download Candidate base on dispatch payload
+        if: github.event_name == 'repository_dispatch'
+        run: aws s3 cp "s3://aws-otel-collector-release-candidate/${{ github.event.client_payload.sha }}.tar.gz" ./candidate.tar.gz
+      
+      - name: uncompress the candidate package
+        run: tar -zxf ./candidate.tar.gz
           
       - name: get testing version
         id: get-testing-version


### PR DESCRIPTION
**Description:** 

1. use s3 cp command instead of the downloading function in the deprecating testing framework branch.
2. add a dispatch listener in soaking workflow so we can debug this workflow as well as having ci workflow to trigger soaking when version file is changed.
3. add a dispatch sending in CI workflow.
4. fix the version file in candidate package

Please help to add a secret in the setting of this repo, name "REPO_WRITE_ACCESS_TOKEN", value: token with admin permission to this repo. 