### PR TITLE
bump version to v0.9.0

### DIFF
--- a/docs/releases/v0.9.0.md
+++ b/docs/releases/v0.9.0.md
@@ -1,18 +1,24 @@
 # Changelog
 
-## [v0.9.0](https://github.com/aws-observability/aws-otel-collector/tree/v0.9.0) (2021-04-27)
+## [v0.9.0](https://github.com/aws-observability/aws-otel-collector/tree/v0.9.0) (2021-04-28)
 
 [Full Changelog](https://github.com/aws-observability/aws-otel-collector/compare/pkg/lambdacomponents/v0.9.0...v0.9.0)
 
 **Closed issues:**
 
+- Latests releases not available on Dockerhub [\#481](https://github.com/aws-observability/aws-otel-collector/issues/481)
 - Unable to export traces to XRay [\#469](https://github.com/aws-observability/aws-otel-collector/issues/469)
 - ECS EC2 Prometheus pipeline example - service replicas? [\#454](https://github.com/aws-observability/aws-otel-collector/issues/454)
+- aws-otel-collector when run in container gives a permission denied error to create directory [\#451](https://github.com/aws-observability/aws-otel-collector/issues/451)
+- Upgrade dependencies in lambdacomponents module to the latest 0.24 [\#432](https://github.com/aws-observability/aws-otel-collector/issues/432)
 - SQL Instrumentation Error - Invalid Subsegment [\#390](https://github.com/aws-observability/aws-otel-collector/issues/390)
 
 **Merged pull requests:**
 
+- Fix log init fail when running as nonroot [\#484](https://github.com/aws-observability/aws-otel-collector/pull/484) ([bjrara](https://github.com/bjrara))
+- bump version to v0.9.0 [\#480](https://github.com/aws-observability/aws-otel-collector/pull/480) ([mxiamxia](https://github.com/mxiamxia))
 - remove container insight components [\#479](https://github.com/aws-observability/aws-otel-collector/pull/479) ([pxaws](https://github.com/pxaws))
+- build: Bump builder image go version to 1.16.3 [\#478](https://github.com/aws-observability/aws-otel-collector/pull/478) ([pingleig](https://github.com/pingleig))
 - bump version to 0.9.0 [\#476](https://github.com/aws-observability/aws-otel-collector/pull/476) ([mxiamxia](https://github.com/mxiamxia))
 - Fix SSM package version [\#475](https://github.com/aws-observability/aws-otel-collector/pull/475) ([vastin](https://github.com/vastin))
 - Add re-run support and SSM package test in CD workflow [\#474](https://github.com/aws-observability/aws-otel-collector/pull/474) ([vastin](https://github.com/vastin))
@@ -25,7 +31,6 @@
 - Add AWS Region in Canary workflow to fix resource destroy error on invalid aws region [\#465](https://github.com/aws-observability/aws-otel-collector/pull/465) ([mxiamxia](https://github.com/mxiamxia))
 - Support dry-run in CD workflow [\#463](https://github.com/aws-observability/aws-otel-collector/pull/463) ([vastin](https://github.com/vastin))
 - fix lambda component factory build error [\#462](https://github.com/aws-observability/aws-otel-collector/pull/462) ([mxiamxia](https://github.com/mxiamxia))
-- Config cleansing after job and instance label is added in prometheus receiver [\#456](https://github.com/aws-observability/aws-otel-collector/pull/456) ([bjrara](https://github.com/bjrara))
 
 ## [pkg/lambdacomponents/v0.9.0](https://github.com/aws-observability/aws-otel-collector/tree/pkg/lambdacomponents/v0.9.0) (2021-04-22)
 
@@ -49,6 +54,7 @@
 - add logzio testcase [\#459](https://github.com/aws-observability/aws-otel-collector/pull/459) ([mxiamxia](https://github.com/mxiamxia))
 - Update CI workflows and docs [\#458](https://github.com/aws-observability/aws-otel-collector/pull/458) ([pxaws](https://github.com/pxaws))
 - remove unused IMDS v1 test func from packaging script [\#457](https://github.com/aws-observability/aws-otel-collector/pull/457) ([mxiamxia](https://github.com/mxiamxia))
+- Config cleansing after job and instance label is added in prometheus receiver [\#456](https://github.com/aws-observability/aws-otel-collector/pull/456) ([bjrara](https://github.com/bjrara))
 - add doc for container insight eks support [\#455](https://github.com/aws-observability/aws-otel-collector/pull/455) ([pxaws](https://github.com/pxaws))
 - Update doc layout [\#453](https://github.com/aws-observability/aws-otel-collector/pull/453) ([bjrara](https://github.com/bjrara))
 - allow adding arbitrary env vars in extraCfg  [\#452](https://github.com/aws-observability/aws-otel-collector/pull/452) ([mxiamxia](https://github.com/mxiamxia))
@@ -106,7 +112,6 @@
 - Revert "Add default configurations for Container Insights on EKS with Prometheus" [\#420](https://github.com/aws-observability/aws-otel-collector/pull/420) ([mxiamxia](https://github.com/mxiamxia))
 - update the deps to v0.23.0 from upstream [\#414](https://github.com/aws-observability/aws-otel-collector/pull/414) ([mxiamxia](https://github.com/mxiamxia))
 - Update developer guides. [\#410](https://github.com/aws-observability/aws-otel-collector/pull/410) ([vastin](https://github.com/vastin))
-- Add statsD receiver component [\#400](https://github.com/aws-observability/aws-otel-collector/pull/400) ([gavindoudou](https://github.com/gavindoudou))
 - Add default configurations for Container Insights on EKS with Prometheus [\#394](https://github.com/aws-observability/aws-otel-collector/pull/394) ([bjrara](https://github.com/bjrara))
 - Introduce resourcedetectionprocessor for cluster name injection [\#393](https://github.com/aws-observability/aws-otel-collector/pull/393) ([bjrara](https://github.com/bjrara))
 


### PR DESCRIPTION
**Description:**
Release ADOT collector v0.9.0

https://github.com/aws-observability/aws-otel-collector/compare/v0.8.0...main

* Zipkin Receiver
* Jaeger Receiver
* Logzio Exporter
* SSM Distributor package support on ADOT Collector
