### PR TITLE
Add Splunk HEC trace exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This table represents the supported components of AWS OTel Collector in 2020. Th
 |                                 | metricstransformprocessor     | newrelicexporter                   |                        |
 |                                 |                               | sapmexporter                       |                        |
 |                                 |                               | signalfxexporter                   |                        |
+|                                 |                               | splunkhecexporter                  |                        |
 |                                 |                               | prometheusexporter                 |                        |
 
 

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -36,6 +36,10 @@
 		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING"]
 	},
 	{
+		"case_name": "splunkhec_exporter_trace_mock",
+		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING"]
+	},
+	{
 		"case_name": "dynatrace_exporter_metric_mock",
 		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING"]
 	},

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/newrelicexporter v0.16.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.16.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.16.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.16.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.16.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.16.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -883,6 +883,7 @@ github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.16.0 h1:1pfiYIPFwgbluJDoOZe1x3onGLWJBb8RbaU0EpPth/g=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.16.0/go.mod h1:mKdDCv85c40GroelRo64qm8XewRXIYO1atkPMvyDX7M=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsprometheusremotewriteexporter v0.16.0/go.mod h1:DWnHHeuoiezOtgmL6lMd/JGJ4ea0EvyQRAyP+SiD02c=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.16.0 h1:iwSu/tWVdk0y2eP/+Hjyu4x4Ba1VxpYsMK3heZmuwyc=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.16.0/go.mod h1:8XFceO/drGFmAh5z6Zyo15Aobp9jD8taDxa1sDUkC0s=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.16.0 h1:w0L6cdkIGgB6aWBbp/ouAHez4QSZZnC/8/TRyexs8VY=
@@ -895,6 +896,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter 
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.16.0/go.mod h1:114VWjYOTUVo9PQcnr96NkhEBrWxRGNSTgktg4GatVo=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.16.0 h1:Xdub/hXiH33ungF4dg4AsF4sBCq9+LybOiuJaHtpw4I=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.16.0/go.mod h1:EQs1whEx2JDJpov3Tzn38fetSwP3ryy7CENylXx2Xmc=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.16.0 h1:Xx8oTeq1GCdHT5yUY26Mj41z4mL/N3Th4NJrSa+eatc=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.16.0/go.mod h1:/3qDw9fS144sMhePMB5F4XHrAlcy1INkA+F8vAdLXTs=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/awsxray v0.16.0 h1:iTFF0njHqyq3CXbvURqMcllIGF1Wf3ugPURCgCNTDgY=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/awsxray v0.16.0/go.mod h1:2gUAbcL+AndveUZADYO+8p1H03m3ASYzhtahh46MSWQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.16.0 h1:80u3m7L1D6pfGf0VM6N9gbSKAlTBYKQAy3WQfwrMHPs=

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -24,6 +24,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/newrelicexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver"
@@ -82,6 +83,7 @@ func Components() (component.Factories, error) {
 		dynatraceexporter.NewFactory(),
 		sapmexporter.NewFactory(),
 		signalfxexporter.NewFactory(),
+		splunkhecexporter.NewFactory(),
 		datadogexporter.NewFactory(),
 		newrelicexporter.NewFactory(),
 		awsprometheusremotewriteexporter.NewFactory(),

--- a/pkg/defaultcomponents/defaults_test.go
+++ b/pkg/defaultcomponents/defaults_test.go
@@ -39,6 +39,7 @@ func TestComponents(t *testing.T) {
 
 	assert.True(t, exporters["sapm"] != nil)
 	assert.True(t, exporters["signalfx"] != nil)
+	assert.True(t, exporters["splunk_hec"] != nil)
 	assert.True(t, exporters["newrelic"] != nil)
 
 	receivers := factories.Receivers


### PR DESCRIPTION
**Description:**

- Add Splunk HEC trace exporter to AWS OpenTelemetry distro
- Add end to end tests following wiki description
- Add exporter to README list

**Link to tracking Issue:** n/a

**Testing:**

- Unit tests in collector contrib repository: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/splunkhecexporter
- E2E tests https://github.com/aws-observability/aws-otel-test-framework/pull/140

**Documentation:**

- Added exporter to README list
- Usage documentation: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/master/exporter/splunkhecexporter/README.md
