### PR TITLE
Fix path to default ecs config in developer guide

### DIFF
--- a/docs/developers/ecs-demo.md
+++ b/docs/developers/ecs-demo.md
@@ -83,7 +83,7 @@ Replace the <PATH_TO_CloudFormation_TEMPLATE> with the path where your template 
 * AWS_Region - Region the data will be sent
 * command - Assign value to the command variable to select the config file path; The AWS collector comes with two configs baked in for ECS customers:
   * To consume application metrics, traces (using OTPL and Xray) and container resource utilization metrics (using awsecscontainermetrics receiver):  `--config=/etc/ecs/container-insights/otel-task-metrics-config.yaml`
-  * To consume OTPL metrics/traces and X-Ray SDK traces (custom application metrics/traces):  `--config=/etc/ecs/otel-agent-ecs-default-config.yaml`
+  * To consume OTPL metrics/traces and X-Ray SDK traces (custom application metrics/traces):  `--config=/etc/ecs/ecs-default-config.yaml`
 ```
 ClusterName=<Cluster_Name>
 Region=<AWS_Region>
@@ -109,7 +109,7 @@ Replace the <PATH_TO_CloudFormation_TEMPLATE> with the path where your template 
 * Security_Groups - The security group your ECS Fargate Task is running
 * Subnets - The subnet your ECS Fargate task is running  (ex: ParameterValue=SubnetID1\\,SubnetID2*)
 * command -  Assign value to the command variable to select the config file path;; the AWS collector comes with two configs baked in for ECS customers:
-  * To consome OTPL metrics/traces and X-Ray SDK traces (custom application metrics/traces):  `--config=/etc/ecs/otel-agent-ecs-default-config.yaml`
+  * To consume OTPL metrics/traces and X-Ray SDK traces (custom application metrics/traces):  `--config=/etc/ecs/ecs-default-config.yaml`
   * To Use OTPL, Xray and Container Resource utilization metrics:  `--config=/etc/ecs/container-insights/otel-task-metrics-config.yaml`
 
 ```


### PR DESCRIPTION
**Description:**

The path to the config file `/etc/ecs/otel-agent-ecs-default-config.yaml` in the documentation is not correct. It shall be `/etc/ecs/ecs-default-config.yaml` https://github.com/aws-observability/aws-otel-collector/blob/23cf5733a12a2181c4cb86e1d051ea7a0dec462e/cmd/awscollector/Dockerfile#L46

**Link to tracking Issue:** <Issue number if applicable>
N/A

**Testing:** < Describe what testing was performed and which tests were added.>
N/A

**Documentation:** < Describe the documentation added.>
N/A
