### PR TITLE
Update CI job after terraform test case update

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -559,7 +559,6 @@ jobs:
       ec2-matrix-1: ${{ steps.set-matrix.outputs.ec2-matrix-1 }}
       ec2-matrix-2: ${{ steps.set-matrix.outputs.ec2-matrix-2 }}
       ec2-matrix-3: ${{ steps.set-matrix.outputs.ec2-matrix-3 }}
-      containerinsight-eks-matrix: ${{ steps.set-matrix.outputs.containerinsight-eks-matrix }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -575,13 +574,11 @@ jobs:
           ec2_matrix_3=$(python e2etest/get-testcases.py ec2_matrix_3)
           ecs_matrix=$(python e2etest/get-testcases.py ecs_matrix)
           eks_matrix=$(python e2etest/get-testcases.py eks_matrix)
-          containerinsight_eks_matrix=$(python e2etest/get-testcases.py containerinsight_eks_matrix)
           echo "::set-output name=eks-matrix::$eks_matrix"
           echo "::set-output name=ecs-matrix::$ecs_matrix"
           echo "::set-output name=ec2-matrix-1::$ec2_matrix_1"
           echo "::set-output name=ec2-matrix-2::$ec2_matrix_2"
           echo "::set-output name=ec2-matrix-3::$ec2_matrix_3"
-          echo "::set-output name=containerinsight-eks-matrix::$containerinsight_eks_matrix"
       - name: List testing suites
         run: |
           echo ${{ steps.set-matrix.outputs.eks-matrix }}
@@ -589,7 +586,6 @@ jobs:
           echo ${{ steps.set-matrix.outputs.ec2-matrix-1 }}
           echo ${{ steps.set-matrix.outputs.ec2-matrix-2 }}
           echo ${{ steps.set-matrix.outputs.ec2-matrix-3 }}
-          echo ${{ steps.set-matrix.outputs.containerinsight-eks-matrix }}
 
   e2etest-ec2-1:
     runs-on: ubuntu-latest
@@ -887,66 +883,10 @@ jobs:
         run: |
           cd testing-framework/terraform/eks && terraform destroy -auto-approve
 
-  e2etest-containerinsight-eks:
-    runs-on: ubuntu-latest
-    needs: [ get-testing-suites, e2etest-release, e2etest-preparation ]
-    strategy:
-      fail-fast: false
-      max-parallel: 10
-      matrix: ${{ fromJson(needs.get-testing-suites.outputs.containerinsight-eks-matrix) }}
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Cache if success
-        id: e2etest-containerinsight-eks
-        uses: actions/cache@v2
-        with:
-          path: |
-            VERSION
-          key: e2etest-containerinsight-eks-${{ github.run_id }}-${{ matrix.testcase }}
-
-      - name: Configure AWS Credentials
-        if: steps.e2etest-containerinsight-eks.outputs.cache-hit != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
-          aws-region: us-west-2
-
-      - name: Set up JDK 1.11
-        if: steps.e2etest-containerinsight-eks.outputs.cache-hit != 'true'
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.11
-
-      - name: Set up terraform
-        if: steps.e2etest-containerinsight-eks.outputs.cache-hit != 'true'
-        uses: hashicorp/setup-terraform@v1
-
-      - name: Check out testing framework
-        if: steps.e2etest-containerinsight-eks.outputs.cache-hit != 'true'
-        uses: actions/checkout@v2
-        with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
-          path: testing-framework
-
-      - name: Run testing suite on eks
-        if: steps.e2etest-containerinsight-eks.outputs.cache-hit != 'true'
-        run: |
-          if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
-          cd testing-framework/terraform/${{ matrix.testcase }} && terraform init && terraform apply -auto-approve -lock=false $opts -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}"
-
-      - name: Destroy resources
-        if: ${{ always() && steps.e2etest-containerinsight-eks.outputs.cache-hit != 'true' }}
-        run: |
-          cd testing-framework/terraform/${{ matrix.testcase }} && terraform destroy -var="testcase=../testcases/${{ matrix.testcase }}" -auto-approve
-
-
   release-candidate:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' # only create the artifact when there's a push, not for dispatch.
-    needs: [e2etest-eks, e2etest-ecs, e2etest-ec2-1, e2etest-ec2-2, e2etest-ec2-3, e2etest-containerinsight-eks]
+    needs: [e2etest-eks, e2etest-ecs, e2etest-ec2-1, e2etest-ec2-2, e2etest-ec2-3]
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/e2etest/get-testcases.py
+++ b/e2etest/get-testcases.py
@@ -38,7 +38,6 @@ if __name__ == "__main__":
     negative_soaking_matrix = {"testcase": [], "testing_ami": ["soaking_linux", "soaking_windows"]}
     perf_matrix = {"testcase": [], "testing_ami": ["soaking_linux"], "data_rate": ["100", "1000", "5000"]}
     canary_matrix = {"testcase": [], "testing_ami": ["canary_linux", "canary_windows"]}
-    containerinsight_eks_matrix = {"testcase": []}
 
     matrix = {
             "ec2_matrix_1": ec2_matrix_1, 
@@ -50,8 +49,7 @@ if __name__ == "__main__":
             "soaking_matrix": soaking_matrix,
             "negative_soaking_matrix": negative_soaking_matrix,
             "perf_matrix": perf_matrix,
-            "canary_matrix": canary_matrix,
-            "containerinsight_eks_matrix": containerinsight_eks_matrix
+            "canary_matrix": canary_matrix
             }
 
     with open(testcase_json) as f:
@@ -64,10 +62,7 @@ if __name__ == "__main__":
             if 'ECS' in testcase["platforms"]:
                 ecs_matrix["testcase"].append(testcase["case_name"])
             if 'EKS' in testcase["platforms"]:
-                if 'module' in testcase and testcase["module"] == "containerinsight":
-                    containerinsight_eks_matrix["testcase"].append(testcase["case_name"])
-                else:
-                    eks_matrix["testcase"].append(testcase["case_name"])
+                eks_matrix["testcase"].append(testcase["case_name"])
             if 'LOCAL' in testcase["platforms"]:
                 local_matrix["testcase"].append(testcase["case_name"])
             if 'SOAKING' in testcase["platforms"]:

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -85,7 +85,6 @@
 	},
 	{
 		"case_name": "containerinsight_eks_prometheus",
-		"module": "containerinsight",
 		"platforms": ["EKS"]
 	},
 	{


### PR DESCRIPTION
**Why do we need it?**
This is a follow-up PR of https://github.com/aws-observability/aws-otel-test-framework/pull/281. 

This PR cleanse CI jobs after container insight test cases are merged into EKS.