### PR TITLE
bug fix for container insight

### DIFF
--- a/deployment-template/eks/eks-ci-daemonset.yaml
+++ b/deployment-template/eks/eks-ci-daemonset.yaml
@@ -1,0 +1,252 @@
+# create namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aws-otel-eks
+  labels:
+    name: aws-otel-eks
+
+---
+# create aoc-agent service account and role binding
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-otel-sa
+  namespace: aws-otel-eks
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aoc-agent-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "endpoints"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["nodes/stats", "configmaps", "events"]
+    verbs: ["create", "get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["aoc-clusterleader"]
+    verbs: ["get","update"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aoc-agent-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: aws-otel-sa
+    namespace: aws-otel-eks
+roleRef:
+  kind: ClusterRole
+  name: aoc-agent-role
+  apiGroup: rbac.authorization.k8s.io
+
+
+# create config map for aoc agent
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-agent-conf
+  namespace: aws-otel-eks
+  labels:
+    app: opentelemetry
+    component: otel-agent-conf
+data:
+  otel-agent-config: |
+    extensions:
+      health_check:
+
+    receivers:
+      awscontainerinsightreceiver:
+
+    processors:
+      awscontainerinsightprocessor:
+      batch/metrics:
+        timeout: 60s
+
+    exporters:
+      awsemf:
+        namespace: ContainerInsights
+        log_group_name: '/aws/containerinsights/{ClusterName}/performance'
+        log_stream_name: '{NodeName}'
+        resource_to_telemetry_conversion:
+          enabled: true
+        dimension_rollup_option: NoDimensionRollup
+        parse_json_encoded_attr_values: [Sources, kubernetes]
+        metric_declarations:
+          # node metrics
+          - dimensions: [[NodeName, InstanceId, ClusterName]]
+            metric_name_selectors:
+              - node_cpu_utilization
+              - node_memory_utilization
+              - node_network_total_bytes
+              - node_cpu_reserved_capacity
+              - node_memory_reserved_capacity
+              - node_number_of_running_pods
+              - node_number_of_running_containers
+          - dimensions: [[ClusterName]]
+            metric_name_selectors:
+              - node_cpu_utilization
+              - node_memory_utilization
+              - node_network_total_bytes
+              - node_cpu_reserved_capacity
+              - node_memory_reserved_capacity
+              - node_number_of_running_pods
+              - node_number_of_running_containers
+              - node_cpu_usage_total
+              - node_cpu_limit
+              - node_memory_working_set
+              - node_memory_limit
+
+          # pod metrics
+          - dimensions: [[PodName, Namespace, ClusterName], [Service, Namespace, ClusterName], [Namespace, ClusterName], [ClusterName]]
+            metric_name_selectors:
+              - pod_cpu_utilization
+              - pod_memory_utilization
+              - pod_network_rx_bytes
+              - pod_network_tx_bytes
+              - pod_cpu_utilization_over_pod_limit
+              - pod_memory_utilization_over_pod_limit
+          - dimensions: [[PodName, Namespace, ClusterName], [ClusterName]]
+            metric_name_selectors:
+              - pod_cpu_reserved_capacity
+              - pod_memory_reserved_capacity
+          - dimensions: [[PodName, Namespace, ClusterName]]
+            metric_name_selectors:
+              - pod_number_of_container_restarts
+
+          # cluster metrics
+          - dimensions: [[ClusterName]]
+            metric_name_selectors:
+              - cluster_node_count
+              - cluster_failed_node_count
+
+          # service metrics
+          - dimensions: [[Service, Namespace, ClusterName], [ClusterName]]
+            metric_name_selectors:
+              - service_number_of_running_pods
+
+          # node fs metrics
+          - dimensions: [[NodeName, InstanceId, ClusterName], [ClusterName]]
+            metric_name_selectors:
+              - node_filesystem_utilization
+
+          # namespace metrics
+          - dimensions: [[Namespace, ClusterName], [ClusterName]]
+            metric_name_selectors:
+              - namespace_number_of_running_pods
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [awscontainerinsightreceiver]
+          processors: [awscontainerinsightprocessor, batch/metrics]
+          exporters: [awsemf]
+
+      extensions: [health_check]
+
+
+---
+# create Daemonset
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aws-otel-eks-ci
+  namespace: aws-otel-eks
+spec:
+  selector:
+    matchLabels:
+      name: aws-otel-eks-ci
+  template:
+    metadata:
+      labels:
+        name: aws-otel-eks-ci
+    spec:
+      containers:
+        - name: aws-otel-collector
+          image: amazon/aws-otel-collector:latest
+          env:
+            - name: AWS_REGION
+              value: {{region}}
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_NAMESPACE
+              valueFrom:
+                 fieldRef:
+                   fieldPath: metadata.namespace
+          imagePullPolicy: Always
+          command:
+            - "/awscollector"
+            - "--config=/conf/otel-agent-config.yaml"
+          volumeMounts:
+            - name: rootfs
+              mountPath: /rootfs
+              readOnly: true
+            - name: dockersock
+              mountPath: /var/run/docker.sock
+              readOnly: true
+            - name: varlibdocker
+              mountPath: /var/lib/docker
+              readOnly: true
+            - name: sys
+              mountPath: /sys
+              readOnly: true
+            - name: devdisk
+              mountPath: /dev/disk
+              readOnly: true
+            - name: otel-agent-config-vol
+              mountPath: /conf
+          resources:
+            limits:
+              cpu:  200m
+              memory: 200Mi
+            requests:
+              cpu: 200m
+              memory: 200Mi
+      volumes:
+        - configMap:
+            name: otel-agent-conf
+            items:
+              - key: otel-agent-config
+                path: otel-agent-config.yaml
+          name: otel-agent-config-vol
+        - name: rootfs
+          hostPath:
+            path: /
+        - name: dockersock
+          hostPath:
+            path: /var/run/docker.sock
+        - name: varlibdocker
+          hostPath:
+            path: /var/lib/docker
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: devdisk
+          hostPath:
+            path: /dev/disk/
+      serviceAccountName: aws-otel-sa

--- a/internal/aws/containerinsightcommon/k8sconst.go
+++ b/internal/aws/containerinsightcommon/k8sconst.go
@@ -15,13 +15,6 @@ const (
 	ContainerIdkey   = "ContainerId"
 	PodOwnersKey     = "PodOwners"
 
-	RunningPodCount       = "number_of_running_pods"
-	RunningContainerCount = "number_of_running_containers"
-	ContainerCount        = "number_of_containers"
-	NodeCount             = "node_count"
-	FailedNodeCount       = "failed_node_count"
-	ContainerRestartCount = "number_of_container_restarts"
-
 	PodStatus       = "pod_status"
 	ContainerStatus = "container_status"
 

--- a/internal/processor/awscontainerinsightprocessor/stores/podstore.go
+++ b/internal/processor/awscontainerinsightprocessor/stores/podstore.go
@@ -338,7 +338,7 @@ func (p *PodStore) decorateMem(metric pdata.ResourceMetrics, attributes pdata.At
 
 			if p.nodeInfo.getMemCapacity() != 0 {
 				if podMemReq != 0 {
-					addMetric(MetricName(TypePod, MemReservedCapacity), float64(podMemReq)/float64(p.nodeInfo.getMemCapacity())*100, UnitBytes, metric)
+					addMetric(MetricName(TypePod, MemReservedCapacity), float64(podMemReq)/float64(p.nodeInfo.getMemCapacity())*100, UnitPercent, metric)
 				}
 			}
 

--- a/internal/processor/awscontainerinsightprocessor/structuredlogsadapter/utils.go
+++ b/internal/processor/awscontainerinsightprocessor/structuredlogsadapter/utils.go
@@ -50,7 +50,12 @@ func TagMetricSource(attributes pdata.AttributeMap) {
 func AddKubernetesInfo(attributes pdata.AttributeMap, kubernetesBlob map[string]interface{}) {
 	needMoveToKubernetes := map[string]string{common.ContainerNamekey: "container_name", common.K8sPodNameKey: "pod_name",
 		common.PodIdKey: "pod_id"}
+
 	needCopyToKubernetes := map[string]string{common.K8sNamespace: "namespace_name", common.TypeService: "service_name", common.NodeNameKey: "host"}
+	metricType := stores.GetStringValFromAttributes(common.MetricType, attributes)
+	if metricType == common.TypeClusterNamespace || metricType == common.TypeClusterService {
+		delete(needCopyToKubernetes, common.NodeNameKey)
+	}
 
 	for k, v := range needMoveToKubernetes {
 		if attVal := stores.GetStringValFromAttributes(k, attributes); attVal != "" {

--- a/internal/receiver/awscontainerinsightreceiver/cadvisor/cadvisor_nolinux.go
+++ b/internal/receiver/awscontainerinsightreceiver/cadvisor/cadvisor_nolinux.go
@@ -4,6 +4,7 @@ package cadvisor
 
 import (
 	"github.com/aws-observability/aws-otel-collector/internal/receiver/awscontainerinsightreceiver/cadvisor/extractors"
+	"github.com/aws-observability/aws-otel-collector/internal/receiver/awscontainerinsightreceiver/host"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/zap"
 )
@@ -13,7 +14,7 @@ import (
 type Cadvisor struct {
 }
 
-func New(containerOrchestrator string, logger *zap.Logger) *Cadvisor {
+func New(containerOrchestrator string, machineInfo *host.MachineInfo, logger *zap.Logger) *Cadvisor {
 	return nil
 }
 

--- a/internal/receiver/awscontainerinsightreceiver/cadvisor/extractors/extractor.go
+++ b/internal/receiver/awscontainerinsightreceiver/cadvisor/extractors/extractor.go
@@ -26,8 +26,8 @@ func GetStats(info *cinfo.ContainerInfo) *cinfo.ContainerStats {
 }
 
 type MachineInfoProvider interface {
-	GetNumCores() int
-	GetMemoryCapacity() uint64
+	GetNumCores() int64
+	GetMemoryCapacity() int64
 }
 
 type MetricExtractor interface {
@@ -85,7 +85,7 @@ func (c *CAdvisorMetric) Merge(src *CAdvisorMetric) {
 func newFloat64RateCalculator() aws.MetricCalculator {
 	return aws.NewMetricCalculator(func(prev *aws.MetricValue, val interface{}, timestamp time.Time) (interface{}, bool) {
 		if prev != nil {
-			deltaNs := timestamp.Sub(prev.Timestamp).Nanoseconds()
+			deltaNs := timestamp.Sub(prev.Timestamp)
 			deltaValue := val.(float64) - prev.RawValue.(float64)
 			if deltaNs > common.MinTimeDiff && deltaValue >= 0 {
 				return deltaValue / float64(deltaNs), true

--- a/internal/receiver/awscontainerinsightreceiver/cadvisor/extractors/extractor_utils_for_test.go
+++ b/internal/receiver/awscontainerinsightreceiver/cadvisor/extractors/extractor_utils_for_test.go
@@ -129,10 +129,10 @@ func AssertContainsTaggedField(
 type MockMachineInfo struct {
 }
 
-func (m MockMachineInfo) GetNumCores() int {
+func (m MockMachineInfo) GetNumCores() int64 {
 	return 2
 }
 
-func (m MockMachineInfo) GetMemoryCapacity() uint64 {
+func (m MockMachineInfo) GetMemoryCapacity() int64 {
 	return 1073741824
 }

--- a/internal/receiver/awscontainerinsightreceiver/go.mod
+++ b/internal/receiver/awscontainerinsightreceiver/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/ginkgo v1.14.1 // indirect
 	github.com/onsi/gomega v1.10.2 // indirect
 	github.com/pelletier/go-toml v1.8.0 // indirect
+	github.com/shirou/gopsutil v3.21.3+incompatible
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.24.0
 	go.uber.org/zap v1.16.0

--- a/internal/receiver/awscontainerinsightreceiver/go.sum
+++ b/internal/receiver/awscontainerinsightreceiver/go.sum
@@ -79,6 +79,7 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/sarama v1.22.2-0.20190604114437-cd910a683f9f/go.mod h1:XLH1GYJnLVE0XCr6KdJGVJRTwY30moWNJ4sERjXX6fs=
 github.com/Shopify/sarama v1.28.0/go.mod h1:j/2xTrU39dlzBmsxF1eQ2/DdWrxyBCl6pzz7a81o/ZY=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
+github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 h1:5sXbqlSomvdjlRbWyNqkPsJ3Fg+tQZCbgeX1VGljbQY=
 github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
@@ -273,6 +274,7 @@ github.com/go-logr/logr v0.2.0 h1:QvGt2nLcHH0WK9orKa+ppBPAxREcH364nPUedEpK0TY=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-ole/go-ole v1.2.5 h1:t4MGB5xEDZvXI+0rMjjsfBsD7yAgp/s9ZDkL1JndXwY=
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
 github.com/go-openapi/analysis v0.17.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
@@ -890,6 +892,7 @@ github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfP
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v3.21.2+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shirou/gopsutil v3.21.3+incompatible h1:uenXGGa8ESCQq+dbgtl916dmg6PSAz2cXov0uORQ9v8=
 github.com/shirou/gopsutil v3.21.3+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -959,7 +962,9 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
+github.com/tklauser/go-sysconf v0.3.4 h1:HT8SVixZd3IzLdfs/xlpq0jeSfTX57g1v6wB1EuzV7M=
 github.com/tklauser/go-sysconf v0.3.4/go.mod h1:Cl2c8ZRWfHD5IrfHo9VN+FX9kCFjIOyVklgXycLB6ek=
+github.com/tklauser/numcpus v0.2.1 h1:ct88eFm+Q7m2ZfXJdan1xYoXKlmwsfP+k88q05KvlZc=
 github.com/tklauser/numcpus v0.2.1/go.mod h1:9aU+wOc6WjUIZEwWMP62PL/41d65P+iks1gBkr4QyP8=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/internal/receiver/awscontainerinsightreceiver/host/ec2metadata.go
+++ b/internal/receiver/awscontainerinsightreceiver/host/ec2metadata.go
@@ -1,0 +1,82 @@
+package host
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsec2metadata "github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+
+	"go.uber.org/zap"
+)
+
+type Ec2metadata struct {
+	logger          *zap.Logger
+	refreshInterval time.Duration
+	instanceId      string
+	instanceType    string
+	shutdownC       chan bool
+}
+
+func NewEc2metadata(refreshInterval time.Duration, logger *zap.Logger) *Ec2metadata {
+	emd := &Ec2metadata{
+		refreshInterval: refreshInterval,
+		shutdownC:       make(chan bool),
+		logger:          logger,
+	}
+
+	emd.refresh()
+	go func() {
+		refreshTicker := time.NewTicker(emd.refreshInterval)
+		defer refreshTicker.Stop()
+		for {
+			select {
+			case <-refreshTicker.C:
+				//stop the refresh once we get instance id and type successfully
+				if emd.instanceId != "" && emd.instanceType != "" {
+					return
+				}
+				emd.refresh()
+			case <-emd.shutdownC:
+				return
+			}
+		}
+	}()
+
+	return emd
+}
+
+func (emd *Ec2metadata) getAwsMetadata() awsec2metadata.EC2InstanceIdentityDocument {
+	emd.logger.Info("Fetch instance id and type from ec2 metadata")
+	sess, err := session.NewSession(&aws.Config{})
+	if err != nil {
+		emd.logger.Error("Failed to set up new session to call ec2 api")
+		return awsec2metadata.EC2InstanceIdentityDocument{}
+	}
+	client := awsec2metadata.New(sess)
+	doc, err := client.GetInstanceIdentityDocument()
+	if err != nil {
+		emd.logger.Error("Failed to get ec2 metadata", zap.Error(err))
+		return awsec2metadata.EC2InstanceIdentityDocument{}
+	}
+
+	return doc
+}
+
+func (emd *Ec2metadata) refresh() {
+	metadata := emd.getAwsMetadata()
+	emd.instanceId = metadata.InstanceID
+	emd.instanceType = metadata.InstanceType
+}
+
+func (emd *Ec2metadata) Shutdown() {
+	close(emd.shutdownC)
+}
+
+func (emd *Ec2metadata) GetInstanceID() string {
+	return emd.instanceId
+}
+
+func (emd *Ec2metadata) GetInstanceType() string {
+	return emd.instanceType
+}

--- a/internal/receiver/awscontainerinsightreceiver/host/ec2tags.go
+++ b/internal/receiver/awscontainerinsightreceiver/host/ec2tags.go
@@ -1,0 +1,127 @@
+package host
+
+import (
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"go.uber.org/zap"
+)
+
+const (
+	ClusterNameKey          = "container-insight-eks-cluster-name"
+	ClusterNameTagKeyPrefix = "kubernetes.io/cluster/"
+	AutoScalingGroupNameTag = "aws:autoscaling:groupName"
+)
+
+type Ec2Tags struct {
+	refreshInterval      time.Duration
+	instanceId           string
+	clusterName          string
+	autoScalingGroupName string
+	logger               *zap.Logger
+	shutdownC            chan bool
+}
+
+func NewEc2Tags(instanceId string, refreshInterval time.Duration, logger *zap.Logger) *Ec2Tags {
+	if instanceId == "" {
+		return nil
+	}
+
+	et := &Ec2Tags{
+		instanceId:      instanceId,
+		refreshInterval: refreshInterval,
+		shutdownC:       make(chan bool),
+		logger:          logger,
+	}
+
+	et.refresh()
+	go func() {
+		refreshTicker := time.NewTicker(et.refreshInterval)
+		defer refreshTicker.Stop()
+		for {
+			select {
+			case <-refreshTicker.C:
+				if et.clusterName != "" {
+					//stop once we get the cluster name
+					return
+				}
+				et.refresh()
+			case <-et.shutdownC:
+				return
+			}
+		}
+	}()
+
+	return et
+}
+
+func (et *Ec2Tags) fetchEc2Tags() map[string]string {
+	et.logger.Info("Fetch ec2 tags to detect cluster name and auto scaling group name")
+	tags := make(map[string]string)
+	//add some sleep jitter to prevent a large number of receivers calling the ec2 api at the same time
+	time.Sleep(hostJitter(3 * time.Second))
+
+	sess, err := session.NewSession(&aws.Config{})
+	if err != nil {
+		et.logger.Warn("Fail to set up session to call ec2 api", zap.Error(err))
+	}
+
+	tagFilters := []*ec2.Filter{
+		{
+			Name:   aws.String("resource-type"),
+			Values: aws.StringSlice([]string{"instance"}),
+		},
+		{
+			Name:   aws.String("resource-id"),
+			Values: aws.StringSlice([]string{et.instanceId}),
+		},
+	}
+
+	client := ec2.New(sess)
+	input := &ec2.DescribeTagsInput{
+		Filters: tagFilters,
+	}
+
+	for {
+		result, err := client.DescribeTags(input)
+		if err != nil {
+			et.logger.Warn("Fail to call ec2 DescribeTags", zap.Error(err))
+		}
+
+		for _, tag := range result.Tags {
+			key := *tag.Key
+			tags[key] = *tag.Value
+			if strings.HasPrefix(key, ClusterNameTagKeyPrefix) && *tag.Value == "owned" {
+				tags[ClusterNameKey] = key[len(ClusterNameTagKeyPrefix):]
+			}
+		}
+
+		if result.NextToken == nil {
+			break
+		}
+		input.SetNextToken(*result.NextToken)
+	}
+
+	return tags
+}
+
+func (et *Ec2Tags) GetClusterName() string {
+	return et.clusterName
+}
+
+func (et *Ec2Tags) GetAutoScalingGroupName() string {
+	return et.autoScalingGroupName
+}
+
+func (et *Ec2Tags) refresh() {
+	tags := et.fetchEc2Tags()
+	et.clusterName = tags[ClusterNameKey]
+	et.autoScalingGroupName = tags[AutoScalingGroupNameTag]
+}
+
+func (et *Ec2Tags) Shutdown() {
+	close(et.shutdownC)
+}

--- a/internal/receiver/awscontainerinsightreceiver/host/nodeCapacity.go
+++ b/internal/receiver/awscontainerinsightreceiver/host/nodeCapacity.go
@@ -1,0 +1,51 @@
+package host
+
+import (
+	"os"
+
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/mem"
+	"go.uber.org/zap"
+)
+
+const (
+	GoPSUtilProcDirEnv = "HOST_PROC"
+)
+
+type NodeCapacity struct {
+	MemCapacity int64
+	CPUCapacity int64
+	logger      *zap.Logger
+}
+
+func NewNodeCapacity(logger *zap.Logger) (*NodeCapacity, error) {
+	if _, err := os.Lstat("/rootfs/proc"); os.IsNotExist(err) {
+		return nil, err
+	}
+	if err := os.Setenv(GoPSUtilProcDirEnv, "/rootfs/proc"); err != nil {
+		logger.Error("NodeCapacity cannot set goPSUtilProcDirEnv to /rootfs/proc", zap.Error(err))
+	}
+	nc := &NodeCapacity{logger: logger}
+	nc.parseCpu()
+	nc.parseMemory()
+	return nc, nil
+}
+
+func (n *NodeCapacity) parseMemory() {
+	if memStats, err := mem.VirtualMemory(); err == nil {
+		n.MemCapacity = int64(memStats.Total)
+	} else {
+		// If any error happen, then there will be no mem utilization metrics
+		n.logger.Error("NodeCapacity cannot get memStats from psUtil", zap.Error(err))
+	}
+}
+
+func (n *NodeCapacity) parseCpu() {
+	if cpuInfos, err := cpu.Info(); err == nil {
+		numCores := len(cpuInfos)
+		n.CPUCapacity = int64(numCores)
+	} else {
+		// If any error happen, then there will be no cpu utilization metrics
+		n.logger.Error("NodeCapacity cannot get cpuInfo from psUtil", zap.Error(err))
+	}
+}


### PR DESCRIPTION
**Description:** 
* Fix inconsistent metric units
* Use gopsutil to get cpu/mem capacity instead
   * cadvisor is used previously but it only work for linux
   * gopsutil works for linux, windows and mac os
* Detect cluster name and autoscaling group in receiver
  * we previously rely on the upstream `resourcedetectionprocessor` to fetch ec2 tags to find out cluster name, but that method does not always work. 
  * we now use the same method as cloudwatch agent as it is guaranteed to work
* Add delay at the start of metric collection to avoid missing metric data point intermittently 
* Resolve some regex warning
