### PR TITLE
Use examples/docker Dir In Make File For Docker Compose Up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ docker-run:
 
 .PHONY: docker-compose
 docker-compose:
-	cd examples; docker-compose up -d
+	cd examples/docker; docker-compose up -d
 
 .PHONY: docker-stop
 docker-stop:


### PR DESCRIPTION
**Description:** Changed make file to look at dir examples/docker for docker-compose file. 
Ex. Fixing a bug - Make file is looking at a dir without a docker file. 

**Testing:** docker-compose up -d triggered starting of docker containers. 
