### PR TITLE
chore: Add gpg linux package signing and RPM FIPS support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -205,7 +205,7 @@ jobs:
           gpg --list-secret-keys
           shred -fuvz pkg_sign_private.key
 
-      - name: Sign RPM Pakcage
+      - name: Sign DEB Pakcage
         run: |
           sudo apt install -y dpkg-sig
           dpkg-sig --sign origin -k "aws-otel-collector@amazon.com" build/packages/debian/*/*.deb

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,17 +26,18 @@ on:
 env:
   IMAGE_NAME: aws-otel-collector
   PACKAGING_ROOT: build/packages
-  ECR_REPO: aws/aws-otel-collector  
+  ECR_REPO: aws/aws-otel-collector
   TF_VAR_aws_access_key_id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
-  TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }} 
+  TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+  PKG_SIGN_PRIVATE_KEY_NAME: aoc-linux-pkg-signing-gpg-key
 jobs:
 
- 
+
   build:
     runs-on: ubuntu-latest
 
     steps:
-    # Set up building environment, patch the dev repo code on dispatch events.  
+    # Set up building environment, patch the dev repo code on dispatch events.
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
@@ -139,6 +140,33 @@ jobs:
           ARCH=x86_64 DEST=build/packages/linux/amd64 tools/packaging/linux/create_rpm.sh
           ARCH=aarch64 DEST=build/packages/linux/arm64 tools/packaging/linux/create_rpm.sh
 
+      - name: Download Package Signing GPG key
+        run: |
+          aws secretsmanager get-secret-value --region us-west-2 --secret-id "$PKG_SIGN_PRIVATE_KEY_NAME" | jq -r ".SecretString" > pkg_sign_private.key
+          md5sum pkg_sign_private.key
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.SIGN_PKG_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SIGN_PKG_AWS_SECRET_ACCESS_KEY }}
+
+      - name: Import Package Signing GPG Key
+        run: |
+          gpg --import pkg_sign_private.key
+          gpg --list-keys
+          gpg --armor --export -a "aws-otel-collector@amazon.com" > pkg_sign_public.key
+          rpm --import pkg_sign_public.key
+          echo "%_gpg_name aws-otel-collector@amazon.com" > ~/.rpmmacros
+          md5sum pkg_sign_public.key
+          shred -fuvz pkg_sign_private.key
+
+      - name: Sign RPM Pakcage
+        run: |
+          rpmsign --addsign build/packages/linux/*/*.rpm
+
+      - name: Remove Package Signing GPG Key from local GPG Key Ring
+        run: |
+          gpg --fingerprint --with-colons aws-otel-collector@amazon.com grep "^fpr" | sed -n 's/^fpr:::::::::\([[:alnum:]]\+\):/\1/p' | xargs gpg --batch --yes --delete-secret-keys
+          gpg --list-secret-keys
+
       - name: Cache rpms
         uses: actions/cache@v2
         with:
@@ -162,6 +190,30 @@ jobs:
         run: |
           ARCH=amd64 TARGET_SUPPORTED_ARCH=x86_64 DEST=build/packages/debian/amd64 tools/packaging/debian/create_deb.sh
           ARCH=arm64 TARGET_SUPPORTED_ARCH=aarch64 DEST=build/packages/debian/arm64 tools/packaging/debian/create_deb.sh
+
+      - name: Download Package Signing GPG key
+        run: |
+          aws secretsmanager get-secret-value --region us-west-2 --secret-id "$PKG_SIGN_PRIVATE_KEY_NAME" | jq -r ".SecretString" > pkg_sign_private.key
+          md5sum pkg_sign_private.key
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.SIGN_PKG_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SIGN_PKG_AWS_SECRET_ACCESS_KEY }}
+
+      - name: Import Package Signing GPG Key
+        run: |
+          gpg --import pkg_sign_private.key
+          gpg --list-secret-keys
+          shred -fuvz pkg_sign_private.key
+
+      - name: Sign RPM Pakcage
+        run: |
+          sudo apt install -y dpkg-sig
+          dpkg-sig --sign origin -k "aws-otel-collector@amazon.com" build/packages/debian/*/*.deb
+
+      - name: Remove Package Signing GPG Key from local GPG Key Ring
+        run: |
+          gpg --fingerprint --with-colons aws-otel-collector@amazon.com grep "^fpr" | sed -n 's/^fpr:::::::::\([[:alnum:]]\+\):/\1/p' | xargs gpg --batch --yes --delete-secret-keys
+          gpg --list-secret-keys
 
       - name: Cache Debs
         uses: actions/cache@v2
@@ -200,7 +252,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [packaging-rpm, packaging-deb, packaging-msi, packaging-image]
     outputs:
-      version: ${{ steps.versioning.outputs.version }}  
+      version: ${{ steps.versioning.outputs.version }}
     steps:
       # Archive all the packages into one, and build a unique version number for e2etesting
       - uses: actions/checkout@v2
@@ -216,7 +268,7 @@ jobs:
         with:
           key: "cached_debs_${{ github.run_id }}"
           path: build/packages
-          
+
       - name: Restore cached image
         uses: actions/cache@v2
         with:
@@ -227,7 +279,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: msi_artifacts
-          path: build/packages    
+          path: build/packages
 
       - run: ls -R
 
@@ -242,7 +294,7 @@ jobs:
 
       - name: prepare CI&CD stack
         run: |
-          cp .aoc-stack-test.yml build/packages/ 
+          cp .aoc-stack-test.yml build/packages/
           cp .aoc-stack-release.yml build/packages/
 
       - name: Cache the packages
@@ -269,7 +321,7 @@ jobs:
           path: build/packages
           key: "cached_packages_${{ github.run_id }}"
 
-      - name: upload to s3 in the testing stack 
+      - name: upload to s3 in the testing stack
         uses: aws-observability/aws-otel-collector-test-framework@deprecating
         with:
           running_type: release
@@ -278,11 +330,11 @@ jobs:
       - name: Login ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-      
+
       - name: upload to ECR
         run: |
           docker load < build/packages/$IMAGE_NAME.tar
-          docker tag $IMAGE_NAME ${{ steps.login-ecr.outputs.registry }}/$ECR_REPO:${{ needs.e2etest-preparation.outputs.version }}  
+          docker tag $IMAGE_NAME ${{ steps.login-ecr.outputs.registry }}/$ECR_REPO:${{ needs.e2etest-preparation.outputs.version }}
           docker push ${{ steps.login-ecr.outputs.registry }}/$ECR_REPO:${{ needs.e2etest-preparation.outputs.version }}
 
           #- name: Login Dockerhub
@@ -329,8 +381,8 @@ jobs:
         uses: aws-observability/aws-otel-collector-test-framework@deprecating
         with:
           running_type: integ-test
-          opts: "-t=EC2_TEST -s=build/packages/.aoc-stack-test.yml -a=${{ matrix.ami }}" 
-             
+          opts: "-t=EC2_TEST -s=build/packages/.aoc-stack-test.yml -a=${{ matrix.ami }}"
+
   get-testing-suites:
     runs-on: ubuntu-latest
     outputs:
@@ -340,13 +392,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      
+
       - name: Setup Python
         uses: actions/setup-python@v2.1.4
 
       - name: Get all the testing suites
         id: set-matrix
-        run: | 
+        run: |
           ec2_matrix=$(python e2etest/get-testcases.py ec2_matrix)
           ecs_matrix=$(python e2etest/get-testcases.py ecs_matrix)
           eks_matrix=$(python e2etest/get-testcases.py eks_matrix)
@@ -355,57 +407,17 @@ jobs:
           echo "::set-output name=ec2-matrix::$ec2_matrix"
       - name: List testing suites
         run: |
-          echo ${{ steps.set-matrix.outputs.eks-matrix }}    
+          echo ${{ steps.set-matrix.outputs.eks-matrix }}
           echo ${{ steps.set-matrix.outputs.ecs-matrix }}
           echo ${{ steps.set-matrix.outputs.ec2-matrix }}
-          
+
   e2etest-ec2-new:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, e2etest-release, e2etest-preparation]
     strategy:
       max-parallel: 5
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix) }}
-    
-    steps:
-      - uses: actions/checkout@v2
-        
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
-          aws-region: us-west-2
-          
-      - name: Set up JDK 1.11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.11
-      
-      - name: Set up terraform
-        uses: hashicorp/setup-terraform@v1
-      
-      - name: Check out testing framework
-        uses: actions/checkout@v2
-        with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
-          path: testing-framework
-        
-      - name: Run testing suite on ec2
-        run: |
-          if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
-          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}"
-      - name: Destroy resources
-        if: ${{ always() }}
-        run: |
-          cd testing-framework/terraform/ec2 && terraform destroy -auto-approve        
-          
-  e2etest-ecs:
-    runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
-    strategy:
-      max-parallel: 5
-      matrix: ${{ fromJson(needs.get-testing-suites.outputs.ecs-matrix) }}
-    
+
     steps:
       - uses: actions/checkout@v2
 
@@ -415,21 +427,61 @@ jobs:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
           aws-region: us-west-2
-          
+
       - name: Set up JDK 1.11
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
-      
+
       - name: Set up terraform
         uses: hashicorp/setup-terraform@v1
-      
+
       - name: Check out testing framework
         uses: actions/checkout@v2
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
-      
+
+      - name: Run testing suite on ec2
+        run: |
+          if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
+          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}"
+      - name: Destroy resources
+        if: ${{ always() }}
+        run: |
+          cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
+
+  e2etest-ecs:
+    runs-on: ubuntu-latest
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    strategy:
+      max-parallel: 5
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.ecs-matrix) }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+
+      - name: Set up terraform
+        uses: hashicorp/setup-terraform@v1
+
+      - name: Check out testing framework
+        uses: actions/checkout@v2
+        with:
+          repository: 'aws-observability/aws-otel-collector-test-framework'
+          path: testing-framework
+
       - name: Run testing suite on ecs
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
@@ -438,15 +490,15 @@ jobs:
       - name: Destroy resources
         if: ${{ always() }}
         run: |
-          cd testing-framework/terraform/ecs && terraform destroy -auto-approve        
-      
+          cd testing-framework/terraform/ecs && terraform destroy -auto-approve
+
   e2etest-eks:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, e2etest-release, e2etest-preparation]
     strategy:
       max-parallel: 5
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.eks-matrix) }}
-    
+
     steps:
       - uses: actions/checkout@v2
 
@@ -456,31 +508,31 @@ jobs:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
           aws-region: us-west-2
-          
+
       - name: Set up JDK 1.11
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
-      
+
       - name: Set up terraform
         uses: hashicorp/setup-terraform@v1
-      
+
       - name: Check out testing framework
         uses: actions/checkout@v2
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
-      
+
       - name: Run testing suite on eks
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
-          cd testing-framework/terraform/eks && terraform init && terraform apply -auto-approve -lock=false $opts -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}" 
-          
+          cd testing-framework/terraform/eks && terraform init && terraform apply -auto-approve -lock=false $opts -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}"
+
       - name: Destroy resources
         if: ${{ always() }}
         run: |
           cd testing-framework/terraform/eks && terraform destroy -auto-approve
-          
+
 
   release-candidate:
     runs-on: ubuntu-latest
@@ -513,12 +565,12 @@ jobs:
         with:
           running_type: candidate
           opts: "-t=UploadCandidate -s=build/packages/.aoc-stack-test.yml"
-          
+
       - id: file_changes
         uses: trilom/file-changes-action@v1.2.3
         with:
           fileOutput: ''
-      
+
       - name: Trigger soaking
         if: contains(steps.file_changes.outputs.files_modified, 'VERSION')
         uses: peter-evans/repository-dispatch@v1.1.1

--- a/tools/packaging/linux/create_rpm.sh
+++ b/tools/packaging/linux/create_rpm.sh
@@ -77,7 +77,7 @@ mv ${RPM_NAME}-${VERSION}.tar.gz ${BUILD_ROOT}/SOURCES/
 rm -rf ${WORK_DIR}
 
 echo "Creating the rpm package"
-rpmbuild --define "VERSION $VERSION" --define "RPM_NAME $RPM_NAME" --define "_topdir ${BUILD_ROOT}" -bb -v --clean ${SPEC_FILE} --target ${ARCH}-linux
+rpmbuild --define "VERSION $VERSION" --define "RPM_NAME $RPM_NAME" --define "_topdir ${BUILD_ROOT}" --define "_source_filedigest_algorithm 8" --define "_binary_filedigest_algorithm 8" -bb -v --clean ${SPEC_FILE} --target ${ARCH}-linux
 
 echo "Copy rpm file to ${DEST}"
 mkdir -p ${DEST}


### PR DESCRIPTION
**Description:** 
Adding GPG package signing for Linux packages. For rpm packages, rpmsign is used, where as for deb packages, dpkg-sig is used. Both use the same GPG key for signing, and the public key can be downloaded from: https://aws-otel-collector.s3.amazonaws.com/aws-otel-collector.gpg

**Testing:**
The signing workflow has been tested on my own fork using my own key pair: https://github.com/haojhcwa/aws-otel-collector/actions/runs/414275830

**Documentation:**
There is no usage change for the Linux packages, how to use the public key to verify the packages would come later in a different PR.
