### PR TITLE
Add an extraconfig for enabling debug log

### DIFF
--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -18,6 +18,7 @@ package main // import "aws-observability.io/collector/cmd/awscollector"
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/aws-observability/aws-otel-collector/pkg/config"
 	"github.com/aws-observability/aws-otel-collector/pkg/defaultcomponents"
@@ -51,10 +52,11 @@ func main() {
 	lumberHook := logger.GetLumberHook()
 
 	// set logger level, env var has higher priority
-	if extraConfig != nil {
+	if level, ok := os.LookupEnv("AOT_LOG_LEVEL"); ok {
+		logger.SetLogLevel(level)
+	} else if extraConfig != nil {
 		logger.SetLogLevel(extraConfig.LoggingLevel)
 	}
-	logger.SetLogLevelWithEnvVar()
 
 	info := component.ApplicationStartInfo{
 		ExeName:  "aws-otel-collector",

--- a/docs/developers/debian-deb-demo.md
+++ b/docs/developers/debian-deb-demo.md
@@ -33,3 +33,15 @@ sudo dpkg -i -E ./aws-otel-collector.deb
 ```
 docker run --rm -it -e "otlp_endpoint=172.17.0.1:55680" -e "otlp_instance_id=test_insance" mxiamxia/aws-otel-metric-generator:latest
 ```
+
+
+
+#### enable debugging log
+
+add a key value pair into `/opt/aws/aws-otel-collector/etc/.env` and restart collector
+
+```
+sudo echo "loggingLevel=DEBUG >> /opt/aws/aws-otel-collector/etc/.env"
+sudo /opt/aws/aws-otel-collector/aws-otel-collector-ctl -a stop
+sudo /opt/aws/aws-otel-collector/aws-otel-collector-ctl -a start
+```

--- a/docs/developers/linux-rpm-demo.md
+++ b/docs/developers/linux-rpm-demo.md
@@ -55,3 +55,13 @@ aws cloudformation create-stack --stack-name AWSOTelCollectorEC2-Test \
     --capabilities CAPABILITY_NAMED_IAM \
     --region ${Region}
 ```
+
+#### enable debugging log
+
+add a key value pair into `/opt/aws/aws-otel-collector/etc/.env` and restart collector
+
+```
+sudo echo "loggingLevel=DEBUG >> /opt/aws/aws-otel-collector/etc/.env"
+sudo /opt/aws/aws-otel-collector/aws-otel-collector-ctl -a stop
+sudo /opt/aws/aws-otel-collector/aws-otel-collector-ctl -a start
+```

--- a/docs/developers/windows-other-demo.md
+++ b/docs/developers/windows-other-demo.md
@@ -31,3 +31,14 @@ or can be installed by double clicking the windows msi file.
     ```
       & '.\Program Files\Amazon\AwsOpentelemetryCollector\aws-otel-collector-ctl.ps1' -a status 
     ```
+
+
+#### enable debugging log
+
+add a key value pair into `.\Program Files\Amazon\AwsOpentelemetryCollector\etc\.env` and restart collector
+
+```
+Add-Content .\Program Files\Amazon\AwsOpentelemetryCollector\etc\.env "loggingLevel=DEBUG"
+& '.\Program Files\Amazon\AwsOpentelemetryCollector\aws-otel-collector-ctl.ps1' -a stop 
+& '.\Program Files\Amazon\AwsOpentelemetryCollector\aws-otel-collector-ctl.ps1' -a start
+```

--- a/go.sum
+++ b/go.sum
@@ -883,6 +883,8 @@ github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.16.0 h1:1pfiYIPFwgbluJDoOZe1x3onGLWJBb8RbaU0EpPth/g=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.16.0/go.mod h1:mKdDCv85c40GroelRo64qm8XewRXIYO1atkPMvyDX7M=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsprometheusremotewriteexporter v0.16.0 h1:0TjbpmihZrevF2AaoCpYAr5bfq7j0cuWdHZoV412jpQ=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsprometheusremotewriteexporter v0.16.0/go.mod h1:DWnHHeuoiezOtgmL6lMd/JGJ4ea0EvyQRAyP+SiD02c=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.16.0 h1:iwSu/tWVdk0y2eP/+Hjyu4x4Ba1VxpYsMK3heZmuwyc=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.16.0/go.mod h1:8XFceO/drGFmAh5z6Zyo15Aobp9jD8taDxa1sDUkC0s=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.16.0 h1:w0L6cdkIGgB6aWBbp/ouAHez4QSZZnC/8/TRyexs8VY=

--- a/pkg/extraconfig/extraconfig.go
+++ b/pkg/extraconfig/extraconfig.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package extraconfig
+
+import (
+	"bufio"
+	"os"
+	"runtime"
+	"strings"
+)
+
+var (
+	unixExtraConfigPath    = "/opt/aws/aws-otel-collector/etc/.env"
+	windowsExtraConfigPath = "C:\\ProgramData\\Amazon\\AwsOTelCollector\\etc\\.env"
+)
+
+type ExtraConfig struct {
+	LoggingLevel string
+}
+
+// GetExtraConfig returns the extra configs.
+func GetExtraConfig() (*ExtraConfig, error) {
+	// read .env from os
+	file, err := os.Open(getConfigFilePath())
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	// read its content line by line and handle it as keyvalue pairs
+	extraConfigMap := map[string]string{}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if equal := strings.Index(line, "="); equal >= 0 {
+			if key := strings.TrimSpace(line[:equal]); len(key) > 0 {
+				value := ""
+				if len(line) > equal {
+					value = strings.TrimSpace(line[equal+1:])
+				}
+				extraConfigMap[key] = value
+
+			}
+		}
+	}
+
+	// check error
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	// build extraconfig object
+	extraConfig := ExtraConfig{}
+	if val, ok := extraConfigMap["loggingLevel"]; ok {
+		extraConfig.LoggingLevel = val
+	}
+
+	return &extraConfig, nil
+}
+
+// getConfigFilePath return the path base on os
+func getConfigFilePath() string {
+	if runtime.GOOS == "windows" {
+		return windowsExtraConfigPath
+	}
+	return unixExtraConfigPath
+}

--- a/pkg/extraconfig/extraconfig_test.go
+++ b/pkg/extraconfig/extraconfig_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package extraconfig
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetExtraConfig(t *testing.T) {
+	unixExtraConfigPath = "./test/extraconfig.txt"
+	extraConfig, err := GetExtraConfig()
+
+	assert.NoError(t, err)
+	assert.Equal(t, extraConfig.LoggingLevel, "DEBUG")
+}
+
+func TestGetExtraConfigWithNoLoggingLevel(t *testing.T) {
+	unixExtraConfigPath = "./test/extraconfigwithnologginglevel.txt"
+	extraConfig, err := GetExtraConfig()
+
+	assert.NoError(t, err)
+	assert.Equal(t, extraConfig.LoggingLevel, "")
+}
+
+func TestGetExtraConfigWithNoFile(t *testing.T) {
+	unixExtraConfigPath = "./notexistedextraconfig.txt"
+	_, err := GetExtraConfig()
+	assert.Error(t, err)
+}

--- a/pkg/extraconfig/test/extraconfig.txt
+++ b/pkg/extraconfig/test/extraconfig.txt
@@ -1,0 +1,2 @@
+config=--config /opt/aws/aws-otel-collector/etc/config.yaml
+loggingLevel=DEBUG

--- a/pkg/extraconfig/test/extraconfigwithnologginglevel.txt
+++ b/pkg/extraconfig/test/extraconfigwithnologginglevel.txt
@@ -1,0 +1,1 @@
+config=--config /opt/aws/aws-otel-collector/etc/config.yaml

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -80,9 +80,18 @@ func getLogFilePath() string {
 	return UnixInstallPath + "logs/aws-otel-collector.log"
 }
 
+// SetLogLevel allows to set log level by parameter
+// possible values (DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL)
+func SetLogLevel(level string) {
+	if level != "" {
+		os.Args = append(os.Args, "--log-level", level)
+	}
+
+}
+
 // SetLogLevel allow to set log level by environment vars
 // possible values (DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL)
-func SetLogLevel() {
+func SetLogLevelWithEnvVar() {
 	if level, ok := os.LookupEnv("AOT_LOG_LEVEL"); ok {
 		os.Args = append(os.Args, "--log-level", level)
 	}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -88,11 +88,3 @@ func SetLogLevel(level string) {
 	}
 
 }
-
-// SetLogLevel allow to set log level by environment vars
-// possible values (DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL)
-func SetLogLevelWithEnvVar() {
-	if level, ok := os.LookupEnv("AOT_LOG_LEVEL"); ok {
-		os.Args = append(os.Args, "--log-level", level)
-	}
-}

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -59,14 +59,6 @@ func TestGetLogFilePath(t *testing.T) {
 	}
 }
 
-func TestSetLogLevelWithEnvVar(t *testing.T) {
-	os.Setenv("AOT_LOG_LEVEL", "DEBUG")
-	defer os.Unsetenv("AOT_LOG_LEVEL")
-	SetLogLevelWithEnvVar()
-	argStr := strings.Join(os.Args[:], "=")
-	assert.True(t, strings.Contains(argStr, "--log-level=DEBUG"))
-}
-
 func TestSetLogLevel(t *testing.T) {
 	SetLogLevel("DEBUG")
 	argStr := strings.Join(os.Args[:], "=")

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -53,16 +53,22 @@ func TestSetupErrorLoggerWithNoFilePath(t *testing.T) {
 func TestGetLogFilePath(t *testing.T) {
 	logPath := getLogFilePath()
 	if runtime.GOOS == "windows" {
-		assert.Equal(t, WindowsInstallPath + "Logs\\aws-otel-collector.log", logPath)
+		assert.Equal(t, WindowsInstallPath+"Logs\\aws-otel-collector.log", logPath)
 	} else {
-		assert.Equal(t, UnixInstallPath + "logs/aws-otel-collector.log", logPath)
+		assert.Equal(t, UnixInstallPath+"logs/aws-otel-collector.log", logPath)
 	}
 }
 
-func TestSetLogLevel(t *testing.T) {
+func TestSetLogLevelWithEnvVar(t *testing.T) {
 	os.Setenv("AOT_LOG_LEVEL", "DEBUG")
 	defer os.Unsetenv("AOT_LOG_LEVEL")
-	SetLogLevel()
+	SetLogLevelWithEnvVar()
+	argStr := strings.Join(os.Args[:], "=")
+	assert.True(t, strings.Contains(argStr, "--log-level=DEBUG"))
+}
+
+func TestSetLogLevel(t *testing.T) {
+	SetLogLevel("DEBUG")
 	argStr := strings.Join(os.Args[:], "=")
 	assert.True(t, strings.Contains(argStr, "--log-level=DEBUG"))
 }


### PR DESCRIPTION
**Description:** 
Added a feature to support config logging level in .env file


**Testing:** 

unit test done

**Documentation:** 

edit the documents:

* https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/linux-rpm-demo.md
* https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/debian-deb-demo.md
* https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/windows-other-demo.md
