### PR TITLE
fix the outdated EC2 user guide and rename CI CD workflow name to fix…

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-name: CD
+name: C/D
 
 on:        
   workflow_dispatch:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-name: CI
+name: C/I
 
 on:
   push:

--- a/deployment-template/ec2/aws-otel-ec2-deployment-cfn.yaml
+++ b/deployment-template/ec2/aws-otel-ec2-deployment-cfn.yaml
@@ -127,7 +127,7 @@ Resources:
         # This script below is to install aws-otel-collector, restart aws-otel-collector and tell the result to cloudformation.
         Fn::Base64: !Sub |
           #!/bin/bash
-          rpm -Uvh /home/ec2-user/aws-otel-collector/build/packages/linux/amd64/aws-otel-collector.rpm
+          sudo rpm -Uvh https://aws-otel-collector.s3.amazonaws.com/amazon_linux/amd64/latest/aws-otel-collector.rpm
           /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
 

--- a/docs/developers/linux-rpm-demo.md
+++ b/docs/developers/linux-rpm-demo.md
@@ -57,7 +57,7 @@ You should now be able to view your metrics in your [CloudWatch console](https:/
 #### Install AWSOTelCollector on ECS EC2
 Download CloudFormation template file for installing AWSOTelCollector on ECS EC2 mode
 ```
-curl -O https://github.com/mxiamxia/aws-opentelemetry-collector/blob/master/deployment-template/ec2/aws-otel-ec2-deployment-cfn.template
+curl -O https://raw.githubusercontent.com/aws-observability/aws-otel-collector/main/deployment-template/ec2/aws-otel-ec2-deployment-cfn.yaml
 ```
 Run CloudFormation the following command once ```IAMRole```, ```Region```, ```EC2Key``` and  ```CFN_File_Downloaded``` are filled.
 ```


### PR DESCRIPTION
… github actino issues

**Description:** <Describe what has changed. 
* Update the outdated EC2 user guide
* Rename CI & CD workflow name since the GitHub actions doesn't recognize `CI` workflow anymore

**Link to tracking Issue:**

**Testing:**

**Documentation:** 
