### PR TITLE
Add statsD receiver component

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This table represents the supported components of AWS OTel Collector in 2020. Th
 | otlpreceiver                    | resourceprocessor             | `awsemfexporter`                   | pprofextension         |
 | `awsecscontainermetricsreceiver`| queuedprocessor               | `awsprometheusremotewriteexporter` | zpagesextension        |
 | `awsxrayreceiver`               | batchprocessor                | loggingexporter                    |                        |
-|                                 | memorylimiter                 | otlpexporter                       |                        |
+| `statsdreceiver`                | memorylimiter                 | otlpexporter                       |                        |
 |                                 | tailsamplingprocessor         | fileexporter                       |                        |
 |                                 | probabilisticsamplerprocessor | otlphttpexporter                   |                        |
 |                                 | spanprocessor                 | prometheusexporter                 |                        |
@@ -46,6 +46,7 @@ This table represents the supported components of AWS OTel Collector in 2020. Th
 * [Trace X-Ray Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/awsxrayexporter)
 * [Metrics EMF Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/awsemfexporter/README.md)
 * [ECS Container Metrics Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/receiver/awsecscontainermetricsreceiver)
+* [StatsD Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/statsdreceiver)
 
 ### Getting Started
 #### Prerequisites

--- a/config/ecs/container-insights/otel-task-metrics-config.yaml
+++ b/config/ecs/container-insights/otel-task-metrics-config.yaml
@@ -11,6 +11,9 @@ receivers:
   awsxray:
     endpoint: 0.0.0.0:2000
     transport: udp
+  statsd:
+    endpoint: 0.0.0.0:8125
+    aggregation_interval: 60s
   awsecscontainermetrics:
 
 processors:
@@ -205,7 +208,7 @@ service:
       processors: [batch/traces]
       exporters: [awsxray]
     metrics/application:
-      receivers: [otlp]
+      receivers: [otlp, statsd]
       processors: [batch/metrics]
       exporters: [awsemf/application]
     metrics/performance:

--- a/config/ecs/ecs-default-config.yaml
+++ b/config/ecs/ecs-default-config.yaml
@@ -11,6 +11,9 @@ receivers:
   awsxray:
     endpoint: 0.0.0.0:2000
     transport: udp
+  statsd:
+    endpoint: 0.0.0.0:8125
+    aggregation_interval: 60s
 
 processors:
   batch/traces:
@@ -32,7 +35,7 @@ service:
       processors: [batch/traces]
       exporters: [awsxray]
     metrics:
-      receivers: [otlp]
+      receivers: [otlp, statsd]
       processors: [batch/metrics]
       exporters: [awsemf]
 

--- a/deployment-template/ecs/aws-otel-ec2-sidecar-deployment-cfn.yaml
+++ b/deployment-template/ecs/aws-otel-ec2-sidecar-deployment-cfn.yaml
@@ -56,6 +56,7 @@ Resources:
           - DefaultExecutionRole
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/AWSOTelExecutionRole'
           - !Ref ExecutionRoleArn
+      NetworkMode: awsvpc
       ContainerDefinitions:
         - logConfiguration:
             logDriver: awslogs
@@ -71,6 +72,9 @@ Resources:
             - hostPort: 4317
               protocol: tcp
               containerPort: 4317
+            - hostPort: 8125
+              protocol: udp
+              containerPort: 8125
           command: [!Ref command]
           image: 'amazon/aws-otel-collector:latest'
           name: aws-collector
@@ -110,8 +114,24 @@ Resources:
           DependsOn:
             - containerName: aws-collector
               condition: START
+        - Name: aoc-statsd-emitter
+          Image: 'alpine/socat:latest'
+          essential: false
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-create-group: 'True'
+              awslogs-group: /ecs/statsd-emitter
+              awslogs-region: !Ref 'AWS::Region'
+              awslogs-stream-prefix: ecs
+          DependsOn:
+            - containerName: aws-collector
+              condition: START
+          EntryPoint:
+            - "/bin/sh"
+            - "-c"
+            - "while true; do echo 'statsdTestMetric:1|c' | socat -v -t 0 - UDP:127.0.0.1:8125; sleep 1; done"
       Memory: '2048'
-      Family: ecs-aws-otel-sidecar-service
       RequiresCompatibilities:
         - EC2
       Cpu: '1024'

--- a/deployment-template/ecs/aws-otel-fargate-sidecar-deployment-cfn.yaml
+++ b/deployment-template/ecs/aws-otel-fargate-sidecar-deployment-cfn.yaml
@@ -108,6 +108,25 @@ Resources:
           DependsOn:
             - containerName: aws-collector
               condition: START
+        - Name: aoc-statsd-emitter
+          Image: 'alpine/socat:latest'
+          Essential: false
+          Cpu: '256'
+          Memory: '512'
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-create-group: 'True'
+              awslogs-group: /ecs/statsd-emitter
+              awslogs-region: !Ref 'AWS::Region'
+              awslogs-stream-prefix: ecs
+          DependsOn:
+            - containerName: aws-collector
+              condition: START
+          EntryPoint:
+            - "/bin/sh"
+            - "-c"
+            - "while true; do echo 'statsdTestMetric:1|c' | socat -v -t 0 - UDP:127.0.0.1:8125; sleep 1; done"
       RequiresCompatibilities:
         - FARGATE
       Cpu: '1024'

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -4,6 +4,14 @@
 		"platforms": ["EC2", "ECS", "EKS", "SOAKING", "CANARY"]
 	},
 	{
+		"case_name": "statsd",
+		"platforms": ["EC2", "ECS", "EKS", "SOAKING"]
+	},
+	{
+		"case_name": "statsd_mock",
+		"platforms": ["LOCAL", "EC2", "ECS", "EKS", "SOAKING"]
+	},
+	{
 		"case_name": "otlp_metric",
 		"platforms": ["EC2", "ECS", "EKS", "SOAKING", "CANARY"]
 	},

--- a/examples/ecs/ecs-ec2-sidecar.json
+++ b/examples/ecs/ecs-ec2-sidecar.json
@@ -2,6 +2,7 @@
   "family": "aws-otel-EC2",
   "taskRoleArn": "{{ecsTaskRoleArn}}",
   "executionRoleArn": "{{ecsTaskExecutionRoleArn}}",
+  "networkMode": "awsvpc",
   "containerDefinitions": [
     {
       "logConfiguration": {
@@ -23,6 +24,11 @@
           "hostPort": 4317,
           "protocol": "tcp",
           "containerPort": 4317
+        },
+        {
+          "hostPort": 8125,
+          "protocol": "udp",
+          "containerPort": 8125
         }
       ],
       "command": [
@@ -71,6 +77,31 @@
       "image": "nginx:latest",
       "name": "nginx",
       "essential": false,
+      "dependsOn": [
+        {
+          "containerName": "aws-otel-collector",
+          "condition": "START"
+        }
+      ]
+    },
+    {
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-create-group": "True",
+          "awslogs-region": "us-west-2",
+          "awslogs-stream-prefix": "ecs",
+          "awslogs-group": "/ecs/statsd-emitter"
+        }
+      },
+      "image": "alpine/socat:latest",
+      "essential": false,
+      "name": "aoc-statsd-emitter",
+      "entryPoint": [
+        "/bin/sh",
+        "-c",
+        "while true; do echo 'statsdTestMetric:1|c' | socat -v -t 0 - UDP:127.0.0.1:8125; sleep 1; done"
+      ],
       "dependsOn": [
         {
           "containerName": "aws-otel-collector",

--- a/examples/ecs/ecs-fargate-sidecar.json
+++ b/examples/ecs/ecs-fargate-sidecar.json
@@ -49,6 +49,33 @@
           "condition": "START"
         }
       ]
+    },
+    {
+      "image": "alpine/socat:latest",
+      "memory": 512,
+      "dependsOn": [
+        {
+          "containerName": "aws-collector",
+          "condition": "START"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-create-group": "True",
+          "awslogs-region": "us-west-2",
+          "awslogs-stream-prefix": "ecs",
+          "awslogs-group": "/ecs/statsd-emitter"
+        }
+      },
+      "entryPoint": [
+        "/bin/sh",
+        "-c",
+        "while true; do echo 'statsdTestMetric:1|c' | socat -v -t 0 - UDP:127.0.0.1:8125; sleep 1; done"
+      ],
+      "name": "aoc-statsd-emitter",
+      "cpu": 256,
+      "essential": false
     }
   ],
   "requiresCompatibilities": [

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.22.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.22.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.22.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver v0.22.0
 	github.com/opencontainers/runc v1.0.0-rc92
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -1170,6 +1170,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiv
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.21.0/go.mod h1:dk1uyth+Rwf6wdDXSMBv1zDQ/UgIBvczVroHReah4ds=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.22.0 h1:fLBsMYzF8La0agsVdz2M39N7hu8XxiI301ELRShr4FY=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.22.0/go.mod h1:2lJk/CA0SWeGgmGAPviXBLtnW+JECvgcTqM5ZVjLIjE=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver v0.22.0 h1:NkHwtPT25hfd2lNDIW5Z+CBp4q5C/VZLWQbKpij6wzU=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver v0.22.0/go.mod h1:Wpo/HZp6+mI7KM9XcU26+Ggh7lQ7IL3bwQibPYflE88=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -27,6 +27,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter/fileexporter"
@@ -53,6 +54,7 @@ func Components() (component.Factories, error) {
 		otlpreceiver.NewFactory(),
 		awsecscontainermetricsreceiver.NewFactory(),
 		awsxrayreceiver.NewFactory(),
+		statsdreceiver.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)


### PR DESCRIPTION
**Description:** 
This PR adds StatsD receiver component to AOC. This is the original PR: https://github.com/aws-observability/aws-otel-collector/pull/330. Will close the old one when this one is merged.

**Link to tracking Issue:** https://github.com/aws-observability/aws-otel-collector/issues/110

**Change:** Besides the above PR:
1. set `Essential` to `false`

**Testing:** 
1. `make build`
2. `make docker-build`
3. Test the image in ECS
