### PR TITLE
Use Setuid/Setgid implemented in go1.16

### DIFF
--- a/pkg/userutils/set_uid_gid.go
+++ b/pkg/userutils/set_uid_gid.go
@@ -1,0 +1,32 @@
+// +build linux
+// +build go1.16
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package userutils
+
+import "syscall"
+
+// go1.15 and before: use Setgid/Setuid from 3rd party library.
+// go1.16 and later: use Setgid/Setuid implemented in go syscall.
+
+func setUid(uid int) (err error) {
+	return syscall.Setuid(uid)
+}
+
+func setGid(gid int) (err error) {
+	return syscall.Setgid(gid)
+}

--- a/pkg/userutils/set_uid_gid_1_15.go
+++ b/pkg/userutils/set_uid_gid_1_15.go
@@ -1,0 +1,34 @@
+// +build linux
+// +build !go1.16
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package userutils
+
+import (
+	"github.com/opencontainers/runc/libcontainer/system"
+)
+
+// go1.15 and before: use Setgid/Setuid from 3rd party library.
+// go1.16 and later: use Setgid/Setuid implemented in go syscall.
+
+func setUid(uid int) (err error) {
+	return system.Setuid(uid)
+}
+
+func setGid(gid int) (err error) {
+	return system.Setgid(gid)
+}

--- a/pkg/userutils/userutil_linux.go
+++ b/pkg/userutils/userutil_linux.go
@@ -25,7 +25,6 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/runc/libcontainer/user"
 	"golang.org/x/sys/unix"
 )
@@ -40,12 +39,12 @@ func switchUser(execUser *user.ExecUser) error {
 		return err
 	}
 
-	if err := system.Setgid(execUser.Gid); err != nil {
+	if err := setGid(execUser.Gid); err != nil {
 		log.Printf("E! Failed to set gid: %v", err)
 		return err
 	}
 
-	if err := system.Setuid(execUser.Uid); err != nil {
+	if err := setUid(execUser.Uid); err != nil {
 		log.Printf("E! Failed to set uid: %v", err)
 		return err
 	}


### PR DESCRIPTION
**Description:** 
Use syscall Setuid/Setgid to change user when built by go1.16 and later.
https://golang.org/doc/go1.16#minor_library_changes
On Linux, Setgid, Setuid, and related calls are now implemented. Previously, they returned an syscall.EOPNOTSUPP error. 

**Testing:**
local test
