### PR TITLE
Enable AWSPrometheusRemoteWriteExporter in the collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ This table represents the supported components of AWS OTel Collector in 2020. Th
 |                                 | metricstransformprocessor     | newrelicexporter   |                        |
 |                                 |                               | sapmexporter       |                        |
 |                                 |                               | signalfxexporter   |                        |
+|                                 |                               | `awsprometheusremotewriteexporter`   |                        |
+
 
 #### AWS OTel Collector AWS Components
 * [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector/)

--- a/README.md
+++ b/README.md
@@ -21,21 +21,21 @@ Use the community resources below for getting help with AWS OTel Collector.
 
 This table represents the supported components of AWS OTel Collector in 2020. The highlighted components below are developed by AWS in-house. The rest of the components in the table are the essential default components that AWS OTel Collector will support.
 
-| Receiver                        | Processor                     | Exporter           | Extensions             |
-|---------------------------------|-------------------------------|--------------------|------------------------|
-| prometheusreceiver              | attributesprocessor           | `awsxrayexporter`  | healthcheckextension   |
-| otlpreceiver                    | resourceprocessor             | `awsemfexporter`   | pprofextension         |
-| `awsecscontainermetricsreceiver`| queuedprocessor               | prometheusexporter | zpagesextension        |
-|                                 | batchprocessor                | loggingexporter    |                        |
-|                                 | memorylimiter                 | otlpexporter       |                        |
-|                                 | tailsamplingprocessor         | fileexporter       |                        |
-|                                 | probabilisticsamplerprocessor | otlphttpexporter   |                        |
-|                                 | spanprocessor                 | datadogexporter    |                        |
-|                                 | filterprocessor               | dynatraceexporter  |                        |
-|                                 | metricstransformprocessor     | newrelicexporter   |                        |
-|                                 |                               | sapmexporter       |                        |
-|                                 |                               | signalfxexporter   |                        |
-|                                 |                               | `awsprometheusremotewriteexporter`   |                        |
+| Receiver                        | Processor                     | Exporter                           | Extensions             |
+|---------------------------------|-------------------------------|------------------------------------|------------------------|
+| prometheusreceiver              | attributesprocessor           | `awsxrayexporter`                  | healthcheckextension   |
+| otlpreceiver                    | resourceprocessor             | `awsemfexporter`                   | pprofextension         |
+| `awsecscontainermetricsreceiver`| queuedprocessor               | `awsprometheusremotewriteexporter` | zpagesextension        |
+|                                 | batchprocessor                | loggingexporter                    |                        |
+|                                 | memorylimiter                 | otlpexporter                       |                        |
+|                                 | tailsamplingprocessor         | fileexporter                       |                        |
+|                                 | probabilisticsamplerprocessor | otlphttpexporter                   |                        |
+|                                 | spanprocessor                 | datadogexporter                    |                        |
+|                                 | filterprocessor               | dynatraceexporter                  |                        |
+|                                 | metricstransformprocessor     | newrelicexporter                   |                        |
+|                                 |                               | sapmexporter                       |                        |
+|                                 |                               | signalfxexporter                   |                        |
+|                                 |                               | prometheusexporter                 |                        |
 
 
 #### AWS OTel Collector AWS Components

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -54,5 +54,17 @@
 	{
 		"case_name": "newrelic_exporter_metric_mock",
 		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING"]
+	},
+	{
+		"case_name": "prometheus_mock",
+		"platforms": ["EC2", "EKS", "LOCAL", "SOAKING"]
+	},
+	{
+		"case_name": "prometheus_static",
+		"platforms": ["EC2", "EKS"]
+	},
+	{
+		"case_name": "prometheus_sd",
+		"platforms": ["EKS"]
 	}
 ]

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -61,7 +61,7 @@
 	},
 	{
 		"case_name": "prometheus_static",
-		"platforms": ["EC2", "EKS"]
+		"platforms": ["EC2", "EKS", "SOAKING"]
 	},
 	{
 		"case_name": "prometheus_sd",

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.16.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsprometheusremotewriteexporter v0.16.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.16.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.16.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter v0.16.0

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -17,6 +17,7 @@ package defaultcomponents // import "aws-observability.io/collector/defaultcompo
 
 import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsprometheusremotewriteexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter"
@@ -83,6 +84,7 @@ func Components() (component.Factories, error) {
 		signalfxexporter.NewFactory(),
 		datadogexporter.NewFactory(),
 		newrelicexporter.NewFactory(),
+		awsprometheusremotewriteexporter.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/pkg/defaultcomponents/defaults_test.go
+++ b/pkg/defaultcomponents/defaults_test.go
@@ -28,6 +28,7 @@ func TestComponents(t *testing.T) {
 	exporters := factories.Exporters
 	// aws exporters
 	assert.True(t, exporters["awsxray"] != nil)
+	assert.True(t, exporters["awsprometheusremotewriteexporter"] != nil)
 	// core exporters
 	assert.True(t, exporters["logging"] != nil)
 	assert.True(t, exporters["otlp"] != nil)

--- a/pkg/defaultcomponents/defaults_test.go
+++ b/pkg/defaultcomponents/defaults_test.go
@@ -28,7 +28,7 @@ func TestComponents(t *testing.T) {
 	exporters := factories.Exporters
 	// aws exporters
 	assert.True(t, exporters["awsxray"] != nil)
-	assert.True(t, exporters["awsprometheusremotewriteexporter"] != nil)
+	assert.True(t, exporters["awsprometheusremotewrite"] != nil)
 	// core exporters
 	assert.True(t, exporters["logging"] != nil)
 	assert.True(t, exporters["otlp"] != nil)


### PR DESCRIPTION
**Description**:
Enable AWSPrometheusRemoteWriteExporter and Prometheus test cases for the appropriate testing platforms

**Testing**:
Tested on local, EC2, EKS