### PR TITLE
[WIP] Add default config for prometheus

### DIFF
--- a/cmd/awscollector-prometheus/Dockerfile
+++ b/cmd/awscollector-prometheus/Dockerfile
@@ -1,0 +1,54 @@
+################################
+#	Building Stage         #	
+#			       #	
+################################
+FROM alpine:latest as build 
+
+# update cert
+RUN apk --update add ca-certificates
+
+# install libs
+RUN apk add --update bash git make build-base
+
+# config go
+COPY --from=golang:1.15.3-alpine /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# download go modules ahead to speed up the building
+WORKDIR /workspace
+COPY go.mod /workspace/go.mod
+COPY go.sum /workspace/go.sum
+RUN go mod download
+
+# copy artifacts
+COPY cmd  /workspace/cmd
+COPY config.yaml /workspace/config.yaml
+COPY pkg /workspace/pkg
+COPY tools /workspace/tools
+COPY VERSION /workspace/VERSION
+COPY .git /workspace/.git
+COPY Makefile /workspace/Makefile
+COPY config /workspace/config
+
+# build binary
+RUN make amd64-build
+
+################################
+#	Final Stage            #	
+#			       #	
+################################
+FROM scratch
+
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build /workspace/build/linux/aoc_linux_x86_64 /awscollector
+COPY --from=build /workspace/config-prometheus.yaml /etc/otel-config.yaml
+COPY --from=build /workspace/config/ecs/container-insights/otel-task-metrics-config.yaml /etc/ecs/container-insights/otel-task-metrics-config.yaml
+COPY --from=build /workspace/config/ecs/ecs-default-config.yaml /etc/ecs/ecs-default-config.yaml
+
+ENV RUN_IN_CONTAINER="True"
+# aws-sdk-go needs $HOME to look up shared credentials
+ENV HOME=/root
+ENTRYPOINT ["/awscollector"]
+CMD ["--config=/etc/otel-config.yaml"]
+EXPOSE 4317 55681 2000
+

--- a/config-prometheus.yaml
+++ b/config-prometheus.yaml
@@ -1,0 +1,368 @@
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 1m
+        scrape_timeout: 10s
+      scrape_configs:
+        - job_name: 'kubernetes-pod-appmesh-envoy'
+          sample_limit: 10000
+          metrics_path: /stats/prometheus
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [ __meta_kubernetes_pod_container_name ]
+              action: keep
+              regex: '^envoy$'
+            - source_labels: [ __address__, __meta_kubernetes_pod_annotation_prometheus_io_port ]
+              action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: ${1}:9901
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - source_labels: [ __meta_kubernetes_pod_name ]
+              action: replace
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_name
+              target_label: pod_controller_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_kind
+              target_label: pod_controller_kind
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_phase
+              target_label: pod_phase
+
+        - job_name: 'kubernetes-pod-fluentbit-plugin'
+          sample_limit: 10000
+          metrics_path: /api/v1/metrics/prometheus
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [ __meta_kubernetes_pod_container_name ]
+              action: keep
+              regex: '^fluent-bit.*$'
+            - source_labels: [ __address__ ]
+              action: replace
+              regex: ([^:]+)(?::\d+)?
+              replacement: ${1}:2020
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - source_labels: [ __meta_kubernetes_pod_name ]
+              action: replace
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_name
+              target_label: pod_controller_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_kind
+              target_label: pod_controller_kind
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_phase
+              target_label: pod_phase
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_node_name
+              target_label: NodeName
+
+        - job_name: kubernetes-service-endpoints
+          sample_limit: 10000
+          kubernetes_sd_configs:
+            - role: endpoints
+          relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (https?)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scheme
+              target_label: __scheme__
+            - action: replace
+              regex: (.+)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              source_labels:
+                - __address__
+                - __meta_kubernetes_service_annotation_prometheus_io_port
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_service_name
+              target_label: Service
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_node_name
+              target_label: kubernetes_node
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_name
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'go_gc_duration_seconds.*'
+              action: drop
+            - source_labels: [ __name__, proxy ]
+              regex: "haproxy_frontend.+;(.+)"
+              target_label: frontend
+              replacement: "$$1"
+            - source_labels: [ __name__, proxy ]
+              regex: "haproxy_server.+;(.+)"
+              target_label: backend
+              replacement: "$$1"
+            - source_labels: [ __name__, proxy ]
+              regex: "haproxy_backend.+;(.+)"
+              target_label: backend
+              replacement: "$$1"
+            - regex: proxy
+              action: labeldrop
+
+        - job_name: 'kubernetes-pod-jmx'
+          sample_limit: 10000
+          metrics_path: /metrics
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [ __address__ ]
+              action: keep
+              regex: '.*:9404$'
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - source_labels: [ __meta_kubernetes_pod_name ]
+              action: replace
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_name
+              target_label: pod_controller_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_kind
+              target_label: pod_controller_kind
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_phase
+              target_label: pod_phase
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'jvm_gc_collection_seconds.*'
+              action: drop
+
+processors:
+  resourcedetection/ec2:
+    detectors: [ env ]
+    timeout: 2s
+    override: false
+  resource:
+    attributes:
+      - key: TaskId
+        from_attribute: service.name
+        action: insert
+  batch/metrics:
+    timeout: 60s
+
+exporters:
+  awsemf:
+    namespace: AWSObservability/CloudWatchEKSService
+    log_group_name: "/aws/containerinsights/{ClusterName}/prometheus"
+    resource_to_telemetry_conversion:
+      enabled: true
+    dimension_rollup_option: NoDimensionRollup
+    metric_declarations:
+      - dimensions: [ [ Service, Namespace, ClusterName ] ]
+        metric_name_selectors:
+          - "^nginx_ingress_controller_(requests|success)$"
+          - "^nginx_ingress_controller_nginx_process_connections$"
+          - "^nginx_ingress_controller_nginx_process_connections_total$"
+          - "^nginx_ingress_controller_nginx_process_resident_memory_bytes$"
+          - "^nginx_ingress_controller_nginx_process_cpu_seconds_total$"
+          - "^nginx_ingress_controller_config_last_reload_successful$"
+        label_matchers:
+          - label_names:
+              - Service
+            regex: ".*nginx.*"
+      - dimensions: [ [ Service, Namespace, ClusterName, ingress ],[ Service, Namespace, ClusterName, status ] ]
+        metric_name_selectors:
+          - "^nginx_ingress_controller_requests$"
+        label_matchers:
+          - label_names:
+              - Service
+            regex: ".*nginx.*"
+      - dimensions: [ [ Service, Namespace, ClusterName, frontend, code ] ]
+        metric_name_selectors:
+          - "^haproxy_frontend_http_responses_total$"
+        label_matchers:
+          - label_names:
+              - Service
+              - frontend
+            regex: ".*haproxy-ingress-.*metrics;(httpfront-shared-frontend|httpfront-default-backend|httpsfront|_front_http)"
+      - dimensions: [ [ Service, Namespace, ClusterName, backend, code ] ]
+        metric_name_selectors:
+          - "^haproxy_backend_http_responses_total$"
+        label_matchers:
+          - label_names:
+              - Service
+              - frontend
+            regex: ".*haproxy-ingress-.*metrics;(httpback-shared-backend|httpback-default-backend|httpsback-shared-backend|_default_backend)"
+      - dimensions: [ [ Service, Namespace, ClusterName ] ]
+        metric_name_selectors:
+          - "^haproxy_backend_up$"
+          - "^haproxy_backend_status$"
+          - "^haproxy_backend_bytes_(in|out)_total$"
+          - "^haproxy_backend_connections_total$"
+          - "^haproxy_backend_connection_errors_total$"
+          - "^haproxy_backend_current_sessions$"
+          - "^haproxy_frontend_bytes_(in|out)_total$"
+          - "^haproxy_frontend_connections_total$"
+          - "^haproxy_frontend_http_requests_total$"
+          - "^haproxy_frontend_request_errors_total$"
+          - "^haproxy_frontend_requests_denied_total$"
+          - "^haproxy_frontend_current_sessions$"
+        label_matchers:
+          - label_names:
+              - Service
+            regex: ".*haproxy-ingress-.*metrics"
+      - dimensions: [ [ Service, Namespace, ClusterName ] ]
+        metric_name_selectors:
+          - "^memcached_current_(bytes|items|connections)$"
+          - "^memcached_items_(reclaimed|evicted)_total$"
+          - "^memcached_(written|read)_bytes_total$"
+          - "^memcached_limit_bytes$"
+          - "^memcached_commands_total$"
+        label_matchers:
+          - label_names:
+              - Service
+            regex: ".*memcached.*"
+      - dimensions: [ [ Service, Namespace, ClusterName, status, command ] ]
+        metric_name_selectors:
+          - "^memcached_commands_total$"
+        label_matchers:
+          - label_names:
+              - Service
+              - status
+              - command
+            regex: ".*memcached.*;hit;get"
+      - dimensions: [ [ Service, Namespace, ClusterName, command ] ]
+        metric_name_selectors:
+          - "^memcached_commands_total$"
+        label_matchers:
+          - label_names:
+              - Service
+              - command
+            regex: ".*memcached.*;(get|set)"
+      - dimensions: [ [ ClusterName, Namespace ] ]
+        metric_name_selectors:
+          - "^envoy_http_downstream_rq_(total|xx)$"
+          - "^envoy_cluster_upstream_cx_(r|t)x_bytes_total$"
+          - "^envoy_cluster_membership_(healthy|total)$"
+          - "^envoy_server_memory_(allocated|heap_size)$"
+          - "^envoy_cluster_upstream_cx_(connect_timeout|destroy_local_with_active_rq)$"
+          - "^envoy_cluster_upstream_rq_(pending_failure_eject|pending_overflow|timeout|per_try_timeout|rx_reset|maintenance_mode)$"
+          - "^envoy_http_downstream_cx_destroy_remote_active_rq$"
+          - "^envoy_cluster_upstream_flow_control_(paused_reading_total|resumed_reading_total|backed_up_total|drained_total)$"
+          - "^envoy_cluster_upstream_rq_retry$"
+          - "^envoy_cluster_upstream_rq_retry_(success|overflow)$"
+          - "^envoy_server_(version|uptime|live)$"
+        label_matchers:
+          - label_names:
+              - container_name
+            regex: ^envoy$
+      - dimensions: [ [ ClusterName, Namespace, envoy_http_conn_manager_prefix, envoy_response_code_class ] ]
+        metric_name_selectors:
+          - "^envoy_http_downstream_rq_xx$"
+        label_matchers:
+          - label_names:
+              - container_name
+            regex: ^envoy$
+      - dimensions: [ [ ClusterName, Namespace, NodeName ] ]
+        metric_name_selectors:
+          - "^fluentbit_output_errors_total$"
+          - "^fluentbit_input_bytes_total$"
+          - "^fluentbit_output_proc_bytes_total$"
+          - "^fluentbit_input_records_total$"
+          - "^fluentbit_output_proc_records_total$"
+          - "^fluentbit_output_retries_(total|failed_total)$"
+        label_matchers:
+          - label_names:
+              - container_name
+            regex: ^fluent-bit.*$
+      - dimensions: [ [ ClusterName, Namespace ] ]
+        metric_name_selectors:
+          - "^jvm_threads_(current|daemon)$"
+          - "^jvm_classes_loaded$"
+          - "^java_lang_operatingsystem_(freephysicalmemorysize|totalphysicalmemorysize|freeswapspacesize|totalswapspacesize|systemcpuload|processcpuload|availableprocessors|openfiledescriptorcount)$"
+          - "^catalina_manager_(rejectedsessions|activesessions)$"
+          - "^jvm_gc_collection_seconds_(count|sum)$"
+          - "^catalina_globalrequestprocessor_(bytesreceived|bytessent|requestcount|errorcount|processingtime)$"
+        label_matchers:
+          - label_names:
+              - job
+            regex: ^kubernetes-pod-jmx$
+      - dimensions: [ [ ClusterName, Namespace, area ] ]
+        metric_name_selectors:
+          - "^jvm_memory_bytes_used$"
+        label_matchers:
+          - label_names:
+              - job
+            regex: ^kubernetes-pod-jmx$
+      - dimensions: [ [ ClusterName, Namespace, pool ] ]
+        metric_name_selectors:
+          - "^jvm_memory_pool_bytes_used$"
+        label_matchers:
+          - label_names:
+              - job
+            regex: ^kubernetes-pod-jmx$
+
+service:
+  pipelines:
+    metrics:
+      receivers: [ prometheus ]
+      processors: [ resourcedetection/ec2, resource, batch/metrics ]
+      exporters: [ awsemf ]

--- a/deployment-template/eks/standalone-otel-eks-deployment.yaml
+++ b/deployment-template/eks/standalone-otel-eks-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aws-otel-collector
+  namespace: aws-otel-eks
+  labels:
+    name: aws-otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: aws-otel-collector
+  template:
+    metadata:
+      labels:
+        name: aws-otel-collector
+    spec:
+      serviceAccountName: aws-otel-collector
+      containers:
+        - name: aws-otel-collector
+          image: amazon/aws-otel-collector-prometheus:latest
+          env:
+            - name: AWS_REGION
+              value: {{aws_region}}
+            - name: OTEL_RESOURCE
+              value: ClusterName={{cluster_name}
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 256m
+              memory: 512Mi
+            requests:
+              cpu: 32m
+              memory: 24Mi

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.20.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.19.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.20.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.20.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.20.0
 	github.com/opencontainers/runc v1.0.0-rc92

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -25,6 +25,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver"
 	"go.opentelemetry.io/collector/component"
@@ -61,6 +62,7 @@ func Components() (component.Factories, error) {
 	// enable the selected processors
 	processors := []component.ProcessorFactory{
 		metricstransformprocessor.NewFactory(),
+		resourcedetectionprocessor.NewFactory(),
 	}
 	for _, pr := range factories.Processors {
 		processors = append(processors, pr)


### PR DESCRIPTION
**Why do we need it?**
1. Add default configuration for aws-otel-collector using prometheus receiver.
2. Inject attribute `ClusterName` from environment variable `OTEL_RESOURCE` and `TaskId` from `service.name` for emf exporter to use in metric declarations.