### PR TITLE
Add default config for prometheus with appmesh and nginx demo

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,7 @@ on:
     branches:
       - main
       - release-branch-v*
+      - prometheus
 
   # from collector and contrib repo
   repository_dispatch:

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -15,7 +15,9 @@ name: PR Build
 
 on:
   pull_request:
-    branches: [ main ]  
+    branches:
+      - main
+      - prometheus
 
 env:
   IMAGE_NAME: aws-otel-collector

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This table represents the supported components of AWS OTel Collector in 2020. Th
 |                                 | spanprocessor                 | prometheusexporter                 |                        |
 |                                 | filterprocessor               | datadogexporter                    |                        |
 |                                 | metricstransformprocessor     | dynatraceexporter                  |                        |
-|                                 |                               | newrelicexporter                   |                        |
+|                                 | resourcedetectionprocessor    | newrelicexporter                   |                        |
 |                                 |                               | sapmexporter                       |                        |
 |                                 |                               | signalfxexporter                   |                        |
 |                                 |                               |                                    |                        |

--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -42,6 +42,8 @@ FROM scratch
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /workspace/build/linux/aoc_linux_x86_64 /awscollector
 COPY --from=build /workspace/config.yaml /etc/otel-config.yaml
+COPY --from=build /workspace/config/eks/prometheus/config-appmesh.yaml /etc/eks/prometheus/config-appmesh.yaml
+COPY --from=build /workspace/config/eks/prometheus/config-nginx.yaml /etc/eks/prometheus/config-nginx.yaml
 COPY --from=build /workspace/config/ecs/container-insights/otel-task-metrics-config.yaml /etc/ecs/container-insights/otel-task-metrics-config.yaml
 COPY --from=build /workspace/config/ecs/ecs-default-config.yaml /etc/ecs/ecs-default-config.yaml
 

--- a/config/eks/prometheus/config-appmesh.yaml
+++ b/config/eks/prometheus/config-appmesh.yaml
@@ -1,0 +1,99 @@
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 1m
+        scrape_timeout: 10s
+      scrape_configs:
+        - job_name: 'kubernetes-pod-appmesh-envoy'
+          sample_limit: 10000
+          metrics_path: /stats/prometheus
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [ __meta_kubernetes_pod_container_name ]
+              action: keep
+              regex: '^envoy$'
+            - source_labels: [ __address__, __meta_kubernetes_pod_annotation_prometheus_io_port ]
+              action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: ${1}:9901
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - source_labels: [ __meta_kubernetes_pod_name ]
+              action: replace
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_name
+              target_label: pod_controller_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_kind
+              target_label: pod_controller_kind
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_phase
+              target_label: pod_phase
+
+processors:
+  resourcedetection/ec2:
+    detectors: [ env ]
+    timeout: 2s
+    override: false
+  resource:
+    attributes:
+      - key: TaskId
+        from_attribute: service.name
+        action: insert
+  batch/metrics:
+    timeout: 60s
+
+exporters:
+  awsemf:
+    namespace: AWSObservability/CloudWatchEKSService
+    log_group_name: "/aws/containerinsights/{ClusterName}/prometheus"
+    resource_to_telemetry_conversion:
+      enabled: true
+    dimension_rollup_option: NoDimensionRollup
+    metric_declarations:
+      - dimensions: [ [ ClusterName, Namespace ] ]
+        metric_name_selectors:
+          - "^envoy_http_downstream_rq_(total|xx)$"
+          - "^envoy_cluster_upstream_cx_(r|t)x_bytes_total$"
+          - "^envoy_cluster_membership_(healthy|total)$"
+          - "^envoy_server_memory_(allocated|heap_size)$"
+          - "^envoy_cluster_upstream_cx_(connect_timeout|destroy_local_with_active_rq)$"
+          - "^envoy_cluster_upstream_rq_(pending_failure_eject|pending_overflow|timeout|per_try_timeout|rx_reset|maintenance_mode)$"
+          - "^envoy_http_downstream_cx_destroy_remote_active_rq$"
+          - "^envoy_cluster_upstream_flow_control_(paused_reading_total|resumed_reading_total|backed_up_total|drained_total)$"
+          - "^envoy_cluster_upstream_rq_retry$"
+          - "^envoy_cluster_upstream_rq_retry_(success|overflow)$"
+          - "^envoy_server_(version|uptime|live)$"
+        label_matchers:
+          - label_names:
+              - container_name
+            regex: ^envoy$
+      - dimensions: [ [ ClusterName, Namespace, envoy_http_conn_manager_prefix, envoy_response_code_class ] ]
+        metric_name_selectors:
+          - "^envoy_http_downstream_rq_xx$"
+        label_matchers:
+          - label_names:
+              - container_name
+            regex: ^envoy$
+
+service:
+  pipelines:
+    metrics:
+      receivers: [ prometheus ]
+      processors: [ resourcedetection/ec2, resource, batch/metrics ]
+      exporters: [ awsemf ]

--- a/config/eks/prometheus/config-nginx.yaml
+++ b/config/eks/prometheus/config-nginx.yaml
@@ -1,0 +1,121 @@
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 1m
+        scrape_timeout: 10s
+      scrape_configs:
+        - job_name: kubernetes-service-endpoints
+          sample_limit: 10000
+          kubernetes_sd_configs:
+            - role: endpoints
+          relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (https?)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scheme
+              target_label: __scheme__
+            - action: replace
+              regex: (.+)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              source_labels:
+                - __address__
+                - __meta_kubernetes_service_annotation_prometheus_io_port
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_service_name
+              target_label: Service
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_node_name
+              target_label: kubernetes_node
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_name
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'go_gc_duration_seconds.*'
+              action: drop
+            - source_labels: [ __name__, proxy ]
+              regex: "haproxy_frontend.+;(.+)"
+              target_label: frontend
+              replacement: "$$1"
+            - source_labels: [ __name__, proxy ]
+              regex: "haproxy_server.+;(.+)"
+              target_label: backend
+              replacement: "$$1"
+            - source_labels: [ __name__, proxy ]
+              regex: "haproxy_backend.+;(.+)"
+              target_label: backend
+              replacement: "$$1"
+            - regex: proxy
+              action: labeldrop
+
+processors:
+  resourcedetection/ec2:
+    detectors: [ env ]
+    timeout: 2s
+    override: false
+  resource:
+    attributes:
+      - key: TaskId
+        from_attribute: service.name
+        action: insert
+  batch/metrics:
+    timeout: 60s
+
+exporters:
+  awsemf:
+    namespace: AWSObservability/CloudWatchEKSService
+    log_group_name: "/aws/containerinsights/{ClusterName}/prometheus"
+    resource_to_telemetry_conversion:
+      enabled: true
+    dimension_rollup_option: NoDimensionRollup
+    metric_declarations:
+      - dimensions: [ [ Service, Namespace, ClusterName ] ]
+        metric_name_selectors:
+          - "^nginx_ingress_controller_(requests|success)$"
+          - "^nginx_ingress_controller_nginx_process_connections$"
+          - "^nginx_ingress_controller_nginx_process_connections_total$"
+          - "^nginx_ingress_controller_nginx_process_resident_memory_bytes$"
+          - "^nginx_ingress_controller_nginx_process_cpu_seconds_total$"
+          - "^nginx_ingress_controller_config_last_reload_successful$"
+        label_matchers:
+          - label_names:
+              - Service
+            regex: ".*nginx.*"
+      - dimensions: [ [ Service, Namespace, ClusterName, ingress ],[ Service, Namespace, ClusterName, status ] ]
+        metric_name_selectors:
+          - "^nginx_ingress_controller_requests$"
+        label_matchers:
+          - label_names:
+              - Service
+            regex: ".*nginx.*"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [ prometheus ]
+      processors: [ resourcedetection/ec2, resource, batch/metrics ]
+      exporters: [ awsemf ]

--- a/deployment-template/eks/standalone-otel-eks-deployment.yaml
+++ b/deployment-template/eks/standalone-otel-eks-deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aws-otel-eks
+  labels:
+    name: aws-otel-eks
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aws-otel-collector
+  namespace: aws-otel-eks
+  labels:
+    name: aws-otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: aws-otel-collector
+  template:
+    metadata:
+      labels:
+        name: aws-otel-collector
+    spec:
+      serviceAccountName: aws-otel-collector
+      containers:
+        - name: aws-otel-collector
+          image: amazon/aws-otel-collector-prometheus:latest
+          command: [ "/awscollector" ]
+          args: [ "--config", "/etc/eks/prometheus/config-{{component}}.yaml" ]
+          env:
+            - name: AWS_REGION
+              value: {{region}}
+            - name: OTEL_RESOURCE
+              value: ClusterName={{cluster_name}}
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 256m
+              memory: 512Mi
+            requests:
+              cpu: 32m
+              memory: 24Mi

--- a/docs/developers/eks-prometheus-demo.md
+++ b/docs/developers/eks-prometheus-demo.md
@@ -1,0 +1,93 @@
+## Deploy AWS OTel Collector on Amazon EKS with Sample Workloads
+
+The tutorial shows you how to set up AWS OTel Collector on Amazon EKS
+with [sample workloads]((https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-Sample-Workloads.html))
+provided by Amazon CloudWatch
+
+### Set Up IAM Policies
+
+In order to allow AWS OTel Collector to send logs to CloudWatch, please ensure that the following policies exist on EKS node role.
+
+#### Create EKS-AWSOTel IAM Policy
+1. Open the IAM console at https://console.aws.amazon.com/iam/.
+2. In the navigation pane, choose **Policies**.
+3. Choose **Create policy, JSON**.
+4. Enter the following policy:
+```json
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Action": [
+				"logs:PutLogEvents",
+				"logs:CreateLogGroup",
+				"logs:CreateLogStream",
+				"logs:DescribeLogStreams",
+				"logs:DescribeLogGroups",
+				"xray:PutTraceSegments",
+				"xray:PutTelemetryRecords",
+				"xray:GetSamplingRules",
+				"xray:GetSamplingTargets",
+				"xray:GetSamplingStatisticSummaries",
+				"ssm:GetParameters"
+			],
+			"Resource": "*"
+		}
+	]
+}
+```
+5. Choose **Review policy**.
+6. On the Review policy page, enter `EKS-AWSOTel` for the Name and choose **Create policy**.
+
+#### Attach EKS-AWSOTel IAM Role to worker nodes
+1. Open the Amazon EC2 console at https://console.aws.amazon.com/ec2/.
+2. Select one of the worker node instances and choose the IAM role in the description.
+3. On the IAM role page, choose **Attach policies**.
+4. In the list of policies, select the check box next to `EKS-AWSOTel`. If necessary, use the search box to find this policy.
+5. Choose **Attach policies**.
+
+### (Optional) Deploy App Mesh Sample Workloads 
+
+1. Follow the [official guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-Sample-Workloads-appmesh.html)
+   to install App Mesh and a sample application onto your EKS cluster.
+
+2. export `COMPONENT` for the coming deployment of AWS OTel Collector 
+```bash
+export COMPONENT=appmesh
+```
+
+### (Optional) Deploy Nginx Sample Workloads
+1. Follow the [official guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-Sample-Workloads-nginx.html)
+   to install Nginx and a sample service onto your EKS cluster.
+
+2. export `COMPONENT` for the coming deployment of AWS OTel Collector
+```bash
+export COMPONENT=nginx
+```
+
+### Install AWS OTel Collector
+1. Set up variables to export metrics of your EKS cluster to the region where the logs should be published to.
+```
+export CLUSTER_NAME=<eks-cluster-name>
+export AWS_REGION=<aws-region>
+```
+2. Deploy a standalone AWS OTel collector application. An example config template can be found [here](../../deployment-template/eks/standalone-otel-eks-deployment.yaml).
+   * Replace `{{region}}` with the name of the region where the logs are published (e.g. `us-west-2`).
+   * Replace `{{cluster_name}}` with the actual eks cluster name.
+```bash
+cat standalone-otel-eks-deployment.yaml |
+sed "s/{{region}}/$AWS_REGION/g" | 
+sed "s/{{cluster_name}}/$CLUSTER_NAME/g" |
+sed "s/{{component}}/$COMPONENT/g" |
+kubectl apply -f - 
+```
+3. View the resources in the `aws-otel-eks` namespace.
+```bash
+kubectl get all -n aws-otel-eks
+```
+4. View Your Metrics  
+You should now be able to view your metrics in your [CloudWatch console](https://console.aws.amazon.com/cloudwatch/). In
+the navigation bar, click on **Metrics**. The collected AWSOTelCollector metrics can be found in the **
+AWSObservability/CloudWatchOTService** namespace. Ensure that your region is set to the region set for your cluster.
+

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.20.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.19.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.20.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.20.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.20.0
 	github.com/opencontainers/runc v1.0.0-rc92

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -25,6 +25,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver"
 	"go.opentelemetry.io/collector/component"
@@ -61,6 +62,7 @@ func Components() (component.Factories, error) {
 	// enable the selected processors
 	processors := []component.ProcessorFactory{
 		metricstransformprocessor.NewFactory(),
+		resourcedetectionprocessor.NewFactory(),
 	}
 	for _, pr := range factories.Processors {
 		processors = append(processors, pr)


### PR DESCRIPTION
**Why do we need it?**
1. This PR adds default configuration using prometheus receiver for App Mesh and Nginx demo from [CloudWatch samples workloads](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-Sample-Workloads.html)

2. It shoes how to inject attribute ClusterName from environment variable OTEL_RESOURCE and TaskId from service.name for EMF exporter to use in metric declarations.