### PR TITLE
Add SSM build and speed up CI re-run

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,6 +98,13 @@ jobs:
         cat go.mod
         ls pkg
 
+    - name: Cache binaries
+      id: cached_binaries
+      uses: actions/cache@v2
+      with:
+        key: "cached_binaries_${{ github.run_id }}"
+        path: build
+
     # Unit Test and attach test coverage badge
     - name: Unit Test
       run: make test
@@ -109,13 +116,8 @@ jobs:
 
     # Build and archive binaries into cache.
     - name: Build Binaries
+      if: steps.cached_binaries.outputs.cache-hit != 'true'
       run: make build
-
-    - name: Cache binaries
-      uses: actions/cache@v2
-      with:
-        key: "cached_binaries_${{ github.run_id }}"
-        path: build
 
     # upload the binaries to artifact as well because cache@v2 hasn't support windows
     - name: Upload
@@ -214,7 +216,15 @@ jobs:
       # Build and archive rpms into cache.
       - uses: actions/checkout@v2
 
+      - name: Cache rpms
+        id: cached_rpms
+        uses: actions/cache@v2
+        with:
+          key: "cached_rpms_${{ github.run_id }}"
+          path: build/packages
+
       - name: restore cached binaries
+        if: steps.cached_rpms.outputs.cache-hit != 'true'
         uses: actions/cache@v2
         with:
           key: "cached_binaries_${{ github.run_id }}"
@@ -224,6 +234,7 @@ jobs:
         run: ls -R
 
       - name: Build RPM
+        if: steps.cached_rpms.outputs.cache-hit != 'true'
         run: |
           ARCH=x86_64 DEST=build/packages/linux/amd64 tools/packaging/linux/create_rpm.sh
           ARCH=aarch64 DEST=build/packages/linux/arm64 tools/packaging/linux/create_rpm.sh
@@ -255,12 +266,6 @@ jobs:
           gpg --fingerprint --with-colons aws-otel-collector@amazon.com grep "^fpr" | sed -n 's/^fpr:::::::::\([[:alnum:]]\+\):/\1/p' | xargs gpg --batch --yes --delete-secret-keys
           gpg --list-secret-keys
 
-      - name: Cache rpms
-        uses: actions/cache@v2
-        with:
-          key: "cached_rpms_${{ github.run_id }}"
-          path: build/packages
-
   packaging-deb:
     runs-on: ubuntu-latest
     needs: build
@@ -268,13 +273,22 @@ jobs:
       # Build and archive debs into cache.
       - uses: actions/checkout@v2
 
+      - name: Cache Debs
+        id: cached_debs
+        uses: actions/cache@v2
+        with:
+          key: "cached_debs_${{ github.run_id }}"
+          path: build/packages
+
       - name: restore cached binaries
+        if: steps.cached_debs.outputs.cache-hit != 'true'
         uses: actions/cache@v2
         with:
           key: "cached_binaries_${{ github.run_id }}"
           path: build
 
       - name: Build Debs
+        if: steps.cached_debs.outputs.cache-hit != 'true'
         run: |
           ARCH=amd64 TARGET_SUPPORTED_ARCH=x86_64 DEST=build/packages/debian/amd64 tools/packaging/debian/create_deb.sh
           ARCH=arm64 TARGET_SUPPORTED_ARCH=aarch64 DEST=build/packages/debian/arm64 tools/packaging/debian/create_deb.sh
@@ -303,12 +317,6 @@ jobs:
           gpg --fingerprint --with-colons aws-otel-collector@amazon.com grep "^fpr" | sed -n 's/^fpr:::::::::\([[:alnum:]]\+\):/\1/p' | xargs gpg --batch --yes --delete-secret-keys
           gpg --list-secret-keys
 
-      - name: Cache Debs
-        uses: actions/cache@v2
-        with:
-          key: "cached_debs_${{ github.run_id }}"
-          path: build/packages
-
   packaging-image:
     runs-on: ubuntu-latest
     needs: build
@@ -316,58 +324,124 @@ jobs:
       # Build and archive image into cache
       - uses: actions/checkout@v2
 
+      - name: Cache Image
+        id: cached_image
+        uses: actions/cache@v2
+        with:
+          key: "cached_image_${{ github.run_id }}"
+          path: "${{ env.PACKAGING_ROOT }}"
+
       - name: restore cached binaries
+        if: steps.cached_image.outputs.cache-hit != 'true'
         uses: actions/cache@v2
         with:
           key: "cached_binaries_${{ github.run_id }}"
           path: build
 
       - name: Build Image
+        if: steps.cached_image.outputs.cache-hit != 'true'
         run: docker build -t $IMAGE_NAME -f cmd/awscollector/Dockerfile .
 
       - name: Extract the Image file
+        if: steps.cached_image.outputs.cache-hit != 'true'
         run: |
           mkdir -p $PACKAGING_ROOT
           docker save --output $PACKAGING_ROOT/$IMAGE_NAME.tar $IMAGE_NAME
 
-      - name: Cache Image
-        uses: actions/cache@v2
-        with:
-          key: "cached_image_${{ github.run_id }}"
-          path: "${{ env.PACKAGING_ROOT }}"
-
-  e2etest-preparation:
+  packaging-ssm:
     runs-on: ubuntu-latest
-    needs: [packaging-rpm, packaging-deb, packaging-msi, packaging-image]
-    outputs:
-      version: ${{ steps.versioning.outputs.version }}
+    needs: [packaging-rpm, packaging-deb, packaging-msi]
     steps:
-      # Archive all the packages into one, and build a unique version number for e2etesting
+      # Build and archive SSM package into cache.
       - uses: actions/checkout@v2
 
+      - name: Cache SSM files
+        id: cached_ssm
+        uses: actions/cache@v2
+        with:
+          key: "cached_ssm_${{ github.run_id }}"
+          path: build/packages/ssm
+
       - name: Restore cached rpms
+        if: steps.cached_ssm.outputs.cache-hit != 'true'
         uses: actions/cache@v2
         with:
           key: "cached_rpms_${{ github.run_id }}"
           path: build/packages
 
       - name: Restore cached debs
+        if: steps.cached_ssm.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "cached_debs_${{ github.run_id }}"
+          path: build/packages
+
+      - name: Download built artifacts
+        if: steps.cached_ssm.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@v2
+        with:
+          name: msi_artifacts
+          path: build/packages
+
+      - run: ls -R
+
+      - name: Create zip file and manifest for SSM package
+        if: steps.cached_ssm.outputs.cache-hit != 'true'
+        run: |
+          # use a version with github run id as same as e2etest-preparation
+          rm -rf build/packages/ssm
+          python3 tools/ssm/ssm_manifest.py "`cat VERSION`-${{ github.run_id }}"
+
+  e2etest-preparation:
+    runs-on: ubuntu-latest
+    needs: [packaging-rpm, packaging-deb, packaging-msi, packaging-image, packaging-ssm]
+    outputs:
+      version: ${{ steps.versioning.outputs.version }}
+    steps:
+      # Archive all the packages into one, and build a unique version number for e2etesting
+      - uses: actions/checkout@v2
+
+      - name: Cache the packages
+        id: cached_packages
+        uses: actions/cache@v2
+        with:
+          key: "cached_packages_${{ github.run_id }}"
+          path: build/packages
+
+      - name: Restore cached rpms
+        if: steps.cached_packages.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "cached_rpms_${{ github.run_id }}"
+          path: build/packages
+
+      - name: Restore cached debs
+        if: steps.cached_packages.outputs.cache-hit != 'true'
         uses: actions/cache@v2
         with:
           key: "cached_debs_${{ github.run_id }}"
           path: build/packages
 
       - name: Restore cached image
+        if: steps.cached_packages.outputs.cache-hit != 'true'
         uses: actions/cache@v2
         with:
           key: "cached_image_${{ github.run_id }}"
           path: build/packages
 
       - name: Download built artifacts
+        if: steps.cached_packages.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v2
         with:
           name: msi_artifacts
           path: build/packages
+
+      - name: Restore cached ssm
+        if: steps.cached_packages.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "cached_ssm_${{ github.run_id }}"
+          path: build/packages/ssm
 
       - run: ls -R
 
@@ -385,12 +459,6 @@ jobs:
           cp .aoc-stack-test.yml build/packages/
           cp .aoc-stack-release.yml build/packages/
 
-      - name: Cache the packages
-        uses: actions/cache@v2
-        with:
-          key: "cached_packages_${{ github.run_id }}"
-          path: build/packages
-
   e2etest-release:
     runs-on: ubuntu-latest
     needs: [e2etest-preparation]
@@ -398,7 +466,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cache if success
+        id: e2etest-release
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: e2etest-release-${{ github.run_id }}
+
       - name: Configure AWS Credentials
+        if: steps.e2etest-release.outputs.cache-hit != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
@@ -406,19 +483,31 @@ jobs:
           aws-region: us-west-2
 
       - name: restore cached rpms
+        if: steps.e2etest-release.outputs.cache-hit != 'true'
         uses: actions/cache@v2
         with:
           path: build/packages
           key: "cached_packages_${{ github.run_id }}"
 
+      - name: Create SSM package
+        if: steps.e2etest-release.outputs.cache-hit != 'true'
+        run: |
+          ssm_pkg_version=`cat build/packages/VERSION`
+          ssm_pkg_version="${ssm_pkg_version:1}"
+          python3 tools/ssm/ssm_manifest.py ${ssm_pkg_version}
+          aws s3 cp build/packages/ssm s3://aws-otel-collector-test/ssm --recursive
+          bash tools/ssm/ssm_create.sh testAWSDistroOTel-Collector ${ssm_pkg_version} aws-otel-collector-test/ssm
+
       - name: upload to s3 in the testing stack
         run: s3_bucket_name=aws-otel-collector-test upload_to_latest=0 bash tools/release/s3-release.sh
 
       - name: Login ECR
+        if: steps.e2etest-release.outputs.cache-hit != 'true'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: upload to ECR
+        if: steps.e2etest-release.outputs.cache-hit != 'true'
         run: |
           docker load < build/packages/$IMAGE_NAME.tar
           docker tag $IMAGE_NAME ${{ steps.login-ecr.outputs.registry }}/$ECR_REPO:${{ needs.e2etest-preparation.outputs.version }}
@@ -483,13 +572,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, e2etest-release, e2etest-preparation]
     strategy:
+      fail-fast: false
       max-parallel: 5
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-1) }}
 
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cache if success
+        id: e2etest-ec2-1
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: e2etest-ec2-1-${{ github.run_id }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
+
       - name: Configure AWS Credentials
+        if: steps.e2etest-ec2-1.outputs.cache-hit != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
@@ -497,30 +596,36 @@ jobs:
           aws-region: us-west-2
 
       - name: Set up JDK 1.11
+        if: steps.e2etest-ec2-1.outputs.cache-hit != 'true'
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
 
       - name: Set up terraform
+        if: steps.e2etest-ec2-1.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v1
 
       - name: Check out testing framework
+        if: steps.e2etest-ec2-1.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
+
       - name: Restore aoutil
+        if: steps.e2etest-ec2-1.outputs.cache-hit != 'true'
         uses: actions/cache@v2
         with:
           key: "aotutil_${{ github.run_id }}"
           path: testing-framework/cmd/aotutil/aotutil
 
       - name: Run testing suite on ec2
+        if: steps.e2etest-ec2-1.outputs.cache-hit != 'true'
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
           cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}"
       - name: Destroy resources
-        if: ${{ always() }}
+        if: ${{ always() && steps.e2etest-ec2-1.outputs.cache-hit != 'true' }}
         run: |
           cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
 
@@ -528,12 +633,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, e2etest-release, e2etest-preparation]
     strategy:
+      fail-fast: false
       max-parallel: 5
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-2) }}
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Cache if success
+        id: e2etest-ec2-2
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: e2etest-ec2-2-${{ github.run_id }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
+
       - name: Configure AWS Credentials
+        if: steps.e2etest-ec2-2.outputs.cache-hit != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
@@ -541,30 +657,36 @@ jobs:
           aws-region: us-west-2
 
       - name: Set up JDK 1.11
+        if: steps.e2etest-ec2-2.outputs.cache-hit != 'true'
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
 
       - name: Set up terraform
+        if: steps.e2etest-ec2-2.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v1
 
       - name: Check out testing framework
+        if: steps.e2etest-ec2-2.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
+
       - name: Restore aoutil
+        if: steps.e2etest-ec2-2.outputs.cache-hit != 'true'
         uses: actions/cache@v2
         with:
           key: "aotutil_${{ github.run_id }}"
           path: testing-framework/cmd/aotutil/aotutil
 
       - name: Run testing suite on ec2
+        if: steps.e2etest-ec2-2.outputs.cache-hit != 'true'
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
           cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}"
       - name: Destroy resources
-        if: ${{ always() }}
+        if: ${{ always() && steps.e2etest-ec2-2.outputs.cache-hit != 'true'}}
         run: |
           cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
 
@@ -572,13 +694,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, e2etest-release, e2etest-preparation]
     strategy:
+      fail-fast: false
       max-parallel: 5
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-3) }}
 
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cache if success
+        id: e2etest-ec2-3
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: e2etest-ec2-3-${{ github.run_id }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
+
       - name: Configure AWS Credentials
+        if: steps.e2etest-ec2-3.outputs.cache-hit != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
@@ -586,30 +718,37 @@ jobs:
           aws-region: us-west-2
 
       - name: Set up JDK 1.11
+        if: steps.e2etest-ec2-3.outputs.cache-hit != 'true'
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
 
       - name: Set up terraform
+        if: steps.e2etest-ec2-3.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v1
 
       - name: Check out testing framework
+        if: steps.e2etest-ec2-3.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
+
       - name: Restore aoutil
+        if: steps.e2etest-ec2-3.outputs.cache-hit != 'true'
         uses: actions/cache@v2
         with:
           key: "aotutil_${{ github.run_id }}"
           path: testing-framework/cmd/aotutil/aotutil
 
       - name: Run testing suite on ec2
+        if: steps.e2etest-ec2-3.outputs.cache-hit != 'true'
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
           cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}"
+
       - name: Destroy resources
-        if: ${{ always() }}
+        if: ${{ always() && steps.e2etest-ec2-3.outputs.cache-hit != 'true' }}
         run: |
           cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
 
@@ -617,13 +756,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, e2etest-release, e2etest-preparation]
     strategy:
+      fail-fast: false
       max-parallel: 5
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.ecs-matrix) }}
 
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cache if success
+        id: e2etest-ecs
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: e2etest-ecs-${{ github.run_id }}-${{ matrix.testcase }}-${{ matrix.launch_type }}
+
       - name: Configure AWS Credentials
+        if: steps.e2etest-ecs.outputs.cache-hit != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
@@ -631,26 +780,30 @@ jobs:
           aws-region: us-west-2
 
       - name: Set up JDK 1.11
+        if: steps.e2etest-ecs.outputs.cache-hit != 'true'
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
 
       - name: Set up terraform
+        if: steps.e2etest-ecs.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v1
 
       - name: Check out testing framework
+        if: steps.e2etest-ecs.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
 
       - name: Run testing suite on ecs
+        if: steps.e2etest-ecs.outputs.cache-hit != 'true'
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
           cd testing-framework/terraform/ecs && terraform init && terraform apply -auto-approve -lock=false $opts -var="ecs_launch_type=${{ matrix.launch_type }}" -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}"
 
       - name: Destroy resources
-        if: ${{ always() }}
+        if: ${{ always() && steps.e2etest-ecs.outputs.cache-hit != 'true' }}
         run: |
           cd testing-framework/terraform/ecs && terraform destroy -auto-approve
 
@@ -658,13 +811,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, e2etest-release, e2etest-preparation]
     strategy:
+      fail-fast: false
       max-parallel: 5
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.eks-matrix) }}
 
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cache if success
+        id: e2etest-eks
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: e2etest-ec2-1-${{ github.run_id }}-${{ matrix.testcase }}
+
       - name: Configure AWS Credentials
+        if: steps.e2etest-eks.outputs.cache-hit != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
@@ -672,26 +835,30 @@ jobs:
           aws-region: us-west-2
 
       - name: Set up JDK 1.11
+        if: steps.e2etest-eks.outputs.cache-hit != 'true'
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
 
       - name: Set up terraform
+        if: steps.e2etest-eks.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v1
 
       - name: Check out testing framework
+        if: steps.e2etest-eks.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
 
       - name: Run testing suite on eks
+        if: steps.e2etest-eks.outputs.cache-hit != 'true'
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
           cd testing-framework/terraform/eks && terraform init && terraform apply -auto-approve -lock=false $opts -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}"
 
       - name: Destroy resources
-        if: ${{ always() }}
+        if: ${{ always() && steps.e2etest-eks.outputs.cache-hit != 'true' }}
         run: |
           cd testing-framework/terraform/eks && terraform destroy -auto-approve
 
@@ -699,13 +866,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ get-testing-suites, e2etest-release, e2etest-preparation ]
     strategy:
+      fail-fast: false
       max-parallel: 5
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.containerinsight-eks-prometheus-matrix) }}
 
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cache if success
+        id: e2etest-containerinsight-eks-prometheus
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: e2etest-containerinsight-eks-prometheus-${{ github.run_id }}-${{ matrix.testcase }}
+
       - name: Configure AWS Credentials
+        if: steps.e2etest-containerinsight-eks-prometheus.outputs.cache-hit != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
@@ -713,26 +890,30 @@ jobs:
           aws-region: us-west-2
 
       - name: Set up JDK 1.11
+        if: steps.e2etest-containerinsight-eks-prometheus.outputs.cache-hit != 'true'
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
 
       - name: Set up terraform
+        if: steps.e2etest-containerinsight-eks-prometheus.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v1
 
       - name: Check out testing framework
+        if: steps.e2etest-containerinsight-eks-prometheus.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
 
       - name: Run testing suite on eks
+        if: steps.e2etest-containerinsight-eks-prometheus.outputs.cache-hit != 'true'
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
           cd testing-framework/terraform/containerinsight_eks_prometheus && terraform init && terraform apply -auto-approve -lock=false $opts -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}"
 
       - name: Destroy resources
-        if: ${{ always() }}
+        if: ${{ always() && steps.e2etest-containerinsight-eks-prometheus.outputs.cache-hit != 'true' }}
         run: |
           cd testing-framework/terraform/containerinsight_eks_prometheus && terraform destroy -auto-approve
 

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -95,5 +95,9 @@
 	{
 		"case_name": "jaeger_mock",
 		"platforms": ["LOCAL", "EC2", "ECS", "EKS", "SOAKING"]
+	},
+	{
+		"case_name": "ssm_package",
+		"platforms": ["EC2"]
 	}
 ]

--- a/tools/ssm/linux-amd64-deb/install.sh
+++ b/tools/ssm/linux-amd64-deb/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/tools/ssm/linux-amd64-deb/install.sh
+++ b/tools/ssm/linux-amd64-deb/install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -e
+set -u
+
+echo 'Installing AWSDistroOTel-Collector.'
+
+dpkg -i -E ./aws-otel-collector.deb
+
+readonly cmd='/opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl'
+readonly conf='/opt/aws/aws-otel-collector/etc/config.yaml'
+
+echo ${SSM_CONFIG} | base64 -d > ${conf}
+
+"${cmd}" -a start
+

--- a/tools/ssm/linux-amd64-deb/uninstall.sh
+++ b/tools/ssm/linux-amd64-deb/uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/tools/ssm/linux-amd64-deb/uninstall.sh
+++ b/tools/ssm/linux-amd64-deb/uninstall.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -e
+set -u
+
+echo 'Uninstalling AWSDistroOTel-Collector.'
+
+readonly cmd='/opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl'
+if [ -x "${cmd}" ]; then
+    "${cmd}" -a stop
+fi
+
+dpkg -r aws-otel-collector

--- a/tools/ssm/linux-amd64-rpm/install.sh
+++ b/tools/ssm/linux-amd64-rpm/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/tools/ssm/linux-amd64-rpm/install.sh
+++ b/tools/ssm/linux-amd64-rpm/install.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -e
+set -u
+
+echo 'Installing AWSDistroOTel-Collector.'
+
+rpm -U --force ./aws-otel-collector.rpm
+
+readonly cmd='/opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl'
+readonly conf='/opt/aws/aws-otel-collector/etc/config.yaml'
+
+echo ${SSM_CONFIG} | base64 -d > ${conf}
+
+"${cmd}" -a start

--- a/tools/ssm/linux-amd64-rpm/uninstall.sh
+++ b/tools/ssm/linux-amd64-rpm/uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/tools/ssm/linux-amd64-rpm/uninstall.sh
+++ b/tools/ssm/linux-amd64-rpm/uninstall.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -e
+set -u
+
+echo 'Uninstalling AWSDistroOTel-Collector.'
+
+readonly cmd='/opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl'
+if [ -x "${cmd}" ]; then
+    "${cmd}" -a stop
+fi
+
+rpm -e aws-otel-collector

--- a/tools/ssm/linux-arm64-deb/install.sh
+++ b/tools/ssm/linux-arm64-deb/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/tools/ssm/linux-arm64-deb/install.sh
+++ b/tools/ssm/linux-arm64-deb/install.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -e
+set -u
+
+echo 'Installing AWSDistroOTel-Collector.'
+
+dpkg -i -E ./aws-otel-collector.deb
+
+readonly cmd='/opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl'
+readonly conf='/opt/aws/aws-otel-collector/etc/config.yaml'
+
+echo ${SSM_CONFIG} | base64 -d > ${conf}
+
+"${cmd}" -a start

--- a/tools/ssm/linux-arm64-deb/uninstall.sh
+++ b/tools/ssm/linux-arm64-deb/uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/tools/ssm/linux-arm64-deb/uninstall.sh
+++ b/tools/ssm/linux-arm64-deb/uninstall.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -e
+set -u
+
+echo 'Uninstalling AWSDistroOTel-Collector.'
+
+readonly cmd='/opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl'
+if [ -x "${cmd}" ]; then
+    "${cmd}" -a stop
+fi
+
+dpkg -r aws-otel-collector

--- a/tools/ssm/linux-arm64-rpm/install.sh
+++ b/tools/ssm/linux-arm64-rpm/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/tools/ssm/linux-arm64-rpm/install.sh
+++ b/tools/ssm/linux-arm64-rpm/install.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -e
+set -u
+
+echo 'Installing AWSDistroOTel-Collector.'
+
+rpm -U --force ./aws-otel-collector.rpm
+
+readonly cmd='/opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl'
+readonly conf='/opt/aws/aws-otel-collector/etc/config.yaml'
+
+echo ${SSM_CONFIG} | base64 -d > ${conf}
+
+"${cmd}" -a start

--- a/tools/ssm/linux-arm64-rpm/uninstall.sh
+++ b/tools/ssm/linux-arm64-rpm/uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/tools/ssm/linux-arm64-rpm/uninstall.sh
+++ b/tools/ssm/linux-arm64-rpm/uninstall.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -e
+set -u
+
+echo 'Uninstalling AWSDistroOTel-Collector.'
+
+readonly cmd='/opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl'
+if [ -x "${cmd}" ]; then
+    "${cmd}" -a stop
+fi
+
+rpm -e aws-otel-collector

--- a/tools/ssm/ssm_create.sh
+++ b/tools/ssm/ssm_create.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/tools/ssm/ssm_create.sh
+++ b/tools/ssm/ssm_create.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -eu
+
+PKG_NAME=$1
+REL_VERSION=$2
+S3_BUCKET=$3
+
+output=$(aws ssm list-documents --filter Key=Owner,Values=Self Key=DocumentType,Values=Package Key=Name,Values=${PKG_NAME})
+echo ${output}
+status=$(echo ${output} | python3 -c "import sys, json; print('empty') if len(json.load(sys.stdin)['DocumentIdentifiers']) == 0 else print('exist')")
+if [[ ${status} == "empty" ]]
+then
+    aws ssm create-document \
+        --name "${PKG_NAME}" \
+        --content file://build/packages/ssm/manifest.json \
+        --attachments Key="SourceUrl",Values="https://s3.amazonaws.com/${S3_BUCKET}" \
+        --version-name ${REL_VERSION} \
+        --document-type Package
+else
+    output=$(aws ssm update-document \
+        --name "${PKG_NAME}" \
+        --content file://build/packages/ssm/manifest.json \
+        --attachments Key="SourceUrl",Values="https://s3.amazonaws.com/${S3_BUCKET}" \
+        --version-name ${REL_VERSION} \
+        --document-version "\$LATEST")
+
+    echo ${output}
+    last_version=$(echo ${output} | python3 -c "import sys, json; print(json.load(sys.stdin)['DocumentDescription']['LatestVersion'])")
+    echo ${last_version}
+
+    aws ssm update-document-default-version \
+        --name "${PKG_NAME}" \
+        --document-version "${last_version}"
+fi

--- a/tools/ssm/ssm_manifest.py
+++ b/tools/ssm/ssm_manifest.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import os
+import json
+import sys
+import zipfile
+import hashlib
+import shutil
+
+
+def buildssmpkg(pkg_version, ssm_base, ssm_files, ssm_installers, output_dir):
+    if not os.path.exists(output_dir):
+        os.mkdir(output_dir)
+    file_hash = {}
+    for ssm_file in ssm_files.keys():
+        zip_file = output_dir + "/" + ssm_file + ".zip"
+        ssm_file_path = ssm_base + "/" + ssm_file
+        if not os.path.isfile(zip_file):
+            shutil.copy(ssm_files[ssm_file], ssm_file_path)
+            zf = zipfile.ZipFile(zip_file, mode="w")
+            file_list = os.listdir(ssm_file_path)
+            for file in file_list:
+                zf.write(ssm_file_path + "/" + file, file)
+            zf.close()
+        sha256 = hashlib.sha256()
+        with open(zip_file, "rb") as f:
+            for chunk in iter(lambda: f.read(4096), b""):
+                sha256.update(chunk)
+            file_hash[ssm_file] = sha256.hexdigest()
+    ssm_sha256_list = {}
+    for ssm_file in ssm_files.keys():
+        ssm_file_zip = ssm_base + "/" + ssm_file + ".zip"
+        ssm_sha256_list[ssm_file + ".zip"] = {
+            "checksums": {"sha256": file_hash[ssm_file]}
+        }
+    manifest = {
+        "schemaVersion": "2.0",
+        "version": pkg_version,
+        "packages": ssm_installers,
+        "files": ssm_sha256_list,
+    }
+    print(json.dumps(manifest))
+    with open(output + "/manifest.json", "w") as f:
+        json.dump(manifest, f)
+    return manifest
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: %s version [base] [build] [output]" % sys.argv[0])
+        sys.exit()
+    aoc_pkg_ver = sys.argv[1]
+    if aoc_pkg_ver.startswith("v"):
+        aoc_pkg_ver = aoc_pkg_ver[1:]
+    if len(sys.argv) < 3:
+        base = "tools/ssm"
+    else:
+        base = sys.argv[2]
+    if len(sys.argv) < 4:
+        build = "build"
+    else:
+        build = sys.argv[3]
+    if len(sys.argv) < 5:
+        output = "build/packages/ssm"
+    else:
+        output = sys.argv[4]
+
+    aoc_files = {
+        "linux-amd64-rpm": build + "/packages/linux/amd64/aws-otel-collector.rpm",
+        "linux-arm64-rpm": build + "/packages/linux/arm64/aws-otel-collector.rpm",
+        "linux-amd64-deb": build + "/packages/debian/amd64/aws-otel-collector.deb",
+        "linux-arm64-deb": build + "/packages/debian/arm64/aws-otel-collector.deb",
+        "windows-amd64-msi": build + "/packages/windows/amd64/aws-otel-collector.msi",
+    }
+    aoc_installers = {
+        "windows": {"_any": {"x86_64": {"file": "windows-amd64-msi.zip"}}},
+        "amazon": {
+            "_any": {
+                "x86_64": {"file": "linux-amd64-rpm.zip"},
+                "arm64": {"file": "linux-arm64-rpm.zip"},
+            }
+        },
+        "ubuntu": {
+            "_any": {
+                "x86_64": {"file": "linux-amd64-deb.zip"},
+                "arm64": {"file": "linux-arm64-deb.zip"},
+            }
+        },
+        "debian": {"_any": {"x86_64": {"file": "linux-amd64-deb.zip"}}},
+        "redhat": {
+            "_any": {
+                "x86_64": {"file": "linux-amd64-rpm.zip"},
+                "arm64": {"file": "linux-arm64-rpm.zip"},
+            }
+        },
+        "centos": {"_any": {"x86_64": {"file": "linux-amd64-rpm.zip"}}},
+        "suse": {
+            "_any": {
+                "x86_64": {"file": "linux-amd64-rpm.zip"},
+                "arm64": {"file": "linux-arm64-rpm.zip"},
+            }
+        },
+    }
+    buildssmpkg(aoc_pkg_ver, base, aoc_files, aoc_installers, output)

--- a/tools/ssm/windows-amd64-msi/install.ps1
+++ b/tools/ssm/windows-amd64-msi/install.ps1
@@ -1,0 +1,27 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+Write-Output 'Installing AWSDistroOTel-Collector.'
+Start-Process msiexec.exe -Wait -ArgumentList '/i aws-otel-collector.msi'
+
+$Cmd = "${Env:ProgramFiles}\Amazon\AWSOTelCollector\aws-otel-collector-ctl.ps1"
+$Conf = "${Env:ProgramFiles}\Amazon\AWSOTelCollector\config.yaml"
+
+$config = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Env:SSM_CONFIG))
+$Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+[System.IO.File]::WriteAllLines($Conf, $config, $Utf8NoBomEncoding)
+
+& "${Cmd}" -a start

--- a/tools/ssm/windows-amd64-msi/uninstall.ps1
+++ b/tools/ssm/windows-amd64-msi/uninstall.ps1
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+Write-Output 'Uninstalling AWSDistroOTel-Collector.'
+
+$Cmd = "${Env:ProgramFiles}\Amazon\AWSOTelCollector\aws-otel-collector-ctl.ps1"
+
+if (Test-Path -LiteralPath "${Cmd}" -PathType Leaf) {
+    & "${Cmd}" -a stop
+}
+
+[System.Management.ManagementObject[]] $agents = Get-WmiObject -Class Win32_Product -ComputerName . -Filter "Name='AWS OTel Collector'"
+
+if($agents) {
+    for ($i = 0; $i -lt @($agents).Count; $i ++) {
+        @($agents)[$i].Uninstall()
+    }
+}


### PR DESCRIPTION
**Description:**
Create and test ADOT Collector SSM package in CI workflow.
Make CI re-run faster by using cache hit flag to skip successful jobs.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>
