### PR TITLE
Add AWS Region in CD workflow to fix resource destroy error on invalid aws region

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Destroy resources
         if: ${{ always() }}
         run: |
-          cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
+          cd testing-framework/terraform/ec2 && AWS_REGION=us-west-2 terraform destroy -auto-approve
           
   s3-release-validation-2:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description:** 
Add AWS Region to fix resource destroy error on invalid aws region

**Link to tracking Issue:**
https://github.com/aws-observability/aws-otel-collector/runs/2414368671?check_suite_focus=true
