### PR TITLE
Config cleansing after job and instance label is added in prometheus receiver

### DIFF
--- a/config/eks/prometheus/config-all.yaml
+++ b/config/eks/prometheus/config-all.yaml
@@ -19,8 +19,6 @@ receivers:
               regex: ([^:]+)(?::\d+)?;(\d+)
               replacement: $${1}:9901
               target_label: __address__
-            - source_labels: [ __address__ ]
-              target_label: exported_instance
             - action: labelmap
               regex: __meta_kubernetes_pod_label_(.+)
             - action: replace
@@ -60,8 +58,6 @@ receivers:
               regex: ([^:]+)(?::\d+)?
               replacement: ${1}:2020
               target_label: __address__
-            - source_labels: [ __address__ ]
-              target_label: exported_instance
             - action: labelmap
               regex: __meta_kubernetes_pod_label_(.+)
             - action: replace
@@ -135,8 +131,6 @@ receivers:
                 - __address__
                 - __meta_kubernetes_service_annotation_prometheus_io_port
               target_label: __address__
-            - source_labels: [ __address__ ]
-              target_label: exported_instance
             - action: labelmap
               regex: __meta_kubernetes_service_label_(.+)
             - action: replace
@@ -186,8 +180,6 @@ receivers:
             - source_labels: [ __address__ ]
               action: keep
               regex: '.*:9404$'
-            - source_labels: [ __address__ ]
-              target_label: exported_instance
             - action: labelmap
               regex: __meta_kubernetes_pod_label_(.+)
             - action: replace
@@ -226,23 +218,11 @@ processors:
   resource:
     attributes:
       - key: TaskId
-        from_attribute: service.name
-        action: insert
-      - key: job
-        from_attribute: service.name
+        from_attribute: job
         action: insert
       - key: receiver
         value: "prometheus"
         action: insert
-  metricstransform:
-    transforms:
-      - include: ".*"
-        match_type: regexp
-        action: update
-        operations:
-          - label: exported_instance
-            new_label: instance
-            action: update_label
 
 exporters:
   awsemf:
@@ -431,5 +411,5 @@ service:
   pipelines:
     metrics:
       receivers: [ prometheus ]
-      processors: [ resourcedetection/ec2, resource, metricstransform ]
+      processors: [ resourcedetection/ec2, resource ]
       exporters: [ awsemf ]

--- a/config/eks/prometheus/config-appmesh.yaml
+++ b/config/eks/prometheus/config-appmesh.yaml
@@ -19,8 +19,6 @@ receivers:
               regex: ([^:]+)(?::\d+)?;(\d+)
               replacement: $${1}:9901
               target_label: __address__
-            - source_labels: [ __address__ ]
-              target_label: exported_instance
             - action: labelmap
               regex: __meta_kubernetes_pod_label_(.+)
             - action: replace
@@ -55,23 +53,11 @@ processors:
   resource:
     attributes:
       - key: TaskId
-        from_attribute: service.name
-        action: insert
-      - key: job
-        from_attribute: service.name
+        from_attribute: job
         action: insert
       - key: receiver
         value: "prometheus"
         action: insert
-  metricstransform:
-    transforms:
-      - include: ".*"
-        match_type: regexp
-        action: update
-        operations:
-          - label: exported_instance
-            new_label: instance
-            action: update_label
 
 exporters:
   awsemf:

--- a/config/eks/prometheus/config-haproxy.yaml
+++ b/config/eks/prometheus/config-haproxy.yaml
@@ -19,8 +19,6 @@ receivers:
               regex: ([^:]+)(?::\d+)?
               replacement: ${1}:2020
               target_label: __address__
-            - source_labels: [ __address__ ]
-              target_label: exported_instance
             - action: labelmap
               regex: __meta_kubernetes_pod_label_(.+)
             - action: replace
@@ -124,23 +122,11 @@ processors:
   resource:
     attributes:
       - key: TaskId
-        from_attribute: service.name
-        action: insert
-      - key: job
-        from_attribute: service.name
+        from_attribute: job
         action: insert
       - key: receiver
         value: "prometheus"
         action: insert
-  metricstransform:
-    transforms:
-      - include: ".*"
-        match_type: regexp
-        action: update
-        operations:
-          - label: exported_instance
-            new_label: instance
-            action: update_label
 
 exporters:
   awsemf:

--- a/config/eks/prometheus/config-jmx.yaml
+++ b/config/eks/prometheus/config-jmx.yaml
@@ -14,8 +14,6 @@ receivers:
             - source_labels: [ __address__ ]
               action: keep
               regex: '.*:9404$'
-            - source_labels: [ __address__ ]
-              target_label: exported_instance
             - action: labelmap
               regex: __meta_kubernetes_pod_label_(.+)
             - action: replace
@@ -54,23 +52,11 @@ processors:
   resource:
     attributes:
       - key: TaskId
-        from_attribute: service.name
-        action: insert
-      - key: job
-        from_attribute: service.name
+        from_attribute: job
         action: insert
       - key: receiver
         value: "prometheus"
         action: insert
-  metricstransform:
-    transforms:
-      - include: ".*"
-        match_type: regexp
-        action: update
-        operations:
-          - label: exported_instance
-            new_label: instance
-            action: update_label
 
 exporters:
   awsemf:

--- a/config/eks/prometheus/config-memcached.yaml
+++ b/config/eks/prometheus/config-memcached.yaml
@@ -31,8 +31,6 @@ receivers:
                 - __address__
                 - __meta_kubernetes_service_annotation_prometheus_io_port
               target_label: __address__
-            - source_labels: [ __address__ ]
-              target_label: exported_instance
             - action: labelmap
               regex: __meta_kubernetes_service_label_(.+)
             - action: replace
@@ -70,23 +68,11 @@ processors:
   resource:
     attributes:
       - key: TaskId
-        from_attribute: service.name
-        action: insert
-      - key: job
-        from_attribute: service.name
+        from_attribute: job
         action: insert
       - key: receiver
         value: "prometheus"
         action: insert
-  metricstransform:
-    transforms:
-      - include: ".*"
-        match_type: regexp
-        action: update
-        operations:
-          - label: exported_instance
-            new_label: instance
-            action: update_label
 
 exporters:
   awsemf:

--- a/config/eks/prometheus/config-nginx.yaml
+++ b/config/eks/prometheus/config-nginx.yaml
@@ -31,8 +31,6 @@ receivers:
                 - __address__
                 - __meta_kubernetes_service_annotation_prometheus_io_port
               target_label: __address__
-            - source_labels: [ __address__ ]
-              target_label: exported_instance
             - action: labelmap
               regex: __meta_kubernetes_service_label_(.+)
             - action: replace
@@ -70,23 +68,11 @@ processors:
   resource:
     attributes:
       - key: TaskId
-        from_attribute: service.name
-        action: insert
-      - key: job
-        from_attribute: service.name
+        from_attribute: job
         action: insert
       - key: receiver
         value: "prometheus"
         action: insert
-  metricstransform:
-    transforms:
-      - include: ".*"
-        match_type: regexp
-        action: update
-        operations:
-          - label: exported_instance
-            new_label: instance
-            action: update_label
 
 exporters:
   awsemf:

--- a/config/eks/prometheus/config-redis.yaml
+++ b/config/eks/prometheus/config-redis.yaml
@@ -31,8 +31,6 @@ receivers:
                 - __address__
                 - __meta_kubernetes_service_annotation_prometheus_io_port
               target_label: __address__
-            - source_labels: [ __address__ ]
-              target_label: exported_instance
             - action: labelmap
               regex: __meta_kubernetes_service_label_(.+)
             - action: replace
@@ -70,23 +68,11 @@ processors:
   resource:
     attributes:
       - key: TaskId
-        from_attribute: service.name
-        action: insert
-      - key: job
-        from_attribute: service.name
+        from_attribute: job
         action: insert
       - key: receiver
         value: "prometheus"
         action: insert
-  metricstransform:
-    transforms:
-      - include: ".*"
-        match_type: regexp
-        action: update
-        operations:
-          - label: exported_instance
-            new_label: instance
-            action: update_label
 
 exporters:
   awsemf:


### PR DESCRIPTION
**Why do we need it?**
We don't need to add `job` and `instance` label explicitly since https://github.com/open-telemetry/opentelemetry-collector/pull/2897 is merged.