### PR TITLE
Update SAPM exporter to v0.15.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.14.1-0.20201111210848-994cabe5d596
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.14.1-0.20201111210848-994cabe5d596
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter v0.15.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.14.1-0.20201111210848-994cabe5d596
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.15.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.15.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/newrelicexporter v0.14.1-0.20201111210848-994cabe5d596
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.14.1-0.20201111210848-994cabe5d596
@@ -24,7 +24,7 @@ require (
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/awsxray => github.com/open-telemetry/opentelemetry-collector-contrib/internal/awsxray v0.14.1-0.20201111210848-994cabe5d596
 
-replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk => github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.14.1-0.20201111210848-994cabe5d596
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk => github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.15.0
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver => github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.15.0
 

--- a/go.sum
+++ b/go.sum
@@ -950,6 +950,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/newrelicexpor
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/newrelicexporter v0.14.1-0.20201111210848-994cabe5d596/go.mod h1:YKXGQbuZ+ESfyoZN9DFeJirsbhRYRzK7cc7xr/i0V8E=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.14.1-0.20201111210848-994cabe5d596 h1:5UYcUM4KNAMdy5qQQ4MIMWcvzrXr36CWCquW6vN4x74=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.14.1-0.20201111210848-994cabe5d596/go.mod h1:Pji1/mR+4vqA5Sp3WvzwCp4pORMKgxSNflDhwlrqyy8=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.15.0 h1:PYXn4umbSKBLN2PplW8KozdrHdHfapOM7JlZJ7y8Qh4=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.15.0/go.mod h1:76NdkrhkgouCHTBo7R1pPtHZzESVBcYo7YDjjaMTOJY=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.14.1-0.20201111210848-994cabe5d596 h1:kKLcXcpyYytYVKBHP+eN+Ym0Bm/q88UiUgW7QI++9K8=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.14.1-0.20201111210848-994cabe5d596/go.mod h1:1eFktOmJ0GCk4GO8qntChUuRip9QTS1LX5Ojkcdcqg8=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.15.0 h1:k4kVJsWqSvhvNCIzmduVQDN+7Kpzih/gIfE550brlhk=
@@ -962,6 +964,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.15.0/go.mod h1:rxjjmziLeV82rgCTItE/OppiFIbx16x7fot0XUqN7Vo=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.14.1-0.20201111210848-994cabe5d596 h1:ovNbyGvvuWv8hgEB0CnlNQGLujshWM+gHs4SgHu/dV8=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.14.1-0.20201111210848-994cabe5d596/go.mod h1:jkSvpHfJ4wMylocJMCWNHIhMXGG2dZRqyYgPcqVbBeY=
+github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.15.0 h1:PMziriVhpQz7qrcZ72Kk9cFmRHY/zuAKZLKWkPHUaVM=
+github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.15.0/go.mod h1:7LRE8sdadcjuQ2dhfBIZ2HQCz85lwz+UApfQX8htqt4=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.14.1-0.20201111210848-994cabe5d596 h1:cbneCn/0LIPFDtI4GhBBya62FYLJcSmIhdnCVxRo9+o=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.14.1-0.20201111210848-994cabe5d596/go.mod h1:fbn7mipPZGttODEBncegXWwNnOwjspP7Kg+Su5SkNbY=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.14.1-0.20201118171217-2398a00e4656 h1:w3MPiDAky+9zherM8ycffyv2laiiy6Kmz90sEcjBos0=


### PR DESCRIPTION
**Description:**
Updated SAPM exporter dependency to v0.15.0.
v0.15.0 is the latest released version of SAPM exporter in OpenTelemetry contrib repo.

**Link to tracking Issue:** N/A

**Testing:** 
Built locally using `make`
