### PR TITLE
fix the default log group name for ECS metrics

### DIFF
--- a/config/ecs/container-insights/otel-task-metrics-config.yaml
+++ b/config/ecs/container-insights/otel-task-metrics-config.yaml
@@ -83,7 +83,7 @@ processors:
 exporters:
   awsxray:
   awsemf/application:
-    log_group_name: 'aws/ecs/containerinsights/{ClusterName}/application/metrics'
+    log_group_name: '/aws/ecs/containerinsights/{ClusterName}/application/metrics'
     log_stream_name: '{TaskId}'
   awsemf/performance:
     namespace: ECS/ContainerInsights

--- a/config/ecs/ecs-default-config.yaml
+++ b/config/ecs/ecs-default-config.yaml
@@ -22,7 +22,7 @@ processors:
 exporters:
   awsxray:
   awsemf:
-    log_group_name: 'aws/ecs/containerinsights/{ClusterName}/application/metrics'
+    log_group_name: '/aws/ecs/containerinsights/{ClusterName}/application/metrics'
     log_stream_name: '{TaskId}'
 
 service:


### PR DESCRIPTION
**Description:** 
fix the invalid default log group name for ECS metrics
```
2021-02-10T16:40:30.731Z	ERROR	exporterhelper/queued_retry.go:204	Exporting failed. Try enabling retry_on_failure config option.	
{
    "component_kind": "exporter",
    "component_type": "awsemf",
    "component_name": "awsemf/application",
    "error": "Permanent error: InvalidParameterException: Log groups starting with AWS/ are reserved for AWS."
}
```

**Link to tracking Issue:** 
https://github.com/aws-observability/aws-otel-collector/issues/353

