### PR TITLE
Remove duplicated test case

### DIFF
--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -95,10 +95,5 @@
 	{
 		"case_name": "jaeger_mock",
 		"platforms": ["LOCAL", "EC2", "ECS", "EKS", "SOAKING"]
-	},
-	{
-		"case_name": "containerinsight_eks_prometheus",
-		"module": "containerinsight_prometheus",
-		"platforms": ["EKS"]
 	}
 ]


### PR DESCRIPTION
This PR removes an duplicated case that was mistakenly added in https://github.com/aws-observability/aws-otel-collector/pull/423