### PR TITLE
lock the tf version to fix aws resource destroy error

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -89,6 +89,8 @@ jobs:
 
       - name: Set up terraform
         uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.10
 
       - name: Check out testing framework
         uses: actions/checkout@v2


### PR DESCRIPTION
**Description:** <Describe what has changed. 
lock the tf version to fix aws resource destroy error caused by TF bug
https://github.com/hashicorp/terraform-provider-aws/issues/8040#issuecomment-822774525


**Testing:** < Describe what testing was performed and which tests were added.>
locally
