### PR TITLE
Add default configurations for Container Insights on EKS with Prometheus

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -422,6 +422,7 @@ jobs:
       ec2-matrix-1: ${{ steps.set-matrix.outputs.ec2-matrix-1 }}
       ec2-matrix-2: ${{ steps.set-matrix.outputs.ec2-matrix-2 }}
       ec2-matrix-3: ${{ steps.set-matrix.outputs.ec2-matrix-3 }}
+      containerinsight-eks-prometheus-matrix: ${{ steps.set-matrix.outputs.containerinsight-eks-prometheus-matrix }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -437,11 +438,13 @@ jobs:
           ec2_matrix_3=$(python e2etest/get-testcases.py ec2_matrix_3)
           ecs_matrix=$(python e2etest/get-testcases.py ecs_matrix)
           eks_matrix=$(python e2etest/get-testcases.py eks_matrix)
+          containerinsight_eks_prometheus_matrix=$(python e2etest/get-testcases.py containerinsight_eks_prometheus_matrix)
           echo "::set-output name=eks-matrix::$eks_matrix"
           echo "::set-output name=ecs-matrix::$ecs_matrix"
           echo "::set-output name=ec2-matrix-1::$ec2_matrix_1"
           echo "::set-output name=ec2-matrix-2::$ec2_matrix_2"
           echo "::set-output name=ec2-matrix-3::$ec2_matrix_3"
+          echo "::set-output name=containerinsight-eks-prometheus-matrix::$containerinsight_eks_prometheus_matrix"
       - name: List testing suites
         run: |
           echo ${{ steps.set-matrix.outputs.eks-matrix }}
@@ -449,6 +452,7 @@ jobs:
           echo ${{ steps.set-matrix.outputs.ec2-matrix-1 }}
           echo ${{ steps.set-matrix.outputs.ec2-matrix-2 }}
           echo ${{ steps.set-matrix.outputs.ec2-matrix-3 }}
+          echo ${{ steps.set-matrix.outputs.containerinsight-eks-prometheus-matrix }}
 
   e2etest-ec2-1:
     runs-on: ubuntu-latest
@@ -651,6 +655,47 @@ jobs:
         if: ${{ always() }}
         run: |
           cd testing-framework/terraform/eks && terraform destroy -auto-approve
+
+  e2etest-containerinsight-eks-prometheus:
+    runs-on: ubuntu-latest
+    needs: [ get-testing-suites, e2etest-release, e2etest-preparation ]
+    strategy:
+      max-parallel: 5
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.containerinsight-eks-prometheus-matrix) }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+
+      - name: Set up terraform
+        uses: hashicorp/setup-terraform@v1
+
+      - name: Check out testing framework
+        uses: actions/checkout@v2
+        with:
+          repository: 'aws-observability/aws-otel-collector-test-framework'
+          path: testing-framework
+
+      - name: Run testing suite on eks
+        run: |
+          if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
+          cd testing-framework/terraform/containerinsight_eks_prometheus && terraform init && terraform apply -auto-approve -lock=false $opts -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}"
+
+      - name: Destroy resources
+        if: ${{ always() }}
+        run: |
+          cd testing-framework/terraform/containerinsight_eks_prometheus && terraform destroy -auto-approve
 
 
   release-candidate:

--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -42,6 +42,13 @@ FROM scratch
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /workspace/build/linux/aoc_linux_x86_64 /awscollector
 COPY --from=build /workspace/config.yaml /etc/otel-config.yaml
+COPY --from=build /workspace/config/eks/prometheus/config-appmesh.yaml /etc/eks/prometheus/config-appmesh.yaml
+COPY --from=build /workspace/config/eks/prometheus/config-haproxy.yaml /etc/eks/prometheus/config-haproxy.yaml
+COPY --from=build /workspace/config/eks/prometheus/config-jmx.yaml /etc/eks/prometheus/config-jmx.yaml
+COPY --from=build /workspace/config/eks/prometheus/config-memcached.yaml /etc/eks/prometheus/config-memcached.yaml
+COPY --from=build /workspace/config/eks/prometheus/config-nginx.yaml /etc/eks/prometheus/config-nginx.yaml
+COPY --from=build /workspace/config/eks/prometheus/config-redis.yaml /etc/eks/prometheus/config-redis.yaml
+COPY --from=build /workspace/config/eks/prometheus/config-all.yaml /etc/eks/prometheus/config-all.yaml
 COPY --from=build /workspace/config/ecs/container-insights/otel-task-metrics-config.yaml /etc/ecs/container-insights/otel-task-metrics-config.yaml
 COPY --from=build /workspace/config/ecs/ecs-default-config.yaml /etc/ecs/ecs-default-config.yaml
 

--- a/config/eks/prometheus/config-all.yaml
+++ b/config/eks/prometheus/config-all.yaml
@@ -1,0 +1,435 @@
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 1m
+        scrape_timeout: 10s
+      scrape_configs:
+        - job_name: 'kubernetes-pod-appmesh-envoy'
+          sample_limit: 10000
+          metrics_path: /stats/prometheus
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [ __meta_kubernetes_pod_container_name ]
+              action: keep
+              regex: '^envoy$'
+            - source_labels: [ __address__, __meta_kubernetes_pod_annotation_prometheus_io_port ]
+              action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $${1}:9901
+              target_label: __address__
+            - source_labels: [ __address__ ]
+              target_label: exported_instance
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - source_labels: [ __meta_kubernetes_pod_name ]
+              action: replace
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_name
+              target_label: pod_controller_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_kind
+              target_label: pod_controller_kind
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_phase
+              target_label: pod_phase
+        - job_name: 'kubernetes-pod-fluentbit-plugin'
+          sample_limit: 10000
+          metrics_path: /api/v1/metrics/prometheus
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [ __meta_kubernetes_pod_container_name ]
+              action: keep
+              regex: '^fluent-bit.*$'
+            - source_labels: [ __address__ ]
+              action: replace
+              regex: ([^:]+)(?::\d+)?
+              replacement: ${1}:2020
+              target_label: __address__
+            - source_labels: [ __address__ ]
+              target_label: exported_instance
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - source_labels: [ __meta_kubernetes_pod_name ]
+              action: replace
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_name
+              target_label: pod_controller_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_kind
+              target_label: pod_controller_kind
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_phase
+              target_label: pod_phase
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_node_name
+              target_label: container_name
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'go_gc_duration_seconds.*'
+              action: drop
+            - source_labels: [ __name__, proxy ]
+              regex: "haproxy_frontend.+;(.+)"
+              target_label: frontend
+              replacement: "$$1"
+            - source_labels: [ __name__, proxy ]
+              regex: "haproxy_server.+;(.+)"
+              target_label: backend
+              replacement: "$$1"
+            - source_labels: [ __name__, proxy ]
+              regex: "haproxy_backend.+;(.+)"
+              target_label: backend
+              replacement: "$$1"
+            - regex: proxy
+              action: labeldrop
+        - job_name: kubernetes-service-endpoints
+          sample_limit: 10000
+          kubernetes_sd_configs:
+            - role: endpoints
+          relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (https?)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scheme
+              target_label: __scheme__
+            - action: replace
+              regex: (.+)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              source_labels:
+                - __address__
+                - __meta_kubernetes_service_annotation_prometheus_io_port
+              target_label: __address__
+            - source_labels: [ __address__ ]
+              target_label: exported_instance
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_service_name
+              target_label: Service
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_node_name
+              target_label: kubernetes_node
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_name
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'go_gc_duration_seconds.*'
+              action: drop
+            - source_labels: [ __name__, proxy ]
+              regex: "haproxy_frontend.+;(.+)"
+              target_label: frontend
+              replacement: "$$1"
+            - source_labels: [ __name__, proxy ]
+              regex: "haproxy_server.+;(.+)"
+              target_label: backend
+              replacement: "$$1"
+            - source_labels: [ __name__, proxy ]
+              regex: "haproxy_backend.+;(.+)"
+              target_label: backend
+              replacement: "$$1"
+            - regex: proxy
+              action: labeldrop
+        - job_name: 'kubernetes-pod-jmx'
+          sample_limit: 10000
+          metrics_path: /metrics
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [ __address__ ]
+              action: keep
+              regex: '.*:9404$'
+            - source_labels: [ __address__ ]
+              target_label: exported_instance
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - source_labels: [ __meta_kubernetes_pod_name ]
+              action: replace
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_name
+              target_label: pod_controller_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_kind
+              target_label: pod_controller_kind
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_phase
+              target_label: pod_phase
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'jvm_gc_collection_seconds.*'
+              action: drop
+
+processors:
+  resourcedetection/ec2:
+    detectors: [ env ]
+    timeout: 2s
+    override: false
+  resource:
+    attributes:
+      - key: TaskId
+        from_attribute: service.name
+        action: insert
+      - key: job
+        from_attribute: service.name
+        action: insert
+      - key: receiver
+        value: "prometheus"
+        action: insert
+  metricstransform:
+    transforms:
+      - include: ".*"
+        match_type: regexp
+        action: update
+        operations:
+          - label: exported_instance
+            new_label: instance
+            action: update_label
+
+exporters:
+  awsemf:
+    namespace: ContainerInsights/Prometheus
+    log_group_name: "/aws/containerinsights/{ClusterName}/prometheus"
+    log_stream_name: "{TaskId}"
+    resource_to_telemetry_conversion:
+      enabled: true
+    dimension_rollup_option: NoDimensionRollup
+    metric_declarations:
+      - dimensions: [ [ ClusterName, Namespace ] ]
+        metric_name_selectors:
+          - "^envoy_http_downstream_rq_(total|xx)$"
+          - "^envoy_cluster_upstream_cx_(r|t)x_bytes_total$"
+          - "^envoy_cluster_membership_(healthy|total)$"
+          - "^envoy_server_memory_(allocated|heap_size)$"
+          - "^envoy_cluster_upstream_cx_(connect_timeout|destroy_local_with_active_rq)$"
+          - "^envoy_cluster_upstream_rq_(pending_failure_eject|pending_overflow|timeout|per_try_timeout|rx_reset|maintenance_mode)$"
+          - "^envoy_http_downstream_cx_destroy_remote_active_rq$"
+          - "^envoy_cluster_upstream_flow_control_(paused_reading_total|resumed_reading_total|backed_up_total|drained_total)$"
+          - "^envoy_cluster_upstream_rq_retry$"
+          - "^envoy_cluster_upstream_rq_retry_(success|overflow)$"
+          - "^envoy_server_(version|uptime|live)$"
+        label_matchers:
+          - label_names:
+              - container_name
+            regex: ^envoy$
+      - dimensions: [ [ ClusterName, Namespace, envoy_http_conn_manager_prefix, envoy_response_code_class ] ]
+        metric_name_selectors:
+          - "^envoy_http_downstream_rq_xx$"
+        label_matchers:
+          - label_names:
+              - container_name
+            regex: ^envoy$
+      - dimensions: [ [ ClusterName, Namespace, NodeName ] ]
+        metric_name_selectors:
+          - "^fluentbit_output_errors_total$"
+          - "^fluentbit_input_bytes_total$"
+          - "^fluentbit_output_proc_bytes_total$"
+          - "^fluentbit_input_records_total$"
+          - "^fluentbit_output_proc_records_total$"
+          - "^fluentbit_output_retries_(total|failed_total)$"
+        label_matchers:
+          - label_names:
+              - container_name
+            regex: "^fluent-bit.*$"
+      - dimensions: [ [ Service, Namespace, ClusterName, frontend, code ] ]
+        metric_name_selectors:
+          - "^haproxy_frontend_http_responses_total$"
+        label_matchers:
+          - label_names:
+              - Service
+              - frontend
+            regex: ".*haproxy-ingress-.*metrics;(httpfront-shared-frontend|httpfront-default-backend|httpsfront|_front_http)"
+      - dimensions: [ [ Service, Namespace, ClusterName, backend, code ] ]
+        metric_name_selectors:
+          - "^haproxy_backend_http_responses_total$"
+        label_matchers:
+          - label_names:
+              - Service
+              - backend
+            regex: ".*haproxy-ingress-.*metrics;(httpback-shared-backend|httpback-default-backend|httpsback-shared-backend|_default_backend)"
+      - dimensions: [ [ Service, Namespace, ClusterName ] ]
+        metric_name_selectors:
+          - "^haproxy_backend_up$"
+          - "^haproxy_backend_status$"
+          - "^haproxy_backend_bytes_(in|out)_total$"
+          - "^haproxy_backend_connections_total$"
+          - "^haproxy_backend_connection_errors_total$"
+          - "^haproxy_backend_current_sessions$"
+          - "^haproxy_frontend_bytes_(in|out)_total$"
+          - "^haproxy_frontend_connections_total$"
+          - "^haproxy_frontend_http_requests_total$"
+          - "^haproxy_frontend_request_errors_total$"
+          - "^haproxy_frontend_requests_denied_total$"
+          - "^haproxy_frontend_current_sessions$"
+        label_matchers:
+          - label_names:
+              - Service
+            regex: ".*haproxy-ingress-.*metrics"
+      - dimensions: [ [ ClusterName, Namespace ] ]
+        metric_name_selectors:
+          - "^jvm_threads_(current|daemon)$"
+          - "^jvm_classes_loaded$"
+          - "^java_lang_operatingsystem_(freephysicalmemorysize|totalphysicalmemorysize|freeswapspacesize|totalswapspacesize|systemcpuload|processcpuload|availableprocessors|openfiledescriptorcount)$"
+          - "^catalina_manager_(rejectedsessions|activesessions)$"
+          - "^jvm_gc_collection_seconds_(count|sum)$"
+          - "^catalina_globalrequestprocessor_(bytesreceived|bytessent|requestcount|errorcount|processingtime)$"
+        label_matchers:
+          - label_names:
+              - service.name
+            regex: ^kubernetes-pod-jmx$
+      - dimensions: [ [ ClusterName, Namespace, area ] ]
+        metric_name_selectors:
+          - "^jvm_memory_bytes_used$"
+        label_matchers:
+          - label_names:
+              - service.name
+            regex: ^kubernetes-pod-jmx$
+      - dimensions: [ [ ClusterName, Namespace, pool ] ]
+        metric_name_selectors:
+          - "^jvm_memory_pool_bytes_used$"
+        label_matchers:
+          - label_names:
+              - service.name
+            regex: ^kubernetes-pod-jmx$
+      - dimensions: [ [ Service, Namespace, ClusterName ] ]
+        metric_name_selectors:
+          - "^memcached_current_(bytes|items|connections)$"
+          - "^memcached_items_(reclaimed|evicted)_total$"
+          - "^memcached_(written|read)_bytes_total$"
+          - "^memcached_limit_bytes$"
+          - "^memcached_commands_total$"
+        label_matchers:
+          - label_names:
+              - Service
+            regex: ".*memcached.*"
+      - dimensions: [ [ Service, Namespace, ClusterName, status, command ] ]
+        metric_name_selectors:
+          - "^memcached_commands_total$"
+        label_matchers:
+          - label_names:
+              - Service
+              - status
+              - command
+            regex: ".*memcached.*;hit;get"
+      - dimensions: [ [ Service, Namespace, ClusterName, command ] ]
+        metric_name_selectors:
+          - "^memcached_commands_total$"
+        label_matchers:
+          - label_names:
+              - Service
+              - command
+            regex: ".*memcached.*;(get|set)"
+      - dimensions: [ [ Service, Namespace, ClusterName ] ]
+        metric_name_selectors:
+          - "^nginx_ingress_controller_(requests|success)$"
+          - "^nginx_ingress_controller_nginx_process_connections$"
+          - "^nginx_ingress_controller_nginx_process_connections_total$"
+          - "^nginx_ingress_controller_nginx_process_resident_memory_bytes$"
+          - "^nginx_ingress_controller_nginx_process_cpu_seconds_total$"
+          - "^nginx_ingress_controller_config_last_reload_successful$"
+        label_matchers:
+          - label_names:
+              - Service
+            regex: ".*nginx.*"
+      - dimensions: [ [ Service, Namespace, ClusterName, ingress ],[ Service, Namespace, ClusterName, status ] ]
+        metric_name_selectors:
+          - "^nginx_ingress_controller_requests$"
+        label_matchers:
+          - label_names:
+              - Service
+            regex: ".*nginx.*"
+      - dimensions: [ [ Namespace, ClusterName ] ]
+        metric_name_selectors:
+          - "^redis_net_(in|out)put_bytes_total$"
+          - "^redis_(expired|evicted)_keys_total$"
+          - "^redis_keyspace_(hits|misses)_total$"
+          - "^redis_memory_used_bytes$"
+          - "^redis_connected_clients$"
+        label_matchers:
+          - label_names:
+              - pod_name
+            regex: "^redis-instance$"
+      - dimensions: [ [ Namespace, ClusterName, cmd ] ]
+        metric_name_selectors:
+          - "^redis_commands_total$"
+        label_matchers:
+          - label_names:
+              - pod_name
+            regex: "^redis-instance$"
+      - dimensions: [ [ Namespace, ClusterName, db ] ]
+        metric_name_selectors:
+          - "^redis_db_keys$"
+        label_matchers:
+          - label_names:
+              - pod_name
+            regex: "^redis-instance$"
+  logging:
+    loglevel: debug
+
+extensions:
+  pprof:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [ prometheus ]
+      processors: [ resourcedetection/ec2, resource, metricstransform ]
+      exporters: [ awsemf ]

--- a/config/eks/prometheus/config-appmesh.yaml
+++ b/config/eks/prometheus/config-appmesh.yaml
@@ -1,0 +1,115 @@
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 1m
+        scrape_timeout: 10s
+      scrape_configs:
+        - job_name: 'kubernetes-pod-appmesh-envoy'
+          sample_limit: 10000
+          metrics_path: /stats/prometheus
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [ __meta_kubernetes_pod_container_name ]
+              action: keep
+              regex: '^envoy$'
+            - source_labels: [ __address__, __meta_kubernetes_pod_annotation_prometheus_io_port ]
+              action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $${1}:9901
+              target_label: __address__
+            - source_labels: [ __address__ ]
+              target_label: exported_instance
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - source_labels: [ __meta_kubernetes_pod_name ]
+              action: replace
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_name
+              target_label: pod_controller_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_kind
+              target_label: pod_controller_kind
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_phase
+              target_label: pod_phase
+
+processors:
+  resourcedetection/ec2:
+    detectors: [ env ]
+    timeout: 2s
+    override: false
+  resource:
+    attributes:
+      - key: TaskId
+        from_attribute: service.name
+        action: insert
+      - key: job
+        from_attribute: service.name
+        action: insert
+      - key: receiver
+        value: "prometheus"
+        action: insert
+  metricstransform:
+    transforms:
+      - include: ".*"
+        match_type: regexp
+        action: update
+        operations:
+          - label: exported_instance
+            new_label: instance
+            action: update_label
+
+exporters:
+  awsemf:
+    namespace: ContainerInsights/Prometheus
+    log_group_name: "/aws/containerinsights/{ClusterName}/prometheus"
+    log_stream_name: "{TaskId}"
+    resource_to_telemetry_conversion:
+      enabled: true
+    dimension_rollup_option: NoDimensionRollup
+    metric_declarations:
+      - dimensions: [ [ ClusterName, Namespace ] ]
+        metric_name_selectors:
+          - "^envoy_http_downstream_rq_(total|xx)$"
+          - "^envoy_cluster_upstream_cx_(r|t)x_bytes_total$"
+          - "^envoy_cluster_membership_(healthy|total)$"
+          - "^envoy_server_memory_(allocated|heap_size)$"
+          - "^envoy_cluster_upstream_cx_(connect_timeout|destroy_local_with_active_rq)$"
+          - "^envoy_cluster_upstream_rq_(pending_failure_eject|pending_overflow|timeout|per_try_timeout|rx_reset|maintenance_mode)$"
+          - "^envoy_http_downstream_cx_destroy_remote_active_rq$"
+          - "^envoy_cluster_upstream_flow_control_(paused_reading_total|resumed_reading_total|backed_up_total|drained_total)$"
+          - "^envoy_cluster_upstream_rq_retry$"
+          - "^envoy_cluster_upstream_rq_retry_(success|overflow)$"
+          - "^envoy_server_(version|uptime|live)$"
+        label_matchers:
+          - label_names:
+              - container_name
+            regex: ^envoy$
+      - dimensions: [ [ ClusterName, Namespace, envoy_http_conn_manager_prefix, envoy_response_code_class ] ]
+        metric_name_selectors:
+          - "^envoy_http_downstream_rq_xx$"
+        label_matchers:
+          - label_names:
+              - container_name
+            regex: ^envoy$
+
+service:
+  pipelines:
+    metrics:
+      receivers: [ prometheus ]
+      processors: [ resourcedetection/ec2, resource ]
+      exporters: [ awsemf ]

--- a/config/eks/prometheus/config-haproxy.yaml
+++ b/config/eks/prometheus/config-haproxy.yaml
@@ -1,0 +1,193 @@
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 1m
+        scrape_timeout: 10s
+      scrape_configs:
+        - job_name: 'kubernetes-pod-fluentbit-plugin'
+          sample_limit: 10000
+          metrics_path: /api/v1/metrics/prometheus
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [ __meta_kubernetes_pod_container_name ]
+              action: keep
+              regex: '^fluent-bit.*$'
+            - source_labels: [ __address__ ]
+              action: replace
+              regex: ([^:]+)(?::\d+)?
+              replacement: ${1}:2020
+              target_label: __address__
+            - source_labels: [ __address__ ]
+              target_label: exported_instance
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - source_labels: [ __meta_kubernetes_pod_name ]
+              action: replace
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_name
+              target_label: pod_controller_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_kind
+              target_label: pod_controller_kind
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_phase
+              target_label: pod_phase
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_node_name
+        - job_name: kubernetes-service-endpoints
+          sample_limit: 10000
+          kubernetes_sd_configs:
+            - role: endpoints
+          relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (https?)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scheme
+              target_label: __scheme__
+            - action: replace
+              regex: (.+)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              source_labels:
+                - __address__
+                - __meta_kubernetes_service_annotation_prometheus_io_port
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_service_name
+              target_label: Service
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_node_name
+              target_label: kubernetes_node
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_name
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'go_gc_duration_seconds.*'
+              action: drop
+            - source_labels: [ __name__, proxy ]
+              regex: "haproxy_frontend.+;(.+)"
+              target_label: frontend
+              replacement: "$$1"
+            - source_labels: [ __name__, proxy ]
+              regex: "haproxy_server.+;(.+)"
+              target_label: backend
+              replacement: "$$1"
+            - source_labels: [ __name__, proxy ]
+              regex: "haproxy_backend.+;(.+)"
+              target_label: backend
+              replacement: "$$1"
+            - regex: proxy
+              action: labeldrop
+
+processors:
+  resourcedetection/ec2:
+    detectors: [ env ]
+    timeout: 2s
+    override: false
+  resource:
+    attributes:
+      - key: TaskId
+        from_attribute: service.name
+        action: insert
+      - key: job
+        from_attribute: service.name
+        action: insert
+      - key: receiver
+        value: "prometheus"
+        action: insert
+  metricstransform:
+    transforms:
+      - include: ".*"
+        match_type: regexp
+        action: update
+        operations:
+          - label: exported_instance
+            new_label: instance
+            action: update_label
+
+exporters:
+  awsemf:
+    namespace: ContainerInsights/Prometheus
+    log_group_name: "/aws/containerinsights/{ClusterName}/prometheus"
+    log_stream_name: "{TaskId}"
+    resource_to_telemetry_conversion:
+      enabled: true
+    dimension_rollup_option: NoDimensionRollup
+    metric_declarations:
+      - dimensions: [ [ Service, Namespace, ClusterName, frontend, code ] ]
+        metric_name_selectors:
+          - "^haproxy_frontend_http_responses_total$"
+        label_matchers:
+          - label_names:
+              - Service
+              - frontend
+            regex: ".*haproxy-ingress-.*metrics;(httpfront-shared-frontend|httpfront-default-backend|httpsfront|_front_http)"
+      - dimensions: [ [ Service, Namespace, ClusterName, backend, code ] ]
+        metric_name_selectors:
+          - "^haproxy_backend_http_responses_total$"
+        label_matchers:
+          - label_names:
+              - Service
+              - backend
+            regex: ".*haproxy-ingress-.*metrics;(httpback-shared-backend|httpback-default-backend|httpsback-shared-backend|_default_backend)"
+      - dimensions: [ [ Service, Namespace, ClusterName ] ]
+        metric_name_selectors:
+          - "^haproxy_backend_up$"
+          - "^haproxy_backend_status$"
+          - "^haproxy_backend_bytes_(in|out)_total$"
+          - "^haproxy_backend_connections_total$"
+          - "^haproxy_backend_connection_errors_total$"
+          - "^haproxy_backend_current_sessions$"
+          - "^haproxy_frontend_bytes_(in|out)_total$"
+          - "^haproxy_frontend_connections_total$"
+          - "^haproxy_frontend_http_requests_total$"
+          - "^haproxy_frontend_request_errors_total$"
+          - "^haproxy_frontend_requests_denied_total$"
+          - "^haproxy_frontend_current_sessions$"
+        label_matchers:
+          - label_names:
+              - Service
+            regex: ".*haproxy-ingress-.*metrics"
+service:
+  pipelines:
+    metrics:
+      receivers: [ prometheus ]
+      processors: [ resourcedetection/ec2, resource ]
+      exporters: [ awsemf ]

--- a/config/eks/prometheus/config-jmx.yaml
+++ b/config/eks/prometheus/config-jmx.yaml
@@ -1,0 +1,123 @@
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 1m
+        scrape_timeout: 10s
+      scrape_configs:
+        - job_name: 'kubernetes-pod-jmx'
+          sample_limit: 10000
+          metrics_path: /metrics
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [ __address__ ]
+              action: keep
+              regex: '.*:9404$'
+            - source_labels: [ __address__ ]
+              target_label: exported_instance
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - source_labels: [ __meta_kubernetes_pod_name ]
+              action: replace
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_name
+              target_label: pod_controller_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_controller_kind
+              target_label: pod_controller_kind
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_phase
+              target_label: pod_phase
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'jvm_gc_collection_seconds.*'
+              action: drop
+
+processors:
+  resourcedetection/ec2:
+    detectors: [ env ]
+    timeout: 2s
+    override: false
+  resource:
+    attributes:
+      - key: TaskId
+        from_attribute: service.name
+        action: insert
+      - key: job
+        from_attribute: service.name
+        action: insert
+      - key: receiver
+        value: "prometheus"
+        action: insert
+  metricstransform:
+    transforms:
+      - include: ".*"
+        match_type: regexp
+        action: update
+        operations:
+          - label: exported_instance
+            new_label: instance
+            action: update_label
+
+exporters:
+  awsemf:
+    namespace: ContainerInsights/Prometheus
+    log_group_name: "/aws/containerinsights/{ClusterName}/prometheus"
+    log_stream_name: "{TaskId}"
+    resource_to_telemetry_conversion:
+      enabled: true
+    dimension_rollup_option: NoDimensionRollup
+    metric_declarations:
+      - dimensions: [ [ ClusterName, Namespace ] ]
+        metric_name_selectors:
+          - "^jvm_threads_(current|daemon)$"
+          - "^jvm_classes_loaded$"
+          - "^java_lang_operatingsystem_(freephysicalmemorysize|totalphysicalmemorysize|freeswapspacesize|totalswapspacesize|systemcpuload|processcpuload|availableprocessors|openfiledescriptorcount)$"
+          - "^catalina_manager_(rejectedsessions|activesessions)$"
+          - "^jvm_gc_collection_seconds_(count|sum)$"
+          - "^catalina_globalrequestprocessor_(bytesreceived|bytessent|requestcount|errorcount|processingtime)$"
+        label_matchers:
+          - label_names:
+              - service.name
+            regex: ^kubernetes-pod-jmx$
+      - dimensions: [ [ ClusterName, Namespace, area ] ]
+        metric_name_selectors:
+          - "^jvm_memory_bytes_used$"
+        label_matchers:
+          - label_names:
+              - service.name
+            regex: ^kubernetes-pod-jmx$
+      - dimensions: [ [ ClusterName, Namespace, area ] ]
+        metric_name_selectors:
+          - "^jvm_memory_bytes_used$"
+        label_matchers:
+          - label_names:
+              - service.name
+            regex: ^kubernetes-pod-jmx$
+      - dimensions: [ [ ClusterName, Namespace, pool ] ]
+        metric_name_selectors:
+          - "^jvm_memory_pool_bytes_used$"
+        label_matchers:
+          - label_names:
+              - service.name
+            regex: ^kubernetes-pod-jmx$
+
+service:
+  pipelines:
+    metrics:
+      receivers: [ prometheus ]
+      processors: [ resourcedetection/ec2, resource ]
+      exporters: [ awsemf ]

--- a/config/eks/prometheus/config-memcached.yaml
+++ b/config/eks/prometheus/config-memcached.yaml
@@ -1,0 +1,133 @@
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 1m
+        scrape_timeout: 10s
+      scrape_configs:
+        - job_name: kubernetes-service-endpoints
+          sample_limit: 10000
+          kubernetes_sd_configs:
+            - role: endpoints
+          relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (https?)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scheme
+              target_label: __scheme__
+            - action: replace
+              regex: (.+)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              source_labels:
+                - __address__
+                - __meta_kubernetes_service_annotation_prometheus_io_port
+              target_label: __address__
+            - source_labels: [ __address__ ]
+              target_label: exported_instance
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_service_name
+              target_label: Service
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_node_name
+              target_label: kubernetes_node
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_name
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'go_gc_duration_seconds.*'
+              action: drop
+            - regex: proxy
+              action: labeldrop
+
+processors:
+  resourcedetection/ec2:
+    detectors: [ env ]
+    timeout: 2s
+    override: false
+  resource:
+    attributes:
+      - key: TaskId
+        from_attribute: service.name
+        action: insert
+      - key: job
+        from_attribute: service.name
+        action: insert
+      - key: receiver
+        value: "prometheus"
+        action: insert
+  metricstransform:
+    transforms:
+      - include: ".*"
+        match_type: regexp
+        action: update
+        operations:
+          - label: exported_instance
+            new_label: instance
+            action: update_label
+
+exporters:
+  awsemf:
+    namespace: ContainerInsights/Prometheus
+    log_group_name: "/aws/containerinsights/{ClusterName}/prometheus"
+    log_stream_name: "{TaskId}"
+    resource_to_telemetry_conversion:
+      enabled: true
+    dimension_rollup_option: NoDimensionRollup
+    metric_declarations:
+      - dimensions: [ [ Service, Namespace, ClusterName ] ]
+        metric_name_selectors:
+          - "^memcached_current_(bytes|items|connections)$"
+          - "^memcached_items_(reclaimed|evicted)_total$"
+          - "^memcached_(written|read)_bytes_total$"
+          - "^memcached_limit_bytes$"
+          - "^memcached_commands_total$"
+        label_matchers:
+          - label_names:
+              - Service
+            regex: ".*memcached.*"
+      - dimensions: [ [ Service, Namespace, ClusterName, status, command ] ]
+        metric_name_selectors:
+          - "^memcached_commands_total$"
+        label_matchers:
+          - label_names:
+              - Service
+              - status
+              - command
+            regex: ".*memcached.*;hit;get"
+      - dimensions: [ [ Service, Namespace, ClusterName, command ] ]
+        metric_name_selectors:
+          - "^memcached_commands_total$"
+        label_matchers:
+          - label_names:
+              - Service
+              - command
+            regex: ".*memcached.*;(get|set)"
+service:
+  pipelines:
+    metrics:
+      receivers: [ prometheus ]
+      processors: [ resourcedetection/ec2, resource ]
+      exporters: [ awsemf ]

--- a/config/eks/prometheus/config-nginx.yaml
+++ b/config/eks/prometheus/config-nginx.yaml
@@ -1,0 +1,125 @@
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 1m
+        scrape_timeout: 10s
+      scrape_configs:
+        - job_name: kubernetes-service-endpoints
+          sample_limit: 10000
+          kubernetes_sd_configs:
+            - role: endpoints
+          relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (https?)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scheme
+              target_label: __scheme__
+            - action: replace
+              regex: (.+)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              source_labels:
+                - __address__
+                - __meta_kubernetes_service_annotation_prometheus_io_port
+              target_label: __address__
+            - source_labels: [ __address__ ]
+              target_label: exported_instance
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_service_name
+              target_label: Service
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_node_name
+              target_label: kubernetes_node
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_name
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'go_gc_duration_seconds.*'
+              action: drop
+            - regex: proxy
+              action: labeldrop
+
+processors:
+  resourcedetection/ec2:
+    detectors: [ env ]
+    timeout: 2s
+    override: false
+  resource:
+    attributes:
+      - key: TaskId
+        from_attribute: service.name
+        action: insert
+      - key: job
+        from_attribute: service.name
+        action: insert
+      - key: receiver
+        value: "prometheus"
+        action: insert
+  metricstransform:
+    transforms:
+      - include: ".*"
+        match_type: regexp
+        action: update
+        operations:
+          - label: exported_instance
+            new_label: instance
+            action: update_label
+
+exporters:
+  awsemf:
+    namespace: ContainerInsights/Prometheus
+    log_group_name: "/aws/containerinsights/{ClusterName}/prometheus"
+    log_stream_name: "{TaskId}"
+    resource_to_telemetry_conversion:
+      enabled: true
+    dimension_rollup_option: NoDimensionRollup
+    metric_declarations:
+      - dimensions: [ [ Service, Namespace, ClusterName ] ]
+        metric_name_selectors:
+          - "^nginx_ingress_controller_(requests|success)$"
+          - "^nginx_ingress_controller_nginx_process_connections$"
+          - "^nginx_ingress_controller_nginx_process_connections_total$"
+          - "^nginx_ingress_controller_nginx_process_resident_memory_bytes$"
+          - "^nginx_ingress_controller_nginx_process_cpu_seconds_total$"
+          - "^nginx_ingress_controller_config_last_reload_successful$"
+        label_matchers:
+          - label_names:
+              - Service
+            regex: ".*nginx.*"
+      - dimensions: [ [ Service, Namespace, ClusterName, ingress ],[ Service, Namespace, ClusterName, status ] ]
+        metric_name_selectors:
+          - "^nginx_ingress_controller_requests$"
+        label_matchers:
+          - label_names:
+              - Service
+            regex: ".*nginx.*"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [ prometheus ]
+      processors: [ resourcedetection/ec2, resource ]
+      exporters: [ awsemf ]

--- a/config/eks/prometheus/config-redis.yaml
+++ b/config/eks/prometheus/config-redis.yaml
@@ -1,0 +1,130 @@
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 1m
+        scrape_timeout: 10s
+      scrape_configs:
+        - job_name: kubernetes-service-endpoints
+          sample_limit: 10000
+          kubernetes_sd_configs:
+            - role: endpoints
+          relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (https?)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scheme
+              target_label: __scheme__
+            - action: replace
+              regex: (.+)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              source_labels:
+                - __address__
+                - __meta_kubernetes_service_annotation_prometheus_io_port
+              target_label: __address__
+            - source_labels: [ __address__ ]
+              target_label: exported_instance
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_namespace
+              target_label: Namespace
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_service_name
+              target_label: Service
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_node_name
+              target_label: kubernetes_node
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_name
+              target_label: pod_name
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container_name
+          metric_relabel_configs:
+            - source_labels: [ __name__ ]
+              regex: 'go_gc_duration_seconds.*'
+              action: drop
+            - regex: proxy
+              action: labeldrop
+
+processors:
+  resourcedetection/ec2:
+    detectors: [ env ]
+    timeout: 2s
+    override: false
+  resource:
+    attributes:
+      - key: TaskId
+        from_attribute: service.name
+        action: insert
+      - key: job
+        from_attribute: service.name
+        action: insert
+      - key: receiver
+        value: "prometheus"
+        action: insert
+  metricstransform:
+    transforms:
+      - include: ".*"
+        match_type: regexp
+        action: update
+        operations:
+          - label: exported_instance
+            new_label: instance
+            action: update_label
+
+exporters:
+  awsemf:
+    namespace: ContainerInsights/Prometheus
+    log_group_name: "/aws/containerinsights/{ClusterName}/prometheus"
+    log_stream_name: "{TaskId}"
+    resource_to_telemetry_conversion:
+      enabled: true
+    dimension_rollup_option: NoDimensionRollup
+    metric_declarations:
+      - dimensions: [ [ Namespace, ClusterName ] ]
+        metric_name_selectors:
+          - "^redis_net_(in|out)put_bytes_total$"
+          - "^redis_(expired|evicted)_keys_total$"
+          - "^redis_keyspace_(hits|misses)_total$"
+          - "^redis_memory_used_bytes$"
+          - "^redis_connected_clients$"
+        label_matchers:
+          - label_names:
+              - pod_name
+            regex: "^redis-instance$"
+      - dimensions: [ [ Namespace, ClusterName, cmd ] ]
+        metric_name_selectors:
+          - "^redis_commands_total$"
+        label_matchers:
+          - label_names:
+              - pod_name
+            regex: "^redis-instance$"
+      - dimensions: [ [ Namespace, ClusterName, db ] ]
+        metric_name_selectors:
+          - "^redis_db_keys$"
+        label_matchers:
+          - label_names:
+              - pod_name
+            regex: "^redis-instance$"
+service:
+  pipelines:
+    metrics:
+      receivers: [ prometheus ]
+      processors: [ resourcedetection/ec2, resource ]
+      exporters: [ awsemf ]

--- a/deployment-template/eks/standalone-otel-eks-deployment.yaml
+++ b/deployment-template/eks/standalone-otel-eks-deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aws-otel-eks
+  labels:
+    name: aws-otel-eks
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-otel-collector
+  namespace: aws-otel-eks
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-prometheus-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-prometheus-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-prometheus-role
+subjects:
+  - kind: ServiceAccount
+    name: aws-otel-collector
+    namespace: aws-otel-eks
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aws-otel-collector
+  namespace: aws-otel-eks
+  labels:
+    name: aws-otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: aws-otel-collector
+  template:
+    metadata:
+      labels:
+        name: aws-otel-collector
+    spec:
+      serviceAccountName: aws-otel-collector
+      containers:
+        - name: aws-otel-collector
+          image: amazon/aws-otel-collector:latest
+          command: [ "/awscollector" ]
+          args: [ "--config", "/etc/eks/prometheus/config-all.yaml" ]
+          env:
+            - name: AWS_REGION
+              value: {{region}}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: ClusterName={{cluster_name}}
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 256m
+              memory: 512Mi
+            requests:
+              cpu: 32m
+              memory: 24Mi

--- a/docs/developers/eks-prometheus-demo.md
+++ b/docs/developers/eks-prometheus-demo.md
@@ -1,0 +1,73 @@
+## Deploy AWS OTel Collector on Amazon EKS with Sample Workloads
+
+The tutorial shows you how to set up AWS OTel Collector on Amazon EKS
+with [sample workloads]((https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-Sample-Workloads.html))
+provided by Amazon CloudWatch
+
+### Set Up IAM Policies
+
+In order to allow AWS OTel Collector to send logs to CloudWatch, please ensure that the following policies exist on EKS node role.
+
+#### Create EKS-AWSOTel IAM Policy
+1. Open the IAM console at https://console.aws.amazon.com/iam/.
+2. In the navigation pane, choose **Policies**.
+3. Choose **Create policy, JSON**.
+4. Enter the following policy:
+```json
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Action": [
+				"logs:PutLogEvents",
+				"logs:CreateLogGroup",
+				"logs:CreateLogStream",
+				"logs:DescribeLogStreams",
+				"logs:DescribeLogGroups",
+				"xray:PutTraceSegments",
+				"xray:PutTelemetryRecords",
+				"xray:GetSamplingRules",
+				"xray:GetSamplingTargets",
+				"xray:GetSamplingStatisticSummaries",
+				"ssm:GetParameters"
+			],
+			"Resource": "*"
+		}
+	]
+}
+```
+5. Choose **Review policy**.
+6. On the Review policy page, enter `EKS-AWSOTel` for the Name and choose **Create policy**.
+
+#### Attach EKS-AWSOTel IAM Role to worker nodes
+1. Open the Amazon EC2 console at https://console.aws.amazon.com/ec2/.
+2. Select one of the worker node instances and choose the IAM role in the description.
+3. On the IAM role page, choose **Attach policies**.
+4. In the list of policies, select the check box next to `EKS-AWSOTel`. If necessary, use the search box to find this policy.
+5. Choose **Attach policies**.
+
+### Install AWS OTel Collector
+1. Set up variables to export metrics of your EKS cluster to the region where the logs should be published to.
+```
+export CLUSTER_NAME=<eks-cluster-name>
+export AWS_REGION=<aws-region>
+```
+2. Deploy a standalone AWS OTel collector application. An example config template can be found [here](../../deployment-template/eks/standalone-otel-eks-deployment.yaml).
+   * Replace `{{region}}` with the name of the region where the logs are published (e.g. `us-west-2`).
+   * Replace `{{cluster_name}}` with the actual eks cluster name.
+```bash
+cat standalone-otel-eks-deployment.yaml |
+sed "s/{{region}}/$AWS_REGION/g" | 
+sed "s/{{cluster_name}}/$CLUSTER_NAME/g" |
+kubectl apply -f - 
+```
+3. View the resources in the `aws-otel-eks` namespace.
+```bash
+kubectl get all -n aws-otel-eks
+```
+4. View Your Metrics  
+You should now be able to view your metrics in your [CloudWatch console](https://console.aws.amazon.com/cloudwatch/). In
+the navigation bar, click on **Metrics**. The collected AWSOTelCollector metrics can be found in the **
+AWSObservability/CloudWatchOTService** namespace. Ensure that your region is set to the region set for your cluster.
+

--- a/e2etest/get-testcases.py
+++ b/e2etest/get-testcases.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
         "redhat8", 
         "redhat7", 
         "centos7", 
-        "centos6", 
+        "centos6",
         "windows2019"
     ]}
     ec2_matrix_3 = {"testcase": [], "testing_ami": [
@@ -39,18 +39,20 @@ if __name__ == "__main__":
     negative_soaking_matrix = {"testcase": [], "testing_ami": ["soaking_linux", "soaking_windows"]}
     perf_matrix = {"testcase": [], "testing_ami": ["soaking_linux"], "data_rate": ["100", "1000", "5000"]}
     canary_matrix = {"testcase": [], "testing_ami": ["canary_linux", "canary_windows"]}
+    containerinsight_eks_prometheus_matrix = {"testcase": []}
 
     matrix = {
             "ec2_matrix_1": ec2_matrix_1, 
             "ec2_matrix_2": ec2_matrix_2,
             "ec2_matrix_3": ec2_matrix_3,
             "ecs_matrix": ecs_matrix,
-            "eks_matrix": eks_matrix, 
+            "eks_matrix": eks_matrix,
             "local_matrix": local_matrix,
             "soaking_matrix": soaking_matrix,
             "negative_soaking_matrix": negative_soaking_matrix,
             "perf_matrix": perf_matrix,
-            "canary_matrix": canary_matrix
+            "canary_matrix": canary_matrix,
+            "containerinsight_eks_prometheus_matrix": containerinsight_eks_prometheus_matrix
             }
 
     with open(testcase_json) as f:
@@ -63,7 +65,10 @@ if __name__ == "__main__":
             if 'ECS' in testcase["platforms"]:
                 ecs_matrix["testcase"].append(testcase["case_name"])
             if 'EKS' in testcase["platforms"]:
-                eks_matrix["testcase"].append(testcase["case_name"])
+                if 'module' in testcase and testcase["module"] == "containerinsight_prometheus":
+                    containerinsight_eks_prometheus_matrix["testcase"].append(testcase["case_name"])
+                else:
+                    eks_matrix["testcase"].append(testcase["case_name"])
             if 'LOCAL' in testcase["platforms"]:
                 local_matrix["testcase"].append(testcase["case_name"])
             if 'SOAKING' in testcase["platforms"]:

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -82,5 +82,10 @@
 	{
 		"case_name": "prometheus_sd",
 		"platforms": ["EKS"]
+	},
+	{
+		"case_name": "containerinsight_eks_prometheus",
+		"module": "containerinsight_prometheus",
+		"platforms": ["EKS"]
 	}
 ]


### PR DESCRIPTION
Why do we need it?
This is a follow-up PR of #393. This PR can be tested after https://github.com/aws-observability/aws-otel-test-framework/pull/260 is merged.

This PR adds configurations for demo workloads including AppMesh, HAProxy, Nginx, Java/Jmx, Memcached, and Redis. It also contains a one-for-all config to collect multiple resources in the cluster.

Metrics should show up automatically from the out-of-box container insight dashboard if user follows the official document and deploys the workloads properly.