### PR TITLE
Split up performance results into separate tables

### DIFF
--- a/e2etest/get-performance-model-table.py
+++ b/e2etest/get-performance-model-table.py
@@ -5,6 +5,51 @@ from pathlib import Path
 import jinja2
 import string
 
+# Schema: performance_models[data_mode][tps] = [model]
+performance_models = {}
+
+
+def add_performance_model(model):
+    """
+    Adds performance model to the list of performance models.
+    """
+    # process model values
+    model["avgCpu"] = "{:.2f}".format(model["avgCpu"])
+    model["avgMem"] = "{:.2f}".format(model["avgMem"])
+
+    data_mode = model["dataMode"].capitalize()
+    data_rate = model["dataRate"]
+
+    if data_mode not in performance_models:
+        performance_models[data_mode] = {}
+    if data_rate not in performance_models[data_mode]:
+        performance_models[data_mode][data_rate] = []
+
+    performance_models[data_mode][data_rate].append(model)
+
+
+def flatten_performance_models(models):
+    """
+    Flattens performance model into list of grouped models where each group
+    corresponds to a table in the report.
+    """
+    models_list = []
+
+    for data_mode, data_rates in performance_models.items():
+        for data_rate, models in data_rates.items():
+            model = {}
+            model["data_mode"] = data_mode
+            model["data_rate"] = data_rate
+            # sort by name and type
+            model["models"] = sorted(
+                models, key=lambda x: (x["testcase"], x["dataType"]))
+            models_list.append(model)
+
+    # sort by data mode and rate
+    models_list = sorted(models_list, key=lambda x: (
+        x["data_mode"], x["data_rate"]))
+    return models_list
+
 
 if __name__ == "__main__":
     from jinja2 import Environment, PackageLoader, select_autoescape
@@ -12,7 +57,6 @@ if __name__ == "__main__":
     env = Environment(loader=templateLoader)
 
     # get performance models from artifacts
-    performance_models = []
     artifacts_path = "artifacts/"
     commit_id = ""
     collection_period = None
@@ -20,15 +64,12 @@ if __name__ == "__main__":
     for sub_dir in os.listdir(artifacts_path):
         with open(artifacts_path + sub_dir + "/performance.json") as f:
             model = json.load(f)
-            model["avgCpu"] = "{:.2f}".format(model["avgCpu"])
-            model["avgMem"] = "{:.2f}".format(model["avgMem"])
             commit_id = model["commitId"]
             collection_period = model["collectionPeriod"]
             testing_ami = model["testingAmi"]
-            performance_models.append(model)
+            add_performance_model(model)
 
-    # sort by testing_ami, name and rate
-    performance_models = sorted(performance_models, key = lambda x: (x["testingAmi"], x["testcase"], x["dataRate"]))
+    models_list = flatten_performance_models(performance_models)
 
     # render performance models into markdown
     template = env.get_template('performance_model.tpl')
@@ -36,7 +77,7 @@ if __name__ == "__main__":
         "commit_id": commit_id,
         "collection_period": collection_period,
         "testing_ami": testing_ami,
-        "performance_models": performance_models,
+        "models_list": models_list,
     })
     print(rendered_result)
 

--- a/e2etest/templates/performance_model.tpl
+++ b/e2etest/templates/performance_model.tpl
@@ -6,9 +6,11 @@
 
 **Testing AMI:** {{ testing_ami }}
 
-| Test Case | Data Rate |  Data Type | Instance Type | Avg CPU Usage (Percent) | Avg Memory Usage (Megabytes) |
-|:---------:|:---------:|:----------:|:------------:|:-----------------------:|:----------------------------:|
-{% for performance_model in performance_models -%}
-| {{ performance_model.testcase }} | {{ performance_model.dataRate }} | {{ performance_model.dataType }} | {{ performance_model.instanceType }} | {{ performance_model.avgCpu }} | {{ performance_model.avgMem }} |
+{% for models in models_list %}
+### {{ models.data_mode }} (TPS: {{ models.data_rate }})
+| Test Case |  Data Type | Instance Type | Avg CPU Usage (Percent) | Avg Memory Usage (Megabytes) |
+|:---------:|:----------:|:------------:|:-----------------------:|:----------------------------:|
+{% for model in models.models -%}
+| {{ model.testcase }} | {{ model.dataType }} | {{ model.instanceType }} | {{ model.avgCpu }} | {{ model.avgMem }} |
 {% endfor %}
- 
+{%- endfor -%}


### PR DESCRIPTION
**Description:**
This PR improves the UI of the performance report generated by the performance testing workflow by splitting up performance results by data mode (i.e. "metric" or "trace) and tps. This allows for easier comparison across performance test cases.

**Testing:**
Performed local testing of `get-performance-model-table.py` with 2 different sample performance results and got the following table output:

## Performance Report

**Commit ID:** [dummy_commit](https://github.com/aws-observability/aws-otel-collector/commit/dummy_commit)

**Collection Period:** 2 minutes

**Testing AMI:** soaking_linux


### Metric (TPS: 2000)
| Test Case |  Data Type | Instance Type | Avg CPU Usage (Percent) | Avg Memory Usage (Megabytes) |
|:---------:|:----------:|:------------:|:-----------------------:|:----------------------------:|
| otlp_metric | otlp | m5.2xlarge | 0.03 | 56.79 |

### Metric (TPS: 5000)
| Test Case |  Data Type | Instance Type | Avg CPU Usage (Percent) | Avg Memory Usage (Megabytes) |
|:---------:|:----------:|:------------:|:-----------------------:|:----------------------------:|
| otlp_metric | otlp | m5.2xlarge | 0.03 | 56.79 |
