### PR TITLE
Use aws cli instead of old testing framework for candidate uploading

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -52,14 +52,16 @@ jobs:
           aws-region: us-west-2
 
       - name: download packages as release candidate from s3
-        uses: aws-observability/aws-otel-collector-test-framework@deprecating
-        with:
-          running_type: candidate
-          opts: "-t=DownloadCandidate -s=.aoc-stack-test.yml -p=${{ github.event.inputs.version }} -g=${{ github.event.inputs.sha }}"
-
-      - name: cp stack into packages
         run: |
-          cp .aoc-stack-release.yml build/packages/           
+          # download candidate package
+          aws s3 cp "s3://aws-otel-collector-release-candidate/${{ github.event.inputs.sha }}.tar.gz" candidate.tar.gz
+          tar zxvf candidate.tar.gz
+          
+          # check commit sha and version
+          version_in_candidate=`cat build/packages/VERSION`
+          sha_in_candidate=`cat build/packages/GITHUB_SHA`
+          [ $version_in_candidate -ne ${{ github.event.inputs.version }} ] && echo "wrong version is detected: $version_in_candidate != ${{ github.event.inputs.version }}" && exit 1
+          [ $sha_in_candidate -ne ${{ github.event.inputs.sha }} ] && echo "wrong sha is detected: $sha_in_candidate != ${{ github.event.inputs.sha }}" && exit 1         
 
       - name: Cache packages
         uses: actions/cache@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -575,10 +575,9 @@ jobs:
           echo $TESTING_VERSION > build/packages/TESTING_VERSION
 
       - name: upload packages as release candidate on s3
-        uses: aws-observability/aws-otel-collector-test-framework@deprecating
-        with:
-          running_type: candidate
-          opts: "-t=UploadCandidate -s=build/packages/.aoc-stack-test.yml"
+        run: |
+          tar czvf $GITHUB_SHA.tar.gz build
+          aws s3 cp $GITHUB_SHA.tar.gz s3://aws-otel-collector-release-candidate/$GITHUB_SHA.tar.gz
 
       - id: file_changes
         uses: trilom/file-changes-action@v1.2.4


### PR DESCRIPTION
**Description:** 

1. use aws cli to upload candidate packages
2. use aws cli to download candidate packages
3. check the version number and commit sha in the candidate package.

**Testing:** 

No, will be tested in workflow once merged.


