### PR TITLE
Update the default config file for ECS container receiver and fixed the bug for app metrics log name 

### DIFF
--- a/config/ecs/container-insights/otel-task-metrics-config.yaml
+++ b/config/ecs/container-insights/otel-task-metrics-config.yaml
@@ -76,7 +76,7 @@ processors:
 
   resource:
     attributes:
-      - key: Cluster
+      - key: ClusterName
         from_attribute: aws.ecs.cluster.name
         action: insert
       - key: aws.ecs.cluster.name
@@ -91,7 +91,7 @@ processors:
         action: insert
       - key: aws.ecs.task.id
         action: delete
-      - key: Family
+      - key: TaskDefinitionFamily
         from_attribute: aws.ecs.task.family
         action: insert
       - key: aws.ecs.task.family
@@ -106,7 +106,7 @@ processors:
         action: insert
       - key: aws.ecs.docker.name
         action: delete
-      - key: Revision
+      - key: TaskRevision
         from_attribute: aws.ecs.task.version
         action: insert
       - key: aws.ecs.task.version
@@ -131,13 +131,8 @@ processors:
         action: insert
       - key: aws.ecs.task.launch_type
         action: delete
-      - key: KnownStatus
-        from_attribute: aws.ecs.task.known_status
-        action: insert
-      - key: aws.ecs.task.known_status
-        action: delete
       - key: Region
-        from_attribute: cloud.regionupd
+        from_attribute: cloud.region
         action: insert
       - key: cloud.region
         action: delete
@@ -151,7 +146,7 @@ processors:
         action: insert
       - key: container.id
         action: delete
-      - key: Name
+      - key: ContainerName
         from_attribute: container.name
         action: insert
       - key: container.name
@@ -170,11 +165,6 @@ processors:
         from_attribute: aws.ecs.container.image.id
         action: insert
       - key: aws.ecs.container.image.id
-        action: delete
-      - key: ContainerKnownStatus
-        from_attribute: aws.ecs.container.know_status
-        action: insert
-      - key: aws.ecs.container.know_status
         action: delete
       - key: ExitCode
         from_attribute: aws.ecs.container.exit_code
@@ -215,7 +205,7 @@ exporters:
       enabled: true
     dimension_rollup_option: NoDimensionRollup
     metric_declarations:
-      - dimensions: [ [ Cluster ], [ Cluster, Family ] ]
+      - dimensions: [ [ ClusterName ], [ ClusterName, TaskDefinitionFamily ] ]
         metric_name_selectors:
           - MemoryUtilized
           - MemoryReserved

--- a/config/ecs/container-insights/otel-task-metrics-config.yaml
+++ b/config/ecs/container-insights/otel-task-metrics-config.yaml
@@ -22,18 +22,33 @@ processors:
   filter:
     metrics:
       include:
-        match_type: strict
+        match_type: regexp
         metric_names:
-          - ecs.task.memory.reserved
-          - ecs.task.memory.utilized
-          - ecs.task.cpu.reserved
-          - ecs.task.cpu.utilized
-          - ecs.task.network.rate.rx
-          - ecs.task.network.rate.tx
-          - ecs.task.storage.read_bytes
-          - ecs.task.storage.write_bytes
+          - .*memory.reserved
+          - .*memory.utilized
+          - .*cpu.reserved
+          - .*cpu.utilized
+          - .*network.rate.rx
+          - .*network.rate.tx
+          - .*storage.read_bytes
+          - .*storage.write_bytes
+          - container.duration
   metricstransform:
     transforms:
+      - include: ecs.task.*
+        match_type: regexp
+        action: update
+        operations:
+          - action: add_label
+            new_label: Type
+            new_value: Task
+      - include: container.*
+        match_type: regexp
+        action: update
+        operations:
+          - action: add_label
+            new_label: Type
+            new_value: Container
       - metric_name: ecs.task.memory.utilized
         action: update
         new_name: MemoryUtilized
@@ -58,9 +73,10 @@ processors:
       - metric_name: ecs.task.storage.write_bytes
         action: update
         new_name: StorageWriteBytes
+
   resource:
     attributes:
-      - key: ClusterName
+      - key: Cluster
         from_attribute: aws.ecs.cluster.name
         action: insert
       - key: aws.ecs.cluster.name
@@ -75,11 +91,117 @@ processors:
         action: insert
       - key: aws.ecs.task.id
         action: delete
-      - key: TaskDefinitionFamily
+      - key: Family
         from_attribute: aws.ecs.task.family
         action: insert
       - key: aws.ecs.task.family
         action: delete
+      - key: TaskARN
+        from_attribute: aws.ecs.task.arn
+        action: insert
+      - key: aws.ecs.task.arn
+        action: delete
+      - key: DockerName
+        from_attribute: aws.ecs.docker.name
+        action: insert
+      - key: aws.ecs.docker.name
+        action: delete
+      - key: Revision
+        from_attribute: aws.ecs.task.version
+        action: insert
+      - key: aws.ecs.task.version
+        action: delete
+      - key: PullStartedAt
+        from_attribute: aws.ecs.task.pull_started_at
+        action: insert
+      - key: aws.ecs.task.pull_started_at
+        action: delete
+      - key: PullStoppedAt
+        from_attribute: aws.ecs.task.pull_stopped_at
+        action: insert
+      - key: aws.ecs.task.pull_stopped_at
+        action: delete
+      - key: AvailabilityZone
+        from_attribute: cloud.zone
+        action: insert
+      - key: cloud.zone
+        action: delete
+      - key: LaunchType
+        from_attribute: aws.ecs.task.launch_type
+        action: insert
+      - key: aws.ecs.task.launch_type
+        action: delete
+      - key: KnownStatus
+        from_attribute: aws.ecs.task.known_status
+        action: insert
+      - key: aws.ecs.task.known_status
+        action: delete
+      - key: Region
+        from_attribute: cloud.regionupd
+        action: insert
+      - key: cloud.region
+        action: delete
+      - key: AccountID
+        from_attribute: cloud.account.id
+        action: insert
+      - key: cloud.account.id
+        action: delete
+      - key: DockerId
+        from_attribute: container.id
+        action: insert
+      - key: container.id
+        action: delete
+      - key: Name
+        from_attribute: container.name
+        action: insert
+      - key: container.name
+        action: delete
+      - key: DockerName
+        from_attribute: aws.ecs.docker.name
+        action: insert
+      - key: aws.ecs.docker.name
+        action: delete
+      - key: Image
+        from_attribute: container.image.name
+        action: insert
+      - key: container.image.name
+        action: delete
+      - key: ImageID
+        from_attribute: aws.ecs.container.image.id
+        action: insert
+      - key: aws.ecs.container.image.id
+        action: delete
+      - key: ContainerKnownStatus
+        from_attribute: aws.ecs.container.know_status
+        action: insert
+      - key: aws.ecs.container.know_status
+        action: delete
+      - key: ExitCode
+        from_attribute: aws.ecs.container.exit_code
+        action: insert
+      - key: aws.ecs.container.exit_code
+        action: delete
+      - key: CreatedAt
+        from_attribute: aws.ecs.container.created_at
+        action: insert
+      - key: aws.ecs.container.created_at
+        action: delete
+      - key: StartedAt
+        from_attribute: aws.ecs.container.started_at
+        action: insert
+      - key: aws.ecs.container.started_at
+        action: delete
+      - key: FinishedAt
+        from_attribute: aws.ecs.container.finished_at
+        action: insert
+      - key: aws.ecs.container.finished_at
+        action: delete
+      - key: ImageTag
+        from_attribute: container.image.tag
+        action: insert
+      - key: container.image.tag
+        action: delete
+
 exporters:
   awsxray:
   awsemf/application:
@@ -93,8 +215,18 @@ exporters:
       enabled: true
     dimension_rollup_option: NoDimensionRollup
     metric_declarations:
-      dimensions: [ [ ClusterName ], [ ClusterName, TaskDefinitionFamily ] ]
-      metric_name_selectors: [ . ]
+      - dimensions: [ [ Cluster ], [ Cluster, Family ] ]
+        metric_name_selectors:
+          - MemoryUtilized
+          - MemoryReserved
+          - CpuUtilized
+          - CpuReserved
+          - NetworkRxBytes
+          - NetworkTxBytes
+          - StorageReadBytes
+          - StorageWriteBytes
+      - metric_name_selectors: [container.*]
+
 service:
   pipelines:
     traces:

--- a/config/ecs/container-insights/otel-task-metrics-config.yaml
+++ b/config/ecs/container-insights/otel-task-metrics-config.yaml
@@ -181,8 +181,8 @@ processors:
 exporters:
   awsxray:
   awsemf/application:
-    log_group_name: '/aws/ecs/containerinsights/{ClusterName}/application/metrics'
-    log_stream_name: '{TaskId}'
+    namespace: ECS/AWSOTel/Application
+    log_group_name: '/aws/ecs/application/metrics'
   awsemf/performance:
     namespace: ECS/ContainerInsights
     log_group_name: '/aws/ecs/containerinsights/{ClusterName}/performance'

--- a/config/ecs/container-insights/otel-task-metrics-config.yaml
+++ b/config/ecs/container-insights/otel-task-metrics-config.yaml
@@ -35,20 +35,6 @@ processors:
           - container.duration
   metricstransform:
     transforms:
-      - include: ecs.task.*
-        match_type: regexp
-        action: update
-        operations:
-          - action: add_label
-            new_label: Type
-            new_value: Task
-      - include: container.*
-        match_type: regexp
-        action: update
-        operations:
-          - action: add_label
-            new_label: Type
-            new_value: Container
       - metric_name: ecs.task.memory.utilized
         action: update
         new_name: MemoryUtilized

--- a/config/ecs/container-insights/otel-task-metrics-config.yaml
+++ b/config/ecs/container-insights/otel-task-metrics-config.yaml
@@ -22,16 +22,16 @@ processors:
   filter:
     metrics:
       include:
-        match_type: regexp
+        match_type: strict
         metric_names:
-          - .*memory.reserved
-          - .*memory.utilized
-          - .*cpu.reserved
-          - .*cpu.utilized
-          - .*network.rate.rx
-          - .*network.rate.tx
-          - .*storage.read_bytes
-          - .*storage.write_bytes
+          - ecs.task.memory.reserved
+          - ecs.task.memory.utilized
+          - ecs.task.cpu.reserved
+          - ecs.task.cpu.utilized
+          - ecs.task.network.rate.rx
+          - ecs.task.network.rate.tx
+          - ecs.task.storage.read_bytes
+          - ecs.task.storage.write_bytes
           - container.duration
   metricstransform:
     transforms:
@@ -106,7 +106,7 @@ processors:
         action: insert
       - key: aws.ecs.docker.name
         action: delete
-      - key: TaskRevision
+      - key: TaskDefinitionRevision
         from_attribute: aws.ecs.task.version
         action: insert
       - key: aws.ecs.task.version

--- a/config/ecs/container-insights/otel-task-metrics-config.yaml
+++ b/config/ecs/container-insights/otel-task-metrics-config.yaml
@@ -137,11 +137,6 @@ processors:
         action: insert
       - key: container.name
         action: delete
-      - key: DockerName
-        from_attribute: aws.ecs.docker.name
-        action: insert
-      - key: aws.ecs.docker.name
-        action: delete
       - key: Image
         from_attribute: container.image.name
         action: insert

--- a/config/ecs/ecs-default-config.yaml
+++ b/config/ecs/ecs-default-config.yaml
@@ -22,8 +22,8 @@ processors:
 exporters:
   awsxray:
   awsemf:
-    log_group_name: '/aws/ecs/containerinsights/{ClusterName}/application/metrics'
-    log_stream_name: '{TaskId}'
+    namespace: ECS/AWSOTel/Application
+    log_group_name: '/aws/ecs/application/metrics'
 
 service:
   pipelines:


### PR DESCRIPTION
**Description:** 

Update the default config file for ECS container receiver. The change will include:

1, Update the resource processor config to transform more labels name to the insights label name.

2, Update the filter processor to be able to pass the new metric data.

3, Add metric_name_selectors to select the metric which will show in the cloudwatch metric part.

**Also Update the default config files for application metrics:**

Fixed the log group name for application matrix.

**Test:**
1, ECS container receiver:
Logs: https://paste.amazon.com/show/jialiawu/1615254392
Metrics:
<img width="1221" alt="Screen Shot 2021-03-08 at 4 33 55 PM" src="https://user-images.githubusercontent.com/59711343/110406117-90bfa480-8036-11eb-84b5-eca324a7dfc8.png">

2, Statsd receiver space name and log name:
![Screen Shot 2021-03-08 at 5 47 58 PM](https://user-images.githubusercontent.com/59711343/110406036-6cfc5e80-8036-11eb-8352-db13e5f8493d.png)
<img width="709" alt="Screen Shot 2021-03-08 at 4 32 19 PM" src="https://user-images.githubusercontent.com/59711343/110406151-9f0dc080-8036-11eb-9804-1d2b385397e2.png">

