### PR TITLE
enable otlp http exporter integration test cases for all the testing …

### DIFF
--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -18,5 +18,13 @@
 	{
 		"case_name": "ecsmetrics",
 		"platforms": ["ECS"]
+	},
+	{
+		"case_name": "otlp_http_exporter_metric_mock",
+		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING"]
+	},
+	{
+		"case_name": "otlp_http_exporter_trace_mock",
+		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING"]
 	}
 ]

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/fileexporter"
 	"go.opentelemetry.io/collector/exporter/loggingexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
+	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
 	"go.opentelemetry.io/collector/exporter/prometheusexporter"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
 	"go.opentelemetry.io/collector/receiver/prometheusreceiver"
@@ -71,6 +72,7 @@ func Components() (component.Factories, error) {
 		loggingexporter.NewFactory(),
 		fileexporter.NewFactory(),
 		otlpexporter.NewFactory(),
+		otlphttpexporter.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/pkg/defaultcomponents/defaults_test.go
+++ b/pkg/defaultcomponents/defaults_test.go
@@ -31,6 +31,7 @@ func TestComponents(t *testing.T) {
 	// core exporters
 	assert.True(t, exporters["logging"] != nil)
 	assert.True(t, exporters["otlp"] != nil)
+	assert.True(t, exporters["otlphttp"] != nil)
 
 	receivers := factories.Receivers
 	assert.True(t, receivers["otlp"] != nil)


### PR DESCRIPTION
**Description:**
Enable otlp http exporter integration test cases for all the testing platforms

**Link to tracking Issue:** 
https://github.com/aws-observability/aws-otel-collector/issues/104

**Testing:** 
Tested on local
aws-otel-test-framework git:(otlp-http) ✗
 `cd terraform/mock; terraform init && terraform apply -var="testcase=../testcases/otlp_http_exporter_trace_mock" `
 `cd terraform/mock; terraform init && terraform apply -var="testcase=../testcases/otlp_http_exporter_metric_mock" `
