### PR TITLE
Remove stripping of trailing new lines

### DIFF
--- a/e2etest/templates/performance_model.tpl
+++ b/e2etest/templates/performance_model.tpl
@@ -10,5 +10,5 @@
 |:---------:|:---------:|:----------:|:------------:|:-----------------------:|:----------------------------:|
 {% for performance_model in performance_models -%}
 | {{ performance_model.testcase }} | {{ performance_model.dataRate }} | {{ performance_model.dataType }} | {{ performance_model.instanceType }} | {{ performance_model.avgCpu }} | {{ performance_model.avgMem }} |
-{%- endfor %}
+{% endfor %}
  


### PR DESCRIPTION
**Description:** 
Remove stripping of trailing new lines when generating performance table rows.

**Testing:**
Local testing was done on 2 rows:

## Performance Report

**Commit ID:** [dummy_commit](https://github.com/aws-observability/aws-otel-collector/commit/dummy_commit)

**Collection Period:** 2 minutes

**Testing AMI:** soaking_linux

| Test Case | Data Rate |  Data Type | Instance Type | Avg CPU Usage (Percent) | Avg Memory Usage (Megabytes) |
|:---------:|:---------:|:----------:|:------------:|:-----------------------:|:----------------------------:|
| otlp_metric | 10000 | otlp | m5.2xlarge | 0.06 | 60.42 |
| otlp_metric | 10000 | otlp | m5.2xlarge | 0.06 | 60.42 |

 
