### PR TITLE
function name is in line with opentelemetry-lambda

### DIFF
--- a/pkg/lambdacomponents/defaults.go
+++ b/pkg/lambdacomponents/defaults.go
@@ -27,7 +27,7 @@
 	 "go.opentelemetry.io/collector/receiver/otlpreceiver"
  )
  
- // LambdaComponents returns a set of stripped components used by the
+ // Components returns a set of stripped components used by the
  // OpenTelemetry collector built for Lambda env.
  func Components() (
 	 component.Factories,

--- a/pkg/lambdacomponents/defaults.go
+++ b/pkg/lambdacomponents/defaults.go
@@ -29,7 +29,7 @@
  
  // LambdaComponents returns a set of stripped components used by the
  // OpenTelemetry collector built for Lambda env.
- func LambdaComponents() (
+ func Components() (
 	 component.Factories,
 	 error,
  ) {

--- a/pkg/lambdacomponents/defaults_test.go
+++ b/pkg/lambdacomponents/defaults_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestComponents(t *testing.T) {
-	factories, err := LambdaComponents()
+	factories, err := Components()
 	require.NoError(t, err)
 	exporters := factories.Exporters
 	// aws exporters


### PR DESCRIPTION
**Description:** 
Keep function name line with opentelemetry-lambda.
https://github.com/open-telemetry/opentelemetry-lambda/blob/main/collector/main.go#L24

**Testing:** 
```
❯ go test . -v
go: downloading go.opentelemetry.io/collector v0.19.0
go: downloading github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.19.0
go: downloading github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.19.0
go: downloading gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
go: downloading github.com/aws/aws-sdk-go v1.36.31
go: downloading github.com/orijtech/prometheus-go-metrics-exporter v0.0.6
go: downloading golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
go: downloading google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d
go: downloading google.golang.org/grpc v1.35.0
go: downloading github.com/jaegertracing/jaeger v1.21.0
go: downloading go.opencensus.io v0.22.5
go: downloading github.com/open-telemetry/opentelemetry-collector-contrib/internal/awsxray v0.19.0
go: downloading github.com/mitchellh/mapstructure v1.3.2
go: downloading github.com/prometheus/common v0.15.0
go: downloading golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e
go: downloading golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
go: downloading golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
=== RUN   TestComponents
--- PASS: TestComponents (0.00s)
```

