### PR TITLE
Disable fail-fast in CD workflow

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -139,6 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, release-to-s3]
     strategy:
+      fail-fast: false
       max-parallel: 5
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-1) }}
 
@@ -195,6 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, release-to-s3]
     strategy:
+      fail-fast: false
       max-parallel: 5
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-2) }}
 
@@ -251,6 +253,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, release-to-s3]
     strategy:
+      fail-fast: false
       max-parallel: 5
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-3) }}
 
@@ -360,6 +363,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, release-image]
     strategy:
+      fail-fast: false
       max-parallel: 5
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.ecs-matrix) }}
     
@@ -416,6 +420,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, release-image]
     strategy:
+      fail-fast: false
       max-parallel: 5
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.eks-matrix) }}
     


### PR DESCRIPTION
**Description:**. 
Disable fail-fast in CD workflow to make it run more tests when failed. It will make re-run faster.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>
