### PR TITLE
removed prometheus exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ This table represents the supported components of AWS OTel Collector in 2020. Th
 |                                 | metricstransformprocessor     | newrelicexporter                   |                        |
 |                                 |                               | sapmexporter                       |                        |
 |                                 |                               | signalfxexporter                   |                        |
-|                                 |                               | prometheusexporter                 |                        |
 
 
 #### AWS OTel Collector AWS Components

--- a/go.sum
+++ b/go.sum
@@ -883,6 +883,8 @@ github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.16.0 h1:1pfiYIPFwgbluJDoOZe1x3onGLWJBb8RbaU0EpPth/g=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.16.0/go.mod h1:mKdDCv85c40GroelRo64qm8XewRXIYO1atkPMvyDX7M=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsprometheusremotewriteexporter v0.16.0 h1:0TjbpmihZrevF2AaoCpYAr5bfq7j0cuWdHZoV412jpQ=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsprometheusremotewriteexporter v0.16.0/go.mod h1:DWnHHeuoiezOtgmL6lMd/JGJ4ea0EvyQRAyP+SiD02c=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.16.0 h1:iwSu/tWVdk0y2eP/+Hjyu4x4Ba1VxpYsMK3heZmuwyc=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.16.0/go.mod h1:8XFceO/drGFmAh5z6Zyo15Aobp9jD8taDxa1sDUkC0s=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.16.0 h1:w0L6cdkIGgB6aWBbp/ouAHez4QSZZnC/8/TRyexs8VY=

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -33,7 +33,6 @@ import (
 	"go.opentelemetry.io/collector/exporter/loggingexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
-	"go.opentelemetry.io/collector/exporter/prometheusexporter"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
 	"go.opentelemetry.io/collector/receiver/prometheusreceiver"
 	"go.opentelemetry.io/collector/service/defaultcomponents"
@@ -74,7 +73,6 @@ func Components() (component.Factories, error) {
 	factories.Exporters, err = component.MakeExporterFactoryMap(
 		awsxrayexporter.NewFactory(),
 		awsemfexporter.NewFactory(),
-		prometheusexporter.NewFactory(),
 		loggingexporter.NewFactory(),
 		fileexporter.NewFactory(),
 		otlpexporter.NewFactory(),


### PR DESCRIPTION
**Description:** 
AWS Prometheus Remote Write Exporter has now been merged, and we only wish to support this instead of the pull-based Prometheus exporter. This PR therefore removes the Prometheus exporter.

--cc @alolita 