### PR TITLE
log: Write to stderr in container Fix #339

### DIFF
--- a/cmd/awscollector/main_others.go
+++ b/cmd/awscollector/main_others.go
@@ -20,21 +20,22 @@ package main
 
 import (
 	"log"
-	"os"
 
+	"github.com/aws-observability/aws-otel-collector/pkg/extraconfig"
 	"github.com/aws-observability/aws-otel-collector/pkg/userutils"
 	"go.opentelemetry.io/collector/service"
 )
 
 func run(params service.Parameters) error {
-	// avoid to run as 'root' user on Linux
-	if os.Getenv("RUN_IN_CONTAINER") != "True" {
+	// Try to switch user when the collector is running on a host.
+	// For container the user and group is determined by the deploy manifest.
+	if !extraconfig.IsRunningInContainer() {
+		// avoid to run as 'root' user on Linux
 		_, err := userutils.ChangeUser()
 		if err != nil {
 			log.Printf("E! Failed to ChangeUser: %v ", err)
 			return err
 		}
 	}
-
 	return runInteractive(params)
 }

--- a/pkg/extraconfig/container.go
+++ b/pkg/extraconfig/container.go
@@ -1,0 +1,18 @@
+package extraconfig
+
+import "os"
+
+const (
+	EnvKeyRunInContainer = "RUN_IN_CONTAINER"
+	EnvValTrue           = "True"
+)
+
+// IsRunningInContainer checks EnvKeyRunInContainer (i.e. RUN_IN_CONTAINER) to determine
+// if the collector is running as a container.
+//
+// Following behaviour changes when running in container:
+// - log writes to stderr instead of rotate in local file under /opt/aws #339
+// - switch user based on config is ignored
+func IsRunningInContainer() bool {
+	return os.Getenv(EnvKeyRunInContainer) == EnvValTrue
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -25,6 +25,8 @@ import (
 
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
+
+	"github.com/aws-observability/aws-otel-collector/pkg/extraconfig"
 )
 
 var UnixLogPath = "/opt/aws/aws-otel-collector/logs/aws-otel-collector.log"
@@ -59,7 +61,8 @@ func GetLumberHook() func(e zapcore.Entry) error {
 func SetupErrorLogger() {
 	log.SetFlags(0)
 	var writer io.WriteCloser
-	if logfile != "" {
+	// When running in container, always log to stderr, it makes debugging easier.
+	if logfile != "" && !extraconfig.IsRunningInContainer() {
 		err := os.MkdirAll(filepath.Dir(logfile), 0755)
 		if err != nil {
 			log.Printf("D! fail to chmod on log file due to : %v \n", err)
@@ -86,5 +89,4 @@ func SetLogLevel(level string) {
 	if level != "" {
 		os.Args = append(os.Args, "--log-level", level)
 	}
-
 }


### PR DESCRIPTION
**Description:**

Fix #339 

**Link to tracking Issue:** <Issue number if applicable>

- #339 

**Testing:**

Using example in #340 no the config error shows up when running via docker-compose (NOTE: the exit 0 is still 0 until #338 is merged)

```text
aoc_1  | AWS OTel Collector version: v0.7.0
aoc_1  | 2021/02/05 00:55:04 find no extra config, skip it, err: open /opt/aws/aws-otel-collector/etc/extracfg.txt: no such file or directory
aoc_1  | 2021-02-05T00:55:04.100Z	INFO	service/service.go:411	Starting AWS OTel Collector...	{"Version": "v0.7.0", "GitHash": "94015373a37231d8678d115fe05e90d662c555a7", "NumCPU": 6}
aoc_1  | 2021-02-05T00:55:04.101Z	INFO	service/service.go:255	Setting up own telemetry...
aoc_1  | 2021-02-05T00:55:04.105Z	INFO	service/telemetry.go:102	Serving Prometheus metrics	{"address": "localhost:8888", "level": 0, "service.instance.id": "bbb29b0d-6f5b-4bb0-b129-67030d3149dd"}
aoc_1  | 2021-02-05T00:55:04.105Z	INFO	service/service.go:292	Loading configuration...
aoc_1  | Config file is missing or invalid, error loading config file "/etc/otel-agent-config.yaml": While parsing config: yaml: line 6: did not find expected key
config-error_aoc_1 exited with code 0
```

**Documentation:** 

Log to stdout/stderr is the expected the behaviour the collector container.