### PR TITLE
Fix the missing extracfg.txt warning and remove the ownership on aws reserved folder

### DIFF
--- a/extracfg.txt
+++ b/extracfg.txt
@@ -1,0 +1,8 @@
+# set debug level
+# loggingLevel=INFO
+
+# set aws profile
+# awsProfile=default
+
+# set aws credential file path
+# awsCredsFile=~/.aws/credentials

--- a/pkg/config/config_factory.go
+++ b/pkg/config/config_factory.go
@@ -36,7 +36,7 @@ func GetCfgFactory() func(otelViper *viper.Viper, cmd *cobra.Command, f componen
 		// aws-otel-collector supports loading yaml config from Env Var
 		// including SSM parameter store for ECS use case
 		if configContent, ok := os.LookupEnv("AOT_CONFIG_CONTENT"); ok {
-			fmt.Printf("Reading AOT config from from environment: %v\n", configContent)
+			log.Printf("Reading AOT config from from environment: %v\n", configContent)
 			return readConfigString(otelViper, f, configContent)
 		}
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -57,7 +57,6 @@ func GetLumberHook() func(e zapcore.Entry) error {
 
 // SetupErrorLogger setup lumberjackLogger for go logger
 func SetupErrorLogger() {
-	log.SetFlags(0)
 	var writer io.WriteCloser
 	if logfile != "" {
 		err := os.MkdirAll(filepath.Dir(logfile), 0755)

--- a/tools/packaging/debian/create_deb.sh
+++ b/tools/packaging/debian/create_deb.sh
@@ -49,6 +49,7 @@ cp build/linux/aoc_linux_${TARGET_SUPPORTED_ARCH} ${AOC_ROOT}/opt/aws/aws-otel-c
 cp tools/ctl/linux/aws-otel-collector-ctl ${AOC_ROOT}/opt/aws/aws-otel-collector/bin/
 cp config.yaml ${AOC_ROOT}/opt/aws/aws-otel-collector/etc
 cp .env ${AOC_ROOT}/opt/aws/aws-otel-collector/etc
+cp extracfg.txt ${AOC_ROOT}/opt/aws/aws-otel-collector/etc
 cp tools/packaging/linux/aws-otel-collector.service ${AOC_ROOT}/etc/systemd/system/
 cp tools/packaging/linux/aws-otel-collector.conf ${AOC_ROOT}/etc/init/
 
@@ -56,7 +57,7 @@ chmod ug+rx ${AOC_ROOT}/opt/aws/aws-otel-collector/bin/aws-otel-collector
 chmod ug+rx ${AOC_ROOT}/opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl
 chmod ug+rx ${AOC_ROOT}/opt/aws/aws-otel-collector/etc/config.yaml
 chmod ug+rx ${AOC_ROOT}/opt/aws/aws-otel-collector/etc/.env
-
+chmod ug+rx ${AOC_ROOT}/opt/aws/aws-otel-collector/etc/extracfg.txt
 
 echo "Creating symlinks"
 # bin

--- a/tools/packaging/linux/build.spec
+++ b/tools/packaging/linux/build.spec
@@ -18,7 +18,6 @@ mkdir -p ${RPM_BUILD_ROOT}
 cp -fa * ${RPM_BUILD_ROOT}
 
 %files
-%dir /opt/aws
 %dir /opt/aws/aws-otel-collector
 %dir /opt/aws/aws-otel-collector/bin
 %dir /opt/aws/aws-otel-collector/doc

--- a/tools/packaging/linux/build.spec
+++ b/tools/packaging/linux/build.spec
@@ -33,6 +33,7 @@ cp -fa * ${RPM_BUILD_ROOT}
 /opt/aws/aws-otel-collector/RELEASE_NOTE
 /opt/aws/aws-otel-collector/var/.config.yaml
 /opt/aws/aws-otel-collector/etc/.env
+/opt/aws/aws-otel-collector/etc/extracfg.txt
 
 /etc/init/aws-otel-collector.conf
 /etc/systemd/system/aws-otel-collector.service

--- a/tools/packaging/linux/create_rpm.sh
+++ b/tools/packaging/linux/create_rpm.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -10,8 +12,6 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-
-#!/usr/bin/env bash
 
 set -e
 echo "**********************************************************"
@@ -55,6 +55,8 @@ cp tools/ctl/linux/aws-otel-collector-ctl ${AOC_ROOT}/opt/aws/aws-otel-collector
 cp config.yaml ${AOC_ROOT}/opt/aws/aws-otel-collector/var/.config.yaml
 # .env
 cp .env ${AOC_ROOT}/opt/aws/aws-otel-collector/etc
+# extracfg.txt
+cp extracfg.txt ${AOC_ROOT}/opt/aws/aws-otel-collector/etc
 # service config
 cp tools/packaging/linux/aws-otel-collector.service ${AOC_ROOT}/etc/systemd/system/
 cp tools/packaging/linux/aws-otel-collector.conf ${AOC_ROOT}/etc/init/

--- a/tools/version/build.go
+++ b/tools/version/build.go
@@ -17,6 +17,7 @@ package version
 import (
 	"bytes"
 	"fmt"
+	"log"
 )
 
 var (
@@ -28,7 +29,7 @@ var (
 )
 
 func init() {
-	fmt.Printf("AWS OTel Collector version: %v\n", Version)
+	log.Printf("AWS OTel Collector version: %v\n", Version)
 }
 
 // Info has properties about the build and runtime.


### PR DESCRIPTION
Fix the missing extracfg.txt warning and remove the ownership on aws reserved folder