### PR TITLE
Fix incorrect variable setting in terraform destroy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -938,7 +938,7 @@ jobs:
       - name: Destroy resources
         if: ${{ always() && steps.e2etest-containerinsight-eks-prometheus.outputs.cache-hit != 'true' }}
         run: |
-          cd testing-framework/terraform/containerinsight_eks_prometheus && terraform destroy -auto-approve
+          cd testing-framework/terraform/containerinsight_eks_prometheus && terraform destroy -var="testcase=../testcases/${{ matrix.testcase }}" -auto-approve
 
 
   release-candidate:


### PR DESCRIPTION
In the recent integration tests, container insights prometheus fails frequently with error:
```
│ Error: Invalid function argument
│ 
│   on nginx/nginx.tf line 88, in data "template_file" "traffic_deployment_file":
│   88:   template = file("${var.testcase}/nginx_traffic_sample.tpl")
│     ├────────────────
│     │ var.testcase is "../testcases/otlp_mock"
│ 
│ Invalid value for "path" parameter: no file exists at
```

This PR sets testcase to the correct folder with `terraform destroy`, though it worked quite well without explicit config...