### PR TITLE
Add New Relic Exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This table represents the supported components of AWS OTel Collector in 2020. Th
 |                                 | probabilisticsamplerprocessor | otlphttpexporter   |                        |
 |                                 | spanprocessor                 | sapmexporter       |                        |
 |                                 | filterprocessor               | datadogexporter    |                        |
-|                                 | metricstransformprocessor     |                    |                        |
+|                                 | metricstransformprocessor     | newrelicexporter   |                        |
 |                                 |                               |                    |                        |
 
 #### AWS OTel Collector AWS Components

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -38,5 +38,13 @@
 	{
 		"case_name": "datadog_exporter_trace_mock",
 		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING"]
+	},
+	{
+		"case_name": "newrelic_exporter_trace_mock",
+		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING"]
+	},
+	{
+		"case_name": "newrelic_exporter_metric_mock",
+		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING"]
 	}
 ]

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.14.1-0.20201111210848-994cabe5d596
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.14.1-0.20201111210848-994cabe5d596
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.14.1-0.20201111210848-994cabe5d596
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/newrelicexporter v0.14.1-0.20201111210848-994cabe5d596
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.14.1-0.20201111210848-994cabe5d596
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.14.1-0.20201118171217-2398a00e4656
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.14.1-0.20201111210848-994cabe5d596

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -20,6 +20,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/newrelicexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver"
@@ -77,6 +78,7 @@ func Components() (component.Factories, error) {
 		otlphttpexporter.NewFactory(),
 		sapmexporter.NewFactory(),
 		datadogexporter.NewFactory(),
+		newrelicexporter.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/pkg/defaultcomponents/defaults_test.go
+++ b/pkg/defaultcomponents/defaults_test.go
@@ -36,6 +36,7 @@ func TestComponents(t *testing.T) {
 	assert.True(t, exporters["datadog"] != nil)
 
 	assert.True(t, exporters["sapm"] != nil)
+	assert.True(t, exporters["newrelic"] != nil)
 
 	receivers := factories.Receivers
 	assert.True(t, receivers["otlp"] != nil)


### PR DESCRIPTION
**Description:**  Adds latest version of New Relic Exporter to the collector.

**Link to tracking Issue:** N/A

**Testing:** https://github.com/aws-observability/aws-otel-test-framework/pull/103

**Documentation:** N/A
