### PR TITLE
Correct port in docker demo

### DIFF
--- a/docs/developers/docker-demo.md
+++ b/docs/developers/docker-demo.md
@@ -13,7 +13,7 @@ You can bring up a single `aws-otel-collector` instance in Docker.
 ```
 git clone https://github.com/aws-observability/aws-otel-collector.git ; \
     cd aws-otel-collector; \
-    docker run --rm -p 4317:4317 -p 55679:55679 -p 8889:8888 \
+    docker run --rm -p 4317:4317 -p 55680:55680 -p 8889:8888 \
       -e AWS_REGION=us-west-2 \
       -v "${PWD}/examples/config-test.yaml":/otel-local-config.yaml \
       --name awscollector public.ecr.aws/aws-observability/aws-otel-collector:latest \


### PR DESCRIPTION
**Description:** Fixes issue raised in https://github.com/aws-observability/aws-otel-js/issues/48 that docker example port # 55679 is incorrect, the config exposed 55680 instead. Once we update the JS sample app to use the official 4317 port this should be resolved anyway.

