### PR TITLE
Add statsd component

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This table represents the supported components of AWS OTel Collector in 2020. Th
 | otlpreceiver                    | resourceprocessor             | `awsemfexporter`                   | pprofextension         |
 | `awsecscontainermetricsreceiver`| queuedprocessor               | `awsprometheusremotewriteexporter` | zpagesextension        |
 | `awsxrayreceiver`               | batchprocessor                | loggingexporter                    |                        |
-|                                 | memorylimiter                 | otlpexporter                       |                        |
+| `statsdreceiver`                | memorylimiter                 | otlpexporter                       |                        |
 |                                 | tailsamplingprocessor         | fileexporter                       |                        |
 |                                 | probabilisticsamplerprocessor | otlphttpexporter                   |                        |
 |                                 | spanprocessor                 | prometheusexporter                 |                        |
@@ -46,6 +46,7 @@ This table represents the supported components of AWS OTel Collector in 2020. Th
 * [Trace X-Ray Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/awsxrayexporter)
 * [Metrics EMF Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/awsemfexporter/README.md)
 * [ECS Container Metrics Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/receiver/awsecscontainermetricsreceiver)
+* [StatsD Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/statsdreceiver)
 
 ### Getting Started
 #### Prerequisites

--- a/config/ecs/container-insights/otel-task-metrics-config.yaml
+++ b/config/ecs/container-insights/otel-task-metrics-config.yaml
@@ -11,6 +11,9 @@ receivers:
   awsxray:
     endpoint: 0.0.0.0:2000
     transport: udp
+  statsd:
+    endpoint: 0.0.0.0:8125
+    aggregation_interval: 60s
   awsecscontainermetrics:
 
 processors:
@@ -83,8 +86,8 @@ processors:
 exporters:
   awsxray:
   awsemf/application:
-    log_group_name: 'aws/ecs/containerinsights/{ClusterName}/application/metrics'
-    log_stream_name: '{TaskId}'
+    namespace: ECS/AWSOTel/Application
+    log_group_name: '/aws/ecs/application/metrics'
   awsemf/performance:
     namespace: ECS/ContainerInsights
     log_group_name: '/aws/ecs/containerinsights/{ClusterName}/performance'
@@ -102,7 +105,7 @@ service:
       processors: [batch/traces]
       exporters: [awsxray]
     metrics/application:
-      receivers: [otlp]
+      receivers: [otlp, statsd]
       processors: [batch/metrics]
       exporters: [awsemf/application]
     metrics/performance:

--- a/config/ecs/ecs-default-config.yaml
+++ b/config/ecs/ecs-default-config.yaml
@@ -11,6 +11,9 @@ receivers:
   awsxray:
     endpoint: 0.0.0.0:2000
     transport: udp
+  statsd:
+    endpoint: 0.0.0.0:8125
+    aggregation_interval: 60s
 
 processors:
   batch/traces:
@@ -22,8 +25,8 @@ processors:
 exporters:
   awsxray:
   awsemf:
-    log_group_name: 'aws/ecs/containerinsights/{ClusterName}/application/metrics'
-    log_stream_name: '{TaskId}'
+    namespace: ECS/AWSOTel/Application
+    log_group_name: '/aws/ecs/application/metrics'
 
 service:
   pipelines:
@@ -32,7 +35,7 @@ service:
       processors: [batch/traces]
       exporters: [awsxray]
     metrics:
-      receivers: [otlp]
+      receivers: [otlp, statsd]
       processors: [batch/metrics]
       exporters: [awsemf]
 

--- a/deployment-template/ecs/aws-otel-ec2-sidecar-deployment-cfn.yaml
+++ b/deployment-template/ecs/aws-otel-ec2-sidecar-deployment-cfn.yaml
@@ -56,6 +56,7 @@ Resources:
           - DefaultExecutionRole
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/AWSOTelExecutionRole'
           - !Ref ExecutionRoleArn
+      NetworkMode: awsvpc
       ContainerDefinitions:
         - logConfiguration:
             logDriver: awslogs
@@ -71,6 +72,9 @@ Resources:
             - hostPort: 55680
               protocol: tcp
               containerPort: 55680
+            - hostPort: 8125
+              protocol: udp
+              containerPort: 8125
           command: [!Ref command]
           image: 'amazon/aws-otel-collector:latest'
           name: aws-collector
@@ -109,8 +113,23 @@ Resources:
           DependsOn:
             - containerName: aws-collector
               condition: START
+        - Name: aoc-statsd-emitter
+          Image: 'alpine/socat:latest'
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-create-group: 'True'
+              awslogs-group: /ecs/statsd-emitter
+              awslogs-region: !Ref 'AWS::Region'
+              awslogs-stream-prefix: ecs
+          DependsOn:
+            - containerName: aws-collector
+              condition: START
+          EntryPoint:
+            - "/bin/sh"
+            - "-c"
+            - "while true; do echo 'statsdTestMetric:1|c' | socat -v -t 0 - UDP:127.0.0.1:8125; sleep 1; done"
       Memory: '2048'
-      Family: ecs-aws-otel-sidecar-service
       RequiresCompatibilities:
         - EC2
       Cpu: '1024'

--- a/deployment-template/ecs/aws-otel-fargate-sidecar-deployment-cfn.yaml
+++ b/deployment-template/ecs/aws-otel-fargate-sidecar-deployment-cfn.yaml
@@ -106,6 +106,24 @@ Resources:
           DependsOn:
             - containerName: aws-collector
               condition: START
+        - Name: aoc-statsd-emitter
+          Image: 'alpine/socat:latest'
+          Cpu: '256'
+          Memory: '512'
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-create-group: 'True'
+              awslogs-group: /ecs/statsd-emitter
+              awslogs-region: !Ref 'AWS::Region'
+              awslogs-stream-prefix: ecs
+          DependsOn:
+            - containerName: aws-collector
+              condition: START
+          EntryPoint:
+            - "/bin/sh"
+            - "-c"
+            - "while true; do echo 'statsdTestMetric:1|c' | socat -v -t 0 - UDP:127.0.0.1:8125; sleep 1; done"
       RequiresCompatibilities:
         - FARGATE
       Cpu: '1024'

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -4,6 +4,14 @@
 		"platforms": ["EC2", "ECS", "EKS", "SOAKING", "CANARY"]
 	},
 	{
+		"case_name": "statsd",
+		"platforms": ["EC2", "ECS", "EKS", "SOAKING"]
+	},
+	{
+		"case_name": "statsd_mock",
+		"platforms": ["LOCAL", "EC2", "ECS", "EKS", "SOAKING"]
+	},
+	{
 		"case_name": "otlp_metric",
 		"platforms": ["EC2", "ECS", "EKS", "SOAKING", "CANARY"]
 	},

--- a/examples/ecs/ecs-ec2-sidecar.json
+++ b/examples/ecs/ecs-ec2-sidecar.json
@@ -2,6 +2,7 @@
   "family": "aws-otel-EC2",
   "taskRoleArn": "{{ecsTaskRoleArn}}",
   "executionRoleArn": "{{ecsTaskExecutionRoleArn}}",
+  "networkMode": "awsvpc",
   "containerDefinitions": [
     {
       "logConfiguration": {
@@ -23,6 +24,11 @@
           "hostPort": 55680,
           "protocol": "tcp",
           "containerPort": 55680
+        },
+        {
+          "hostPort": 8125,
+          "protocol": "udp",
+          "containerPort": 8125
         }
       ],
       "command": [
@@ -70,6 +76,30 @@
     {
       "image": "nginx:latest",
       "name": "nginx",
+      "dependsOn": [
+        {
+          "containerName": "aws-otel-collector",
+          "condition": "START"
+        }
+      ]
+    },
+    {
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-create-group": "True",
+          "awslogs-region": "us-west-2",
+          "awslogs-stream-prefix": "ecs",
+          "awslogs-group": "/ecs/statsd-emitter"
+      }
+    },
+      "image": "alpine/socat:latest",
+      "name": "aoc-statsd-emitter",
+      "entryPoint": [
+        "/bin/sh",
+        "-c",
+        "while true; do echo 'statsdTestMetric:1|c' | socat -v -t 0 - UDP:127.0.0.1:8125; sleep 1; done"
+      ],
       "dependsOn": [
         {
           "containerName": "aws-otel-collector",

--- a/examples/ecs/ecs-fargate-sidecar.json
+++ b/examples/ecs/ecs-fargate-sidecar.json
@@ -47,6 +47,33 @@
           "condition": "START"
         }
       ]
+    },
+    {
+      "image": "alpine/socat:latest",
+      "memory": 512,
+      "dependsOn": [
+        {
+          "containerName": "aws-collector",
+          "condition": "START"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-create-group": "True",
+          "awslogs-region": "us-west-2",
+          "awslogs-stream-prefix": "ecs",
+          "awslogs-group": "/ecs/statsd-emitter"
+        }
+      },
+      "entryPoint": [
+        "/bin/sh",
+        "-c",
+        "while true; do echo 'statsdTestMetric:1|c' | socat -v -t 0 - UDP:127.0.0.1:8125; sleep 1; done"
+      ],
+      "name": "aoc-statsd-emitter",
+      "cpu": 256,
+      "essential": true
     }
   ],
   "requiresCompatibilities": [

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.19.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver v0.19.0
 	github.com/opencontainers/runc v1.0.0-rc92
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.1

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -27,6 +27,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/exporter/fileexporter"
@@ -53,6 +54,7 @@ func Components() (component.Factories, error) {
 		otlpreceiver.NewFactory(),
 		awsecscontainermetricsreceiver.NewFactory(),
 		awsxrayreceiver.NewFactory(),
+		statsdreceiver.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)


### PR DESCRIPTION
**Description:** 
Add statsd component to the AOC
Revise ECS OT config files: revise log_group_name to add `/` and remove placeholder since cannot see it when using statsD and EMF

**Testing:** 
The change to the test framework is here: https://github.com/aws-observability/aws-otel-test-framework/pull/217
Tested in ECS, EKS. Added the performance test. 
Tested these two files: `aws-otel-ec2-sidecar-deployment-cfn.yaml` and `aws-otel-fargate-sidecar-deployment-cfn.yaml` with my personal image, it worked as expected.
