### PR TITLE
Add ECS template configurations for prometheus pipeline

### DIFF
--- a/examples/ecs/prometheus-pipeline/ecs-ec2-adot-config.yaml
+++ b/examples/ecs/prometheus-pipeline/ecs-ec2-adot-config.yaml
@@ -1,0 +1,53 @@
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 15s
+        scrape_timeout: 10s
+      scrape_configs:
+      - job_name: "test-prometheus-sample-app"
+        static_configs:
+        - targets: [ $PROMETHEUS_SAMPLE_APP ]
+  awsecscontainermetrics:
+    collection_interval: 20s
+
+processors:
+  filter:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+          - ecs.task.memory.utilized
+          - ecs.task.memory.reserved
+          - ecs.task.cpu.utilized
+          - ecs.task.cpu.reserved
+          - ecs.task.network.rate.rx
+          - ecs.task.network.rate.tx
+          - ecs.task.storage.read_bytes
+          - ecs.task.storage.write_bytes
+
+exporters:
+  awsprometheusremotewrite:
+    endpoint: {{endpoint}}
+    aws_auth:
+      region: {{region}}
+      service: "aps"
+  logging:
+    loglevel: debug
+extensions:
+  health_check:
+  pprof:
+    endpoint: :1888
+  zpages:
+    endpoint: :55679
+    
+service:
+  extensions: [pprof, zpages, health_check]
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      exporters: [logging, awsprometheusremotewrite]
+    metrics/ecs:
+      receivers: [awsecscontainermetrics]
+      processors: [filter]
+      exporters: [logging, awsprometheusremotewrite]

--- a/examples/ecs/prometheus-pipeline/ecs-ec2-task-def.json
+++ b/examples/ecs/prometheus-pipeline/ecs-ec2-task-def.json
@@ -1,0 +1,62 @@
+{
+    "family": "aws-otel-EC2",
+    "taskRoleArn": "{{ecsTaskRoleArn}}",
+    "executionRoleArn": "{{ecsExecutionRoleArn}}",
+    "networkMode": "default",
+    "containerDefinitions": [
+      {
+        "name": "prometheus-sample-app",
+        "image": "{{sampleAppImage}}",
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "/ecs/ecs-aws-otel-sidecar-app",
+            "awslogs-region": "{{region}}",
+            "awslogs-stream-prefix": "ecs",
+            "awslogs-create-group": "True"
+          }
+        },
+        "portMappings": [
+          {
+            "hostPort": 8080,
+            "protocol": "tcp",
+            "containerPort": 8080
+          }
+        ]
+      },
+      {
+        "name": "aws-otel-collector",
+        "image": "public.ecr.aws/aws-observability/aws-otel-collector:latest",
+        "essential": true,
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "/ecs/ecs-aws-otel-sidecar-collector",
+            "awslogs-region": "{{region}}",
+            "awslogs-stream-prefix": "ecs",
+            "awslogs-create-group": "True"
+          }
+        },
+        "environment": [
+          {
+            "name": "PROMETHEUS_SAMPLE_APP",
+            "value": "prometheus-sample-app:8080"
+          }
+        ],
+        "links": [
+          "prometheus-sample-app"
+        ],
+        "dependsOn": [
+          {
+            "containerName": "prometheus-sample-app",
+            "condition": "START"
+          }
+        ]
+      }
+    ],
+    "requiresCompatibilities": [
+      "EC2"
+    ],
+    "cpu": "256",
+    "memory": "512"
+  }

--- a/examples/ecs/prometheus-pipeline/ecs-fargate-adot-config.yaml
+++ b/examples/ecs/prometheus-pipeline/ecs-fargate-adot-config.yaml
@@ -1,0 +1,53 @@
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 15s
+        scrape_timeout: 10s
+      scrape_configs:
+      - job_name: "test-prometheus-sample-app"
+        static_configs:
+        - targets: [ 0.0.0.0:8080 ]
+  awsecscontainermetrics:
+    collection_interval: 20s
+
+processors:
+  filter:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+          - ecs.task.memory.utilized
+          - ecs.task.memory.reserved
+          - ecs.task.cpu.utilized
+          - ecs.task.cpu.reserved
+          - ecs.task.network.rate.rx
+          - ecs.task.network.rate.tx
+          - ecs.task.storage.read_bytes
+          - ecs.task.storage.write_bytes
+
+exporters:
+  awsprometheusremotewrite:
+    endpoint: {{endpoint}}
+    aws_auth:
+      region: {{region}}
+      service: "aps"
+  logging:
+    loglevel: debug
+extensions:
+  health_check:
+  pprof:
+    endpoint: :1888
+  zpages:
+    endpoint: :55679
+    
+service:
+  extensions: [pprof, zpages, health_check]
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      exporters: [logging, awsprometheusremotewrite]
+    metrics/ecs:
+      receivers: [awsecscontainermetrics]
+      processors: [filter]
+      exporters: [logging, awsprometheusremotewrite]

--- a/examples/ecs/prometheus-pipeline/ecs-fargate-task-def.json
+++ b/examples/ecs/prometheus-pipeline/ecs-fargate-task-def.json
@@ -1,0 +1,40 @@
+{
+  "family": "aws-otel-FARGATE",
+  "taskRoleArn": "{{ecsTaskRoleArn}}",
+  "executionRoleArn": "{{ecsExecutionRoleArn}}",
+  "networkMode": "awsvpc",
+  "containerDefinitions": [
+    {
+      "name": "aws-otel-collector",
+      "image": "public.ecr.aws/aws-observability/aws-otel-collector:latest",
+      "essential": true,
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/ecs-aws-otel-sidecar-collector",
+          "awslogs-region": "{{region}}",
+          "awslogs-stream-prefix": "ecs",
+          "awslogs-create-group": "True"
+        }
+      }
+    },
+    {
+      "name": "prometheus-sample-app",
+      "image": "{{sampleAppImage}}",
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/ecs-aws-otel-sidecar-app",
+          "awslogs-region": "{{region}}",
+          "awslogs-stream-prefix": "ecs",
+          "awslogs-create-group": "True"
+        }
+      }
+    }
+  ],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "256",
+  "memory": "512"
+}


### PR DESCRIPTION
**Description:**

Add ECS template configurations for prometheus pipeline. This will be used in our getting started documentation. 

For both EC2 and Fargate, we include:

* ADOT Collector configurations
* Task definitions for the ADOT Collector and sample app 