### PR TITLE
e2e: Remove centos6

### DIFF
--- a/e2etest/get-testcases.py
+++ b/e2etest/get-testcases.py
@@ -21,7 +21,6 @@ if __name__ == "__main__":
         "redhat8", 
         "redhat7", 
         "centos7", 
-        "centos6",
         "windows2019"
     ]}
     ec2_matrix_3 = {"testcase": [], "testing_ami": [


### PR DESCRIPTION
**Description:** <Describe what has changed. 

https://wiki.centos.org/About/Product

- full update: 2017-05-10
- maintenance update: 2020-11-30
- today: 2021-04-22

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>
