### PR TITLE
Mention Amazon ES, Honeycomb and Lightstep are supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,22 @@ Use the community resources below for getting help with AWS OTel Collector.
 
 This table represents the supported components of AWS OTel Collector in 2020. The highlighted components below are developed by AWS in-house. The rest of the components in the table are the essential default components that AWS OTel Collector will support.
 
-| Receiver                        | Processor                     | Exporter                           | Extensions             |
-|---------------------------------|-------------------------------|------------------------------------|------------------------|
-| prometheusreceiver              | attributesprocessor           | `awsxrayexporter`                  | healthcheckextension   |
-| otlpreceiver                    | resourceprocessor             | `awsemfexporter`                   | pprofextension         |
-| `awsecscontainermetricsreceiver`| queuedprocessor               | `awsprometheusremotewriteexporter` | zpagesextension        |
-| `awsxrayreceiver`               | batchprocessor                | loggingexporter                    |                        |
-| `statsdreceiver`                | memorylimiter                 | otlpexporter                       |                        |
-|                                 | tailsamplingprocessor         | fileexporter                       |                        |
-|                                 | probabilisticsamplerprocessor | otlphttpexporter                   |                        |
-|                                 | spanprocessor                 | prometheusexporter                 |                        |
-|                                 | filterprocessor               | datadogexporter                    |                        |
-|                                 | metricstransformprocessor     | dynatraceexporter                  |                        |
-|                                 | resourcedetectionprocessor    | newrelicexporter                   |                        |
-|                                 |                               | sapmexporter                       |                        |
-|                                 |                               | signalfxexporter                   |                        |
-|                                 |                               |                                    |                        |
-
+| Receivers                        | Processors                    | Exporters                                                                                                       | Extensions           |
+|----------------------------------|-------------------------------|-----------------------------------------------------------------------------------------------------------------|----------------------|
+| prometheusreceiver               | attributesprocessor           | `awsxrayexporter`                                                                                               | healthcheckextension |
+| otlpreceiver                     | resourceprocessor             | `awsemfexporter`                                                                                                | pprofextension       |
+| `awsecscontainermetricsreceiver` | queuedprocessor               | `awsprometheusremotewriteexporter`                                                                              | zpagesextension      |
+| `awsxrayreceiver`                | batchprocessor                | loggingexporter                                                                                                 |                      |
+| `statsdreceiver`                 | memorylimiter                 | otlpexporter                                                                                                    |                      |
+|                                  | tailsamplingprocessor         | fileexporter                                                                                                    |                      |
+|                                  | probabilisticsamplerprocessor | otlphttpexporter                                                                                                |                      |
+|                                  | spanprocessor                 | prometheusexporter                                                                                              |                      |
+|                                  | filterprocessor               | datadogexporter                                                                                                 |                      |
+|                                  | metricstransformprocessor     | dynatraceexporter                                                                                               |                      |
+|                                  | resourcedetectionprocessor    | newrelicexporter                                                                                                |                      |
+|                                  |                               | sapmexporter                                                                                                    |                      |
+|                                  |                               | signalfxexporter                                                                                                |                      |
+|                                  |                               | Amazon Elasticsearch Service, Honeycomb, and Lightstep natively supports OTLP. Use otlpexporter to export them. |                      |
 
 #### AWS OTel Collector AWS Components
 * [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector/)


### PR DESCRIPTION
It's not clear to customers whether these destinations are supported because they don't require an vendor-specific exporter.
