### PR TITLE
remove grpc and http exporter from canary

### DIFF
--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -21,19 +21,19 @@
 	},
 	{
 		"case_name": "otlp_grpc_exporter_metric_mock",
-		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING", "CANARY"]
+		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING"]
 	},
 	{
 		"case_name": "otlp_grpc_exporter_trace_mock",
-		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING", "CANARY"]
+		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING"]
 	},
 	{
 		"case_name": "otlp_http_exporter_metric_mock",
-		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING", "CANARY"]
+		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING"]
 	},
 	{
 		"case_name": "otlp_http_exporter_trace_mock",
-		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING", "CANARY"]
+		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING"]
 	},
 	{
 		"case_name": "sapm_exporter_trace_mock",


### PR DESCRIPTION
since we haven't release them