### PR TITLE
Update the ECS container receiver's version to AOC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,14 +12,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.19.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.19.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.19.1-0.20210205203044-d12186a24b8d
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.19.0
 	github.com/opencontainers/runc v1.0.0-rc92
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/collector v0.19.0
+	go.opentelemetry.io/collector v0.19.1-0.20210127225953-68c5961f7bc2
 	go.uber.org/zap v1.16.0
 	golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0


### PR DESCRIPTION
**Description:** 
Update the version of the ecs container receiver.
**Changes: ** 
Compared to the version v0.19.0, this new version will send the stopped container's metadata without stats data. 
**Test: ** 
Unite test, local test and end2end test.