### PR TITLE
Add jaeger receiver

### DIFF
--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -36,6 +36,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/prometheusexporter"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
 	"go.opentelemetry.io/collector/receiver/prometheusreceiver"
+	"go.opentelemetry.io/collector/receiver/jaegerreceiver"
 	"go.opentelemetry.io/collector/service/defaultcomponents"
 )
 
@@ -53,6 +54,7 @@ func Components() (component.Factories, error) {
 		otlpreceiver.NewFactory(),
 		awsecscontainermetricsreceiver.NewFactory(),
 		awsxrayreceiver.NewFactory(),
+		jaegerreceiver.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/pkg/defaultcomponents/defaults_test.go
+++ b/pkg/defaultcomponents/defaults_test.go
@@ -46,6 +46,7 @@ func TestComponents(t *testing.T) {
 	receivers := factories.Receivers
 	assert.True(t, receivers["otlp"] != nil)
 	assert.True(t, receivers["prometheus"] != nil)
+	assert.True(t, receivers["jaeger"] != nil)
 
 	extensions := factories.Extensions
 	assert.True(t, extensions["pprof"] != nil)


### PR DESCRIPTION
**Description:**

Adds the existing Jaeger receiver from the mainline otel collector.

**Link to tracking Issue:** 

#292 

This implements only the jaeger receiver.

**Testing:** 

Ran locally and in ECS, confirmed traces are received and can be submitted to an otlp exporter.

