### PR TITLE
Fix the typo for the ecs default config file

### DIFF
--- a/config/ecs/ecs-default-config.yaml
+++ b/config/ecs/ecs-default-config.yaml
@@ -28,7 +28,7 @@ exporters:
 service:
   pipelines:
     traces:
-      receivers: [otlp,awxray]
+      receivers: [otlp,awsxray]
       processors: [batch/traces]
       exporters: [awsxray]
     metrics:


### PR DESCRIPTION
Fix a small typo in the config file.