### PR TITLE
Add AWS Region in Canary workflow to fix resource destroy error on invalid aws region

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -109,4 +109,4 @@ jobs:
       - name: Destroy terraform resources
         if: ${{ always() }}
         run: |
-          cd testing-framework/terraform/canary && terraform destroy -auto-approve
+          cd testing-framework/terraform/canary && AWS_REGION=us-west-2 terraform destroy -auto-approve


### PR DESCRIPTION
**Description:** 
Add AWS Region to fix resource destroy error on invalid aws region

**Link to tracking Issue:**
https://github.com/aws-observability/aws-otel-collector/runs/2414368671?check_suite_focus=true