### PR TITLE
Fix log init fail when running as nonroot

### DIFF
--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -63,11 +63,15 @@ func main() {
 		GitHash:  version.GitHash,
 	}
 
-	if err := run(service.Parameters{
+	params := service.Parameters{
 		Factories:            factories,
 		ApplicationStartInfo: info,
 		ParserProvider:       cfgFactory,
-		LoggingOptions:       []zap.Option{zap.Hooks(lumberHook)}}); err != nil {
+	}
+	if lumberHook != nil {
+		params.LoggingOptions = []zap.Option{zap.Hooks(lumberHook)}
+	}
+	if err := run(params); err != nil {
 		logFatal(err)
 	}
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -35,33 +35,43 @@ var WindowsLogPath = "C:\\ProgramData\\Amazon\\AWSOTelCollector\\Logs\\aws-otel-
 
 var logfile = getLogFilePath()
 
-var lumberjackLogger = &lumberjack.Logger{
-	Filename:   logfile,
-	MaxSize:    100, //MB
-	MaxBackups: 5,   //backup files
-	MaxAge:     7,   //days
-	Compress:   true,
+var lumberjackLogger = tryNewLumberJackLogger()
+
+func tryNewLumberJackLogger() *lumberjack.Logger {
+	if logfile != "" && !extraconfig.IsRunningInContainer() {
+		return &lumberjack.Logger{
+			Filename:   logfile,
+			MaxSize:    100, //MB
+			MaxBackups: 5,   //backup files
+			MaxAge:     7,   //days
+			Compress:   true,
+		}
+	}
+	return nil
 }
 
 // GetLumberHook returns lumberjackLogger as a Zap hook
 // for processing log size and log rotation
 func GetLumberHook() func(e zapcore.Entry) error {
-	return func(e zapcore.Entry) error {
-		_, err := lumberjackLogger.Write(
-			[]byte(fmt.Sprintf("{%+v, Level:%+v, Caller:%+v, Message:%+v, Stack:%+v}\r\n",
-				e.Time, e.Level, e.Caller, e.Message, e.Stack)))
-		if err != nil {
-			return err
+	if lumberjackLogger != nil {
+		return func(e zapcore.Entry) error {
+			_, err := lumberjackLogger.Write(
+				[]byte(fmt.Sprintf("{%+v, Level:%+v, Caller:%+v, Message:%+v, Stack:%+v}\r\n",
+					e.Time, e.Level, e.Caller, e.Message, e.Stack)))
+			if err != nil {
+				return err
+			}
+			return nil
 		}
-		return nil
 	}
+	return nil
 }
 
 // SetupErrorLogger setup lumberjackLogger for go logger
 func SetupErrorLogger() {
 	var writer io.WriteCloser
 	// When running in container, always log to stderr, it makes debugging easier.
-	if logfile != "" && !extraconfig.IsRunningInContainer() {
+	if lumberjackLogger != nil {
 		err := os.MkdirAll(filepath.Dir(logfile), 0755)
 		if err != nil {
 			log.Printf("D! fail to chmod on log file due to : %v \n", err)

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -28,7 +28,13 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
+func setupLogEnv() {
+	logfile = getLogFilePath()
+	lumberjackLogger = tryNewLumberJackLogger()
+}
+
 func TestGetLumberHook(t *testing.T) {
+	setupLogEnv()
 	entry := zapcore.Entry{
 		Message: "test",
 	}
@@ -38,6 +44,7 @@ func TestGetLumberHook(t *testing.T) {
 }
 
 func TestSetupErrorLogger(t *testing.T) {
+	setupLogEnv()
 	SetupErrorLogger()
 	_, ok := log.Writer().(*lumberjack.Logger)
 	assert.True(t, ok)
@@ -45,21 +52,24 @@ func TestSetupErrorLogger(t *testing.T) {
 
 func TestSetupErrorLoggerWithNoFilePath(t *testing.T) {
 	logfile = ""
+	lumberjackLogger = tryNewLumberJackLogger()
+
 	SetupErrorLogger()
 	_, ok := log.Writer().(*os.File)
 	assert.True(t, ok)
 }
 
 func TestGetLogFilePath(t *testing.T) {
-	logPath := getLogFilePath()
+	setupLogEnv()
 	if runtime.GOOS == "windows" {
-		assert.Equal(t, WindowsLogPath, logPath)
+		assert.Equal(t, WindowsLogPath, logfile)
 	} else {
-		assert.Equal(t, UnixLogPath, logPath)
+		assert.Equal(t, UnixLogPath, logfile)
 	}
 }
 
 func TestSetLogLevel(t *testing.T) {
+	setupLogEnv()
 	SetLogLevel("DEBUG")
 	argStr := strings.Join(os.Args[:], "=")
 	assert.True(t, strings.Contains(argStr, "--log-level=DEBUG"))


### PR DESCRIPTION
**Why do we need it?**
Fixes https://github.com/aws-observability/aws-otel-collector/issues/451

This is a follow-up PR of https://github.com/aws-observability/aws-otel-collector/pull/341. We skip log hook initialization when running inside containers.