### PR TITLE
Fix performance model report

### DIFF
--- a/e2etest/get-performance-model-table.py
+++ b/e2etest/get-performance-model-table.py
@@ -14,11 +14,17 @@ if __name__ == "__main__":
     # get performance models from artifacts
     performance_models = []
     artifacts_path = "artifacts/"
+    commit_id = ""
+    collection_period = None
+    testing_ami = ""
     for sub_dir in os.listdir(artifacts_path):
         with open(artifacts_path + sub_dir + "/performance.json") as f:
             model = json.load(f)
             model["avgCpu"] = "{:.2f}".format(model["avgCpu"])
             model["avgMem"] = "{:.2f}".format(model["avgMem"])
+            commit_id = model["commitId"]
+            collection_period = model["collectionPeriod"]
+            testing_ami = model["testingAmi"]
             performance_models.append(model)
 
     # sort by testing_ami, name and rate
@@ -26,7 +32,12 @@ if __name__ == "__main__":
 
     # render performance models into markdown
     template = env.get_template('performance_model.tpl')
-    rendered_result = template.render({"performance_models": performance_models})
+    rendered_result = template.render({
+        "commit_id": commit_id,
+        "collection_period": collection_period,
+        "testing_ami": testing_ami,
+        "performance_models": performance_models,
+    })
     print(rendered_result)
 
     # write rendered result to docs/performance_model.md

--- a/e2etest/templates/performance_model.tpl
+++ b/e2etest/templates/performance_model.tpl
@@ -1,14 +1,14 @@
 ## Performance Model for each test cases
 
-**Commit ID:** [{{ performance_model.commitId }}](https://github.com/aws-observability/aws-otel-collector/commit/{{ performance_model.commitId }})
+**Commit ID:** [{{ commit_id }}](https://github.com/aws-observability/aws-otel-collector/commit/{{ commit_id }})
 
-**Collection Period:** {{ performance_model.collectionPeriod }}
+**Collection Period:** {{ collection_period }} minutes
 
-**Testing AMI:** {{ performance_model.testingAmi }}
+**Testing AMI:** {{ testing_ami }}
 
- | Test Case | Data Rate |  Data Type | Instance Type | Avg CPU Usage (Percent) | Avg Memory Usage (Megabytes) |
-  |:---------:|:---------:|:----------:|:------------:|:-----------------------:|:----------------------------:|
-{% for performance_model in performance_models %}
-   | {{ performance_model.testcase }} | {{ performance_model.dataRate }} | {{ performance_model.dataType }} | {{ performance_model.instanceType }} | {{ performance_model.avgCpu }} | {{ performance_model.avgMem }} | {{ performance_model.collectionPeriod }} | asd | {{ performance_model.testingAmi }} |
-{% endfor %}
+| Test Case | Data Rate |  Data Type | Instance Type | Avg CPU Usage (Percent) | Avg Memory Usage (Megabytes) |
+|:---------:|:---------:|:----------:|:------------:|:-----------------------:|:----------------------------:|
+{% for performance_model in performance_models -%}
+| {{ performance_model.testcase }} | {{ performance_model.dataRate }} | {{ performance_model.dataType }} | {{ performance_model.instanceType }} | {{ performance_model.avgCpu }} | {{ performance_model.avgMem }} |
+{%- endfor %}
  

--- a/e2etest/templates/performance_model.tpl
+++ b/e2etest/templates/performance_model.tpl
@@ -1,4 +1,4 @@
-## Performance Model for each test cases
+## Performance Report
 
 **Commit ID:** [{{ commit_id }}](https://github.com/aws-observability/aws-otel-collector/commit/{{ commit_id }})
 


### PR DESCRIPTION
**Description:**
Minor fixes to performance model report.

**Testing:**
Ran it locally and a sample output is:

## Performance Report

**Commit ID:** [dummy_commit](https://github.com/aws-observability/aws-otel-collector/commit/dummy_commit)

**Collection Period:** 2 minutes

**Testing AMI:** soaking_linux

| Test Case | Data Rate |  Data Type | Instance Type | Avg CPU Usage (Percent) | Avg Memory Usage (Megabytes) |
|:---------:|:---------:|:----------:|:------------:|:-----------------------:|:----------------------------:|
| otlp_metric | 10000 | otlp | m5.2xlarge | 0.06 | 60.42 |
 
 
