### PR TITLE
Add OTel pipeline components to performance report

### DIFF
--- a/e2etest/get-performance-model-table.py
+++ b/e2etest/get-performance-model-table.py
@@ -16,6 +16,9 @@ def add_performance_model(model):
     # process model values
     model["avgCpu"] = "{:.2f}".format(model["avgCpu"])
     model["avgMem"] = "{:.2f}".format(model["avgMem"])
+    model["receivers"].sort()
+    model["processors"].sort()
+    model["exporters"].sort()
     model["receivers"] = ", ".join(model["receivers"])
     model["processors"] = ", ".join(model["processors"])
     model["exporters"] = ", ".join(model["exporters"])
@@ -45,7 +48,7 @@ def flatten_performance_models(models):
             model["data_rate"] = data_rate
             # sort by name and type
             model["models"] = sorted(
-                models, key=lambda x: (x["testcase"], x["dataType"]))
+                models, key=lambda x: (x["receivers"], x["testcase"], x["dataType"]))
             models_list.append(model)
 
     # sort by data mode and rate

--- a/e2etest/get-performance-model-table.py
+++ b/e2etest/get-performance-model-table.py
@@ -16,6 +16,9 @@ def add_performance_model(model):
     # process model values
     model["avgCpu"] = "{:.2f}".format(model["avgCpu"])
     model["avgMem"] = "{:.2f}".format(model["avgMem"])
+    model["receivers"] = ", ".join(model["receivers"])
+    model["processors"] = ", ".join(model["processors"])
+    model["exporters"] = ", ".join(model["exporters"])
 
     data_mode = model["dataMode"].capitalize()
     data_rate = model["dataRate"]

--- a/e2etest/templates/performance_model.tpl
+++ b/e2etest/templates/performance_model.tpl
@@ -8,9 +8,9 @@
 
 {% for models in models_list %}
 ### {{ models.data_mode }} (TPS: {{ models.data_rate }})
-| Test Case | Receivers | Processors | Exporters | Data Type | Instance Type | Avg CPU Usage (Percent) | Avg Memory Usage (Megabytes) |
-|:---------:|:---------:|:----------:|:---------:|:---------:|:-------------:|:-----------------------:|:----------------------------:|
+| Receivers | Processors | Exporters | Test Case | Data Type | Instance Type | Avg CPU Usage (Percent) | Avg Memory Usage (Megabytes) |
+|:---------:|:----------:|:---------:|:---------:|:---------:|:-------------:|:-----------------------:|:----------------------------:|
 {% for model in models.models -%}
-| {{ model.testcase }} | {{ model.receivers }} | {{ model.processors }} | {{ model.exporters }} | {{ model.dataType }} | {{ model.instanceType }} | {{ model.avgCpu }} | {{ model.avgMem }} |
+| {{ model.receivers }} | {{ model.processors }} | {{ model.exporters }} | {{ model.testcase }} | {{ model.dataType }} | {{ model.instanceType }} | {{ model.avgCpu }} | {{ model.avgMem }} |
 {% endfor %}
 {%- endfor -%}

--- a/e2etest/templates/performance_model.tpl
+++ b/e2etest/templates/performance_model.tpl
@@ -8,9 +8,9 @@
 
 {% for models in models_list %}
 ### {{ models.data_mode }} (TPS: {{ models.data_rate }})
-| Test Case |  Data Type | Instance Type | Avg CPU Usage (Percent) | Avg Memory Usage (Megabytes) |
-|:---------:|:----------:|:------------:|:-----------------------:|:----------------------------:|
+| Test Case | Receivers | Processors | Exporters | Data Type | Instance Type | Avg CPU Usage (Percent) | Avg Memory Usage (Megabytes) |
+|:---------:|:---------:|:----------:|:---------:|:---------:|:-------------:|:-----------------------:|:----------------------------:|
 {% for model in models.models -%}
-| {{ model.testcase }} | {{ model.dataType }} | {{ model.instanceType }} | {{ model.avgCpu }} | {{ model.avgMem }} |
+| {{ model.testcase }} | {{ model.receivers }} | {{ model.processors }} | {{ model.exporters }} | {{ model.dataType }} | {{ model.instanceType }} | {{ model.avgCpu }} | {{ model.avgMem }} |
 {% endfor %}
 {%- endfor -%}


### PR DESCRIPTION
**Description:**
This PR adds the OTel pipeline components (i.e. receivers, processors, and exporters) to the performance report to provide additional information about each performance test case.

**Testing:**
Local testing was done and a sample output is as follows:

## Performance Report

**Commit ID:** [dummy_commit](https://github.com/aws-observability/aws-otel-collector/commit/dummy_commit)

**Collection Period:** 2 minutes

**Testing AMI:** soaking_linux


### Trace (TPS: 5000)
| Receivers | Processors | Exporters | Test Case | Data Type | Instance Type | Avg CPU Usage (Percent) | Avg Memory Usage (Megabytes) |
|:---------:|:----------:|:---------:|:---------:|:---------:|:-------------:|:-----------------------:|:----------------------------:|
| otlp | batch | awsxray | otlp_mock | otlp | m5.2xlarge | 780.28 | 2512.04 |
| otlp, prometheus |  | awsxray | otlp_mock | otlp | m5.2xlarge | 780.28 | 2512.04 |

