### PR TITLE
Fix canary test to every hour

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -14,7 +14,7 @@
 name: 'Canary Test'
 on:
   schedule:
-    - cron: '* */1 * * *' # triggers the workflow every hour
+    - cron: '0 * * * *' # triggers the workflow every hour
 
   # we can manually trigger this workflow by using dispatch for debuging
   repository_dispatch:


### PR DESCRIPTION
by changing the cronjob config
