### PR TITLE
terraform_version: 0.14.10

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -336,7 +336,7 @@ jobs:
       - name: Login Dockerhub
         uses: docker/login-action@v1
         with:
-          username: "josephwy"
+          username: "mxiamxia"
           password: "${{ secrets.DOCKERHUB_RELEASE_TOKEN }}"
 
       - name: Push Image to dockerhub

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -170,6 +170,8 @@ jobs:
       - name: Set up terraform
         if: steps.s3-release-validation-1.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.10
 
       - name: Check out testing framework
         if: steps.s3-release-validation-1.outputs.cache-hit != 'true'
@@ -224,6 +226,8 @@ jobs:
       - name: Set up terraform
         if: steps.s3-release-validation-2.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.10
 
       - name: Check out testing framework
         if: steps.s3-release-validation-2.outputs.cache-hit != 'true'
@@ -278,6 +282,8 @@ jobs:
       - name: Set up terraform
         if: steps.s3-release-validation-3.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.10
 
       - name: Check out testing framework
         if: steps.s3-release-validation-3.outputs.cache-hit != 'true'
@@ -385,6 +391,8 @@ jobs:
       - name: Set up terraform
         if: steps.release-validation-ecs.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.10
       
       - name: Check out testing framework
         if: steps.release-validation-ecs.outputs.cache-hit != 'true'
@@ -439,6 +447,8 @@ jobs:
       - name: Set up terraform
         if: steps.release-validation-eks.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.10
       
       - name: Check out testing framework
         if: steps.release-validation-eks.outputs.cache-hit != 'true'


### PR DESCRIPTION
**Description:** <Describe what has changed. 
use fixed terraform version 0.14.10 before fixing the compatible issue in test framework. The `list` func deprecated in tf v0.15.0

```
Call to function "list" failed: the "list" function was deprecated in
│ Terraform v0.12 and is no longer available; use tolist([ ... ]) syntax to
│ write a literal list.
```