### PR TITLE
Don't set default version of SSM in CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -517,8 +517,8 @@ jobs:
           pip3 install boto3
           ssm_pkg_version=`cat build/packages/VERSION`
           python3 tools/ssm/ssm_manifest.py ${ssm_pkg_version}
-          aws s3 cp build/packages/ssm s3://aws-otel-collector-test/ssm --recursive
-          python3 tools/ssm/ssm_create.py testAWSDistroOTel-Collector ${ssm_pkg_version} aws-otel-collector-test/ssm us-west-2
+          aws s3 cp build/packages/ssm s3://aws-otel-collector-test/ssm/${ssm_pkg_version} --recursive
+          python3 tools/ssm/ssm_create.py --no-default testAWSDistroOTel-Collector ${ssm_pkg_version} aws-otel-collector-test/ssm/${ssm_pkg_version} us-west-2
 
       - name: upload to s3 in the testing stack
         if: steps.e2etest-release.outputs.cache-hit != 'true'


### PR DESCRIPTION
**Description:**
Don't set current version of SSM test package to default in CI workflow. So it can be deleted when CI is complete successfully.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>
