### PR TITLE
fix: use official aws-otel-collector image

### DIFF
--- a/deployment-template/ecs/aws-otel-ec2-sidecar-deployment-cfn.yaml
+++ b/deployment-template/ecs/aws-otel-ec2-sidecar-deployment-cfn.yaml
@@ -72,7 +72,7 @@ Resources:
               protocol: tcp
               containerPort: 55680
           command: [!Ref command]
-          image: 'rhossai2/aoc:v0.0.20'
+          image: 'amazon/aws-otel-collector:latest'
           name: aws-collector
         - logConfiguration:
             logDriver: awslogs

--- a/deployment-template/ecs/aws-otel-fargate-sidecar-deployment-cfn.yaml
+++ b/deployment-template/ecs/aws-otel-fargate-sidecar-deployment-cfn.yaml
@@ -67,7 +67,7 @@ Resources:
       NetworkMode: awsvpc
       ContainerDefinitions:
         - Name: aws-collector
-          Image: 'rhossai2/aoc:v0.0.20'
+          Image: 'amazon/aws-otel-collector:latest'
           command: [!Ref command]
           Cpu: '256'
           Memory: '512'


### PR DESCRIPTION
This change uses official collector image instead of personal account build. 