### PR TITLE
Add Datadog exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This table represents the supported components of AWS OTel Collector in 2020. Th
 |                                 | memorylimite                  | otlpexporter       |                        |
 |                                 | tailsamplingprocessor         | fileexporter       |                        |
 |                                 | probabilisticsamplerprocessor | otlphttpexporter   |                        |
-|                                 | spanprocessor                 |                    |                        |
+|                                 | spanprocessor                 | datadogexporter    |                        |
 |                                 | filterprocessor               |                    |                        |
 |                                 | metricstransformprocessor     |                    |                        |
 

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -26,5 +26,13 @@
 	{
 		"case_name": "otlp_http_exporter_trace_mock",
 		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING"]
+	},
+	{
+		"case_name": "datadog_exporter_metric_mock",
+		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING"]
+	},
+	{
+		"case_name": "datadog_exporter_trace_mock",
+		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING"]
 	}
 ]

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.14.1-0.20201111210848-994cabe5d596
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.14.1-0.20201111210848-994cabe5d596
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.14.1-0.20201111210848-994cabe5d596
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.14.1-0.20201111210848-994cabe5d596
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.14.1-0.20201111210848-994cabe5d596
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.14.1-0.20201111210848-994cabe5d596

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -18,6 +18,7 @@ package defaultcomponents // import "aws-observability.io/collector/defaultcompo
 import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver"
@@ -73,6 +74,7 @@ func Components() (component.Factories, error) {
 		fileexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),
+		datadogexporter.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/pkg/defaultcomponents/defaults_test.go
+++ b/pkg/defaultcomponents/defaults_test.go
@@ -32,6 +32,8 @@ func TestComponents(t *testing.T) {
 	assert.True(t, exporters["logging"] != nil)
 	assert.True(t, exporters["otlp"] != nil)
 	assert.True(t, exporters["otlphttp"] != nil)
+	// other exporters
+	assert.True(t, exporters["datadog"] != nil)
 
 	receivers := factories.Receivers
 	assert.True(t, receivers["otlp"] != nil)


### PR DESCRIPTION
**Description:**

- Add Datadog exporter to AWS OpenTelemetry distro
- Add end to end tests following wiki description
- Add exporter to README list 

**Link to tracking Issue:** n/a

**Testing:** 

- Unit tests for the component are available in the OpenTelemetry Collector contrib repository.
- End to end tests were added (see aws-observability/aws-otel-test-framework#96)

**Documentation:** 

- Added exporter to README list. I am not sure if this should be done given the description above the table; please let me know if I should not add it.
- Additional documentation is available in the OpenTelemetry Collector contrib repository
