### PR TITLE
Add test case for gRPC exporter

### DIFF
--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -20,6 +20,14 @@
 		"platforms": ["ECS"]
 	},
 	{
+		"case_name": "otlp_grpc_exporter_metric_mock",
+		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING", "CANARY"]
+	},
+	{
+		"case_name": "otlp_grpc_exporter_trace_mock",
+		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING", "CANARY"]
+	},
+	{
 		"case_name": "otlp_http_exporter_metric_mock",
 		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING", "CANARY"]
 	},


### PR DESCRIPTION
**Description:**
Add test case for gRPC exporter

**Link to tracking Issue:** https://github.com/aws-observability/aws-otel-test-framework/pull/176

**Testing:** 
```
cd terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false -var-file="../testcases/otlp_grpc_exporter_metric_mock/parameters.tfvars" -var="aoc_version=latest" -var="testcase=../testcases/otlp_grpc_exporter_metric_mock"
cd terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false -var-file="../testcases/otlp_grpc_exporter_trace_mock/parameters.tfvars" -var="aoc_version=latest" -var="testcase=../testcases/otlp_grpc_exporter_trace_mock"
```
