### PR TITLE
workflow: Enable patch for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,7 @@ env:
   ECR_REPO: aws/aws-otel-collector
   TF_VAR_aws_access_key_id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
   TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+  TF_VAR_patch: 'true'
   PKG_SIGN_PRIVATE_KEY_NAME: aoc-linux-pkg-signing-gpg-key
   WIN_UNSIGNED_PKG_BUCKET: aoc-aws-signer-unsigned-artifact-src
   WIN_SIGNED_PKG_BUCKET: aoc-aws-signer-signed-artifact-dest
@@ -37,7 +38,31 @@ env:
   WIN_SIGNED_PKG_FOLDER: OTelCollectorAuthenticode/AuthenticodeSigner-SHA256-RSA
 
 jobs:
+  build-aotutil:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out testing framework
+        uses: actions/checkout@v2
+        with:
+          repository: 'aws-observability/aws-otel-test-framework'
+          path: testing-framework
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.13
+      - name: Install Go tools
+        run: cd /tmp && go get -u golang.org/x/tools/cmd/goimports
+      - name: Build aotutil
+        run: cd testing-framework/cmd/aotutil && make build
+      - name: Cache aotutil
+        uses: actions/cache@v2
+        with:
+          key: "aotutil_${{ github.run_id }}"
+          path: testing-framework/cmd/aotutil/aotutil
+
   build:
+    needs:
+      - build-aotutil
     runs-on: ubuntu-latest
 
     steps:
@@ -484,6 +509,11 @@ jobs:
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
+      - name: Restore aoutil
+        uses: actions/cache@v2
+        with:
+          key: "aotutil_${{ github.run_id }}"
+          path: testing-framework/cmd/aotutil/aotutil
 
       - name: Run testing suite on ec2
         run: |
@@ -503,7 +533,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -524,6 +553,11 @@ jobs:
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
+      - name: Restore aoutil
+        uses: actions/cache@v2
+        with:
+          key: "aotutil_${{ github.run_id }}"
+          path: testing-framework/cmd/aotutil/aotutil
 
       - name: Run testing suite on ec2
         run: |
@@ -564,6 +598,11 @@ jobs:
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
+      - name: Restore aoutil
+        uses: actions/cache@v2
+        with:
+          key: "aotutil_${{ github.run_id }}"
+          path: testing-framework/cmd/aotutil/aotutil
 
       - name: Run testing suite on ec2
         run: |

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -23,11 +23,35 @@ on:
 env:
   TF_VAR_aws_access_key_id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
   TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+  TF_VAR_patch: 'true'
 
 jobs:
+  build-aotutil:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out testing framework
+        uses: actions/checkout@v2
+        with:
+          repository: 'aws-observability/aws-otel-test-framework'
+          path: testing-framework
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.13
+      - name: Install Go tools
+        run: cd /tmp && go get -u golang.org/x/tools/cmd/goimports
+      - name: Build aotutil
+        run: cd testing-framework/cmd/aotutil && make build
+      - name: Cache aotutil
+        uses: actions/cache@v2
+        with:
+          key: "aotutil_${{ github.run_id }}"
+          path: testing-framework/cmd/aotutil/aotutil
 
   get-canary-test-cases:
     runs-on: ubuntu-latest
+    needs:
+      - build-aotutil
     outputs:
       canary_matrix: ${{ steps.get-test-cases.outputs.canary_matrix }}
     steps:
@@ -71,6 +95,11 @@ jobs:
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
+      - name: Restore aoutil
+        uses: actions/cache@v2
+        with:
+          key: "aotutil_${{ github.run_id }}"
+          path: testing-framework/cmd/aotutil/aotutil
 
       - name: Run Canary test
         run: |

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -23,12 +23,37 @@ on:
         
 env:
   TF_VAR_aws_access_key_id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
-  TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }} 
+  TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+  TF_VAR_patch: 'true'
 
 jobs:
+  build-aotutil:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out testing framework
+        uses: actions/checkout@v2
+        with:
+          repository: 'aws-observability/aws-otel-test-framework'
+          path: testing-framework
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.13
+      - name: Install Go tools
+        run: cd /tmp && go get -u golang.org/x/tools/cmd/goimports
+      - name: Build aotutil
+        run: cd testing-framework/cmd/aotutil && make build
+      - name: Cache aotutil
+        uses: actions/cache@v2
+        with:
+          key: "aotutil_${{ github.run_id }}"
+          path: testing-framework/cmd/aotutil/aotutil
+
   get-testing-version:
     runs-on: ubuntu-latest
-    outputs: 
+    needs:
+      - build-aotutil
+    outputs:
       testing_version: ${{ steps.get-testing-version.outputs.testing_version }}
       commit_id: ${{ steps.get-testing-version.outputs.commit_id }}
     steps:
@@ -127,7 +152,12 @@ jobs:
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
-          
+      - name: Restore aoutil
+        uses: actions/cache@v2
+        with:
+          key: "aotutil_${{ github.run_id }}"
+          path: testing-framework/cmd/aotutil/aotutil
+
       - name: Run Soaking test
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
@@ -282,7 +312,12 @@ jobs:
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
-          
+      - name: Restore aoutil
+        uses: actions/cache@v2
+        with:
+          key: "aotutil_${{ github.run_id }}"
+          path: testing-framework/cmd/aotutil/aotutil
+
       - name: Run Soaking test
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi


### PR DESCRIPTION
**Description:**

For https://github.com/aws-observability/aws-otel-test-framework/issues/253 enable patch on all kind of tests.
Use aotutil instead of shell script to check patching status.

**Link to tracking Issue:** 

**Testing:** 

See https://github.com/aws-observability/aws-otel-test-framework/pull/269

**Documentation:**
