### PR TITLE
use dispatch instead of listening on tagging

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -286,6 +286,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
           tag_name: ${{ github.event.inputs.version }}
+          commitish: ${{ github.event.inputs.sha }}
           release_name: Release ${{ github.event.inputs.version }}
           body_path: release-note
           draft: true

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -15,8 +15,11 @@ name: CD
 
 on:        
   workflow_dispatch:
-    tag:
-      description: 'to release which tag'
+    version:
+      description: 'the version number to release'
+      required: true
+    sha:
+      description: 'the github sha to release'
       required: true
     
 env:
@@ -29,15 +32,13 @@ env:
   TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
 
 jobs:
-  release-checking:
-    outputs:
-      version: ${{ steps.get_version.outputs.version }}  
+  release-checking: 
     runs-on: ubuntu-latest
     steps: 
       - name: Checkout Tag
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.inputs.tag }}
+          ref: ${{ github.event.inputs.sha }}
 
       - name: Checking if the related commit has passed the Soaking test
         run: echo "Checking Soaking test"
@@ -49,19 +50,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
           aws-region: us-west-2
 
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=version::${{ github.event.inputs.tag }}
-      
-      - name: Get the Sha
-        id: get_sha
-        run: echo ::set-output name=sha::$(git rev-parse HEAD)
-
       - name: download packages as release candidate from s3
         uses: aws-observability/aws-otel-collector-test-framework@deprecating
         with:
           running_type: candidate
-          opts: "-t=DownloadCandidate -s=.aoc-stack-test.yml -p=${{ steps.get_version.outputs.version }} -g=${{ steps.get_sha.outputs.sha }}"
+          opts: "-t=DownloadCandidate -s=.aoc-stack-test.yml -p=${{ github.event.inputs.version }} -g=${{ github.event.inputs.sha }}"
 
       - name: cp stack into packages
         run: |
@@ -183,7 +176,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.inputs.tag }}
+          ref: ${{ github.event.inputs.sha }}
       
       - name: Setup Python
         uses: actions/setup-python@v2.1.4
@@ -234,7 +227,7 @@ jobs:
       - name: Run testing suite on ecs
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
-          cd testing-framework/terraform/ecs && terraform init && terraform apply -auto-approve -lock=false $opts -var="ecs_launch_type=${{ matrix.launch_type }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="aoc_image_repo=$IMAGE_LINK" -var="testcase=../testcases/${{ matrix.testcase }}"
+          cd testing-framework/terraform/ecs && terraform init && terraform apply -auto-approve -lock=false $opts -var="ecs_launch_type=${{ matrix.launch_type }}" -var="aoc_version=${{ github.event.inputs.version }}" -var="aoc_image_repo=$IMAGE_LINK" -var="testcase=../testcases/${{ matrix.testcase }}"
                     
       - name: Destroy resources
         if: ${{ always() }}
@@ -272,7 +265,7 @@ jobs:
       - name: Run testing suite on eks
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
-          cd testing-framework/terraform/eks && terraform init && terraform apply -auto-approve -lock=false $opts -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="aoc_image_repo=$IMAGE_LINK" -var="testcase=../testcases/${{ matrix.testcase }}"
+          cd testing-framework/terraform/eks && terraform init && terraform apply -auto-approve -lock=false $opts -var="aoc_version=${{ github.event.inputs.version }}" -var="aoc_image_repo=$IMAGE_LINK" -var="testcase=../testcases/${{ matrix.testcase }}"
           
       - name: Destroy resources
         if: ${{ always() }}
@@ -292,8 +285,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ github.event.inputs.tag }}
-          release_name: Release ${{ github.event.inputs.tag }}
+          tag_name: ${{ github.event.inputs.version }}
+          release_name: Release ${{ github.event.inputs.version }}
           body_path: release-note
           draft: true
           prerelease: true

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -35,7 +35,7 @@ jobs:
   release-checking: 
     runs-on: ubuntu-latest
     steps: 
-      - name: Checkout Tag
+      - name: Checkout the sha
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.sha }}

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -14,9 +14,10 @@
 name: CD
 
 on:        
-  # listen on dispatch, the expected payload is {"tag": "xxx"}
-  repository_dispatch:
-    types: [release]
+  workflow_dispatch:
+    tag:
+      description: 'to release which tag'
+      required: true
     
 env:
   IMAGE_NAME: aws-otel-collector
@@ -36,7 +37,7 @@ jobs:
       - name: Checkout Tag
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.client_payload.tag }}
+          ref: ${{ github.event.inputs.tag }}
 
       - name: Checking if the related commit has passed the Soaking test
         run: echo "Checking Soaking test"
@@ -50,7 +51,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=version::${{ github.event.client_payload.tag }}
+        run: echo ::set-output name=version::${{ github.event.inputs.tag }}
       
       - name: Get the Sha
         id: get_sha
@@ -182,7 +183,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.client_payload.tag }}
+          ref: ${{ github.event.inputs.tag }}
       
       - name: Setup Python
         uses: actions/setup-python@v2.1.4

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -13,12 +13,11 @@
 
 name: CD
 
-# listen on tag with name like v1.0.0
-on:
-  push:
-    tags:
-      - v*
-
+on:        
+  # listen on dispatch, the expected payload is {"tag": "xxx"}
+  repository_dispatch:
+    types: [release]
+    
 env:
   IMAGE_NAME: aws-otel-collector
   IMAGE_NAMESPACE: amazon
@@ -34,8 +33,10 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}  
     runs-on: ubuntu-latest
     steps: 
-      - name: Checkout aws-opentelemetry-collector
+      - name: Checkout Tag
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.tag }}
 
       - name: Checking if the related commit has passed the Soaking test
         run: echo "Checking Soaking test"
@@ -49,19 +50,21 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=version::$(echo $GITHUB_REF | cut -d / -f 3)
+        run: echo ::set-output name=version::${{ github.event.client_payload.tag }}
+      
+      - name: Get the Sha
+        id: get_sha
+        run: echo ::set-output name=sha::$(git rev-parse HEAD)
 
       - name: download packages as release candidate from s3
         uses: aws-observability/aws-otel-collector-test-framework@deprecating
         with:
           running_type: candidate
-          opts: "-t=DownloadCandidate -s=.aoc-stack-test.yml -p=${{ steps.get_version.outputs.version }} -g=${{ github.sha }}"
+          opts: "-t=DownloadCandidate -s=.aoc-stack-test.yml -p=${{ steps.get_version.outputs.version }} -g=${{ steps.get_sha.outputs.sha }}"
 
       - name: cp stack into packages
         run: |
-          cp .aoc-stack-release.yml build/packages/      
-
-      - run: ls -R      
+          cp .aoc-stack-release.yml build/packages/           
 
       - name: Cache packages
         uses: actions/cache@v2
@@ -178,6 +181,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.tag }}
       
       - name: Setup Python
         uses: actions/setup-python@v2.1.4
@@ -204,8 +209,6 @@ jobs:
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.ecs-matrix) }}
     
     steps:
-      - uses: actions/checkout@v2
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -229,7 +232,6 @@ jobs:
           
       - name: Run testing suite on ecs
         run: |
-          pwd=$PWD
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
           cd testing-framework/terraform/ecs && terraform init && terraform apply -auto-approve -lock=false $opts -var="ecs_launch_type=${{ matrix.launch_type }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="aoc_image_repo=$IMAGE_LINK" -var="testcase=../testcases/${{ matrix.testcase }}"
                     
@@ -245,8 +247,6 @@ jobs:
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.eks-matrix) }}
     
     steps:
-      - uses: actions/checkout@v2
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -282,9 +282,7 @@ jobs:
   release-to-github:
     runs-on: ubuntu-latest
     needs: [release-image, release-to-s3]
-    steps:
-      - uses: actions/checkout@v2
-     
+    steps:     
       - name: Generate release-note
         run: sh tools/release/generate-release-note.sh "`cat VERSION`"
         
@@ -293,8 +291,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          tag_name: ${{ github.event.client_payload.tag }}
+          release_name: Release ${{ github.event.client_payload.tag }}
           body_path: release-note
           draft: true
           prerelease: true

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -292,8 +292,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ github.event.client_payload.tag }}
-          release_name: Release ${{ github.event.client_payload.tag }}
+          tag_name: ${{ github.event.inputs.tag }}
+          release_name: Release ${{ github.event.inputs.tag }}
           body_path: release-note
           draft: true
           prerelease: true


### PR DESCRIPTION
to decouple the release logic with the actual release code, so that the release logic will always be in main branch, otherwise, the release logic will come from the tag.  if there's anything wrong in the tag for the release logic, we had to retag, and run CI to upload candidate packages again, which is time-consuming