### PR TITLE
Fix AWS credentials profile

### DIFF
--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -104,6 +104,6 @@ func setCollectorConfigFromExtraCfg(extraCfg *extraconfig.ExtraConfig) {
 		os.Setenv("AWS_PROFILE", extraCfg.AwsProfile)
 	}
 	if extraCfg.AwsCredentialFile != "" {
-		os.Setenv("AWS_CREDENTIAL_PROFILES_FILE", extraCfg.AwsCredentialFile)
+		os.Setenv("AWS_SHARED_CREDENTIALS_FILE", extraCfg.AwsCredentialFile)
 	}
 }


### PR DESCRIPTION
**Description:**
Fixing AWS credentials profile issue by setting correct environment variable for AWS credentials file.

**Testing:**
Set awsProfile and awsCredentialFile in extracfg.txt to select AWS profile.
