### PR TITLE
[extension/ecsobsever] Enable ecsobserver extension

### DIFF
--- a/examples/ecs/aws-cloudwatch/ecs-container-insights-prometheus.yaml
+++ b/examples/ecs/aws-cloudwatch/ecs-container-insights-prometheus.yaml
@@ -1,0 +1,185 @@
+# NOTE: replace {{cluster_name}} with actual cluster name in both extensions and exporter config.
+
+extensions:
+  ecs_observer:
+    cluster_name: '{{cluster_name}}'  # cluster name requires manual config
+    cluster_region: 'us-west-2' # region can be configured directly or use AWS_REGION env var
+    result_file: '/etc/ecs_sd_targets.yaml' # the directory for file must already exists
+    refresh_interval: 60s # format is https://golang.org/pkg/time/#ParseDuration
+    # custom name for 'job' so we can rename it back to 'job' using metricstransform processor
+    job_label_name: prometheus_job
+    # NGINX https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-Setup-nginx-ecs.html
+    services:
+      - name_pattern: '^.*nginx-plus-service$'
+        metrics_ports:
+          - 9113
+        job_name: nginx-plus-prometheus-exporter
+      - name_pattern: '^.*nginx-service$'
+        metrics_ports:
+          - 9113
+        job_name: nginx-prometheus-exporter
+    # JMX
+    docker_labels:
+      - port_label: 'ECS_PROMETHEUS_EXPORTER_PORT'
+    # App Mesh port and metrics are from envoy sidecar
+    task_definitions:
+      - arn_pattern: '.*:task-definition/.*-ColorTeller-(white):[0-9]+'
+        metrics_path: '/stats/prometheus'
+        metrics_ports:
+          - 9901
+        job_name: ecs-appmesh-colorteller
+      - arn_pattern: '.*:task-definition/.*-ColorGateway:[0-9]+'
+        metrics_path: '/stats/prometheus'
+        metrics_ports:
+          - 9901
+        job_name: ecs-appmesh-colorgateway
+
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "ecssd"
+          file_sd_configs:
+            - files:
+                - '/etc/ecs_sd_targets.yaml' # MUST match the file name in ecs_observer.result_file
+          relabel_configs: # Relabel here because label with __ prefix will be dropped by receiver.
+            - source_labels: [ __meta_ecs_cluster_name ] # ClusterName
+              action: replace
+              target_label: ClusterName
+            - source_labels: [ __meta_ecs_service_name ] # ServiceName
+              action: replace
+              target_label: ServiceName
+            - source_labels: [ __meta_ecs_task_definition_family ] # TaskDefinitionFamily
+              action: replace
+              target_label: TaskDefinitionFamily
+            - source_labels: [ __meta_ecs_task_launch_type ] # LaunchType
+              action: replace
+              target_label: LaunchType
+            - source_labels: [ __meta_ecs_container_name ] # container_name
+              action: replace
+              target_label: container_name
+            - action: labelmap # Convert docker labels on container to metric labels
+              regex: ^__meta_ecs_container_labels_(.+)$ # Capture the key using regex, e.g. __meta_ecs_container_labels_Java_EMF_Metrics -> Java_EMF_Metrics
+              replacement: '$$1'
+
+processors:
+  resource:
+    attributes:
+      - key: receiver # Insert receiver: prometheus for CloudWatch EMF Exporter to add prom_metric_type
+        value: "prometheus"
+        action: insert
+  metricstransform:
+    transforms:
+      - include: ".*" # Rename customized job label back to job
+        match_type: regexp
+        action: update
+        operations:
+          - label: prometheus_job # must match the value configured in ecs_observer
+            new_label: job
+            action: update_label
+
+exporters:
+  awsemf:
+    namespace: ECS/ContainerInsights/Prometheus # Use the exact namespace for builtin dashboard to work
+    log_group_name: "/aws/ecs/containerinsights/{{cluster_name}}/prometheus" # Log group name format is fixed as well, the only variable is cluster name
+    dimension_rollup_option: NoDimensionRollup
+    metric_declarations:
+      # NGINX
+      - dimensions: [ [ ClusterName, TaskDefinitionFamily, ServiceName ] ]
+        label_matchers:
+          - label_names:
+              - ServiceName
+            regex: '^.*nginx-service$'
+        metric_name_selectors:
+          - "^nginx_.*$"
+      # NGINX Plus
+      - dimensions: [ [ ClusterName, TaskDefinitionFamily, ServiceName ] ]
+        label_matchers:
+          - label_names:
+              - ServiceName
+            regex: '^.*nginx-plus-service$'
+        metric_name_selectors:
+          - "^nginxplus_connections_accepted$"
+          - "^nginxplus_connections_active$"
+          - "^nginxplus_connections_dropped$"
+          - "^nginxplus_connections_idle$"
+          - "^nginxplus_http_requests_total$"
+          - "^nginxplus_ssl_handshakes$"
+          - "^nginxplus_ssl_handshakes_failed$"
+          - "^nginxplus_up$"
+          - "^nginxplus_upstream_server_health_checks_fails$"
+      - dimensions: [ [ ClusterName, TaskDefinitionFamily, ServiceName, upstream ] ]
+        label_matchers:
+          - label_names:
+              - ServiceName
+            regex: '^.*nginx-plus-service$'
+        metric_name_selectors:
+          - "^nginxplus_upstream_server_response_time$"
+      - dimensions: [ [ ClusterName, TaskDefinitionFamily, ServiceName, code ] ]
+        label_matchers:
+          - label_names:
+              - ServiceName
+            regex: '^.*nginx-plus-service$'
+        metric_name_selectors:
+          - "^nginxplus_upstream_server_responses$"
+          - "^nginxplus_server_zone_responses$"
+      # JMX
+      - dimensions: [ [ ClusterName, TaskDefinitionFamily, area ] ]
+        label_matchers:
+          - label_names:
+              - Java_EMF_Metrics
+            regex: ^true$
+        metric_name_selectors:
+          - "^jvm_memory_bytes_used$"
+      - dimensions: [ [ ClusterName, TaskDefinitionFamily, pool ] ]
+        label_matchers:
+          - label_names:
+              - Java_EMF_Metrics
+            regex: ^true$
+        metric_name_selectors:
+          - "^jvm_memory_pool_bytes_used$"
+      - dimensions: [ [ ClusterName, TaskDefinitionFamily ] ]
+        label_matchers:
+          - label_names:
+              - Java_EMF_Metrics
+            regex: ^true$
+        metric_name_selectors:
+          - "^jvm_threads_(current|daemon)$"
+          - "^jvm_classes_loaded$"
+          - "^java_lang_operatingsystem_(freephysicalmemorysize|totalphysicalmemorysize|freeswapspacesize|totalswapspacesize|systemcpuload|processcpuload|availableprocessors|openfiledescriptorcount)$"
+          - "^catalina_manager_(rejectedsessions|activesessions)$"
+          - "^jvm_gc_collection_seconds_(count|sum)$"
+          - "^catalina_globalrequestprocessor_(bytesreceived|bytessent|requestcount|errorcount|processingtime)$"
+      # AppMesh Envoy
+      - dimensions: [ [ "ClusterName","TaskDefinitionFamily" ] ]
+        label_matchers:
+          - label_names:
+              - container_name
+            regex: ^envoy$
+        metric_name_selectors:
+          - "^envoy_http_downstream_rq_(total|xx)$"
+          - "^envoy_cluster_upstream_cx_(r|t)x_bytes_total$"
+          - "^envoy_cluster_membership_(healthy|total)$"
+          - "^envoy_server_memory_(allocated|heap_size)$"
+          - "^envoy_cluster_upstream_cx_(connect_timeout|destroy_local_with_active_rq)$"
+          - "^envoy_cluster_upstream_rq_(pending_failure_eject|pending_overflow|timeout|per_try_timeout|rx_reset|maintenance_mode)$"
+          - "^envoy_http_downstream_cx_destroy_remote_active_rq$"
+          - "^envoy_cluster_upstream_flow_control_(paused_reading_total|resumed_reading_total|backed_up_total|drained_total)$"
+          - "^envoy_cluster_upstream_rq_retry$"
+          - "^envoy_cluster_upstream_rq_retry_(success|overflow)$"
+          - "^envoy_server_(version|uptime|live)$"
+      - dimensions: [ [ "ClusterName","TaskDefinitionFamily","envoy_http_conn_manager_prefix","envoy_response_code_class" ] ]
+        label_matchers:
+          - label_names:
+              - container_name
+            regex: ^envoy$
+        metric_name_selectors:
+          - "^envoy_http_downstream_rq_xx$"
+
+service:
+  extensions: [ ecs_observer ]
+  pipelines:
+    metrics:
+      receivers: [ prometheus ]
+      processors: [ resource, metricstransform ]
+      exporters: [ awsemf ]

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/newrelicexporter v0.28.1-0.20210622144532-a1c3cdc676ee
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.28.1-0.20210622144532-a1c3cdc676ee
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.28.1-0.20210622144532-a1c3cdc676ee
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver v0.28.1-0.20210622144532-a1c3cdc676ee
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.28.1-0.20210622144532-a1c3cdc676ee
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.28.1-0.20210622144532-a1c3cdc676ee
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.28.1-0.20210622144532-a1c3cdc676ee

--- a/go.sum
+++ b/go.sum
@@ -21,7 +21,6 @@ cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmW
 cloud.google.com/go v0.78.0/go.mod h1:QjdrLG0uq+YwhjoVOLsS1t7TW8fs36kLs4XO5R5ECHg=
 cloud.google.com/go v0.79.0/go.mod h1:3bzgcEeQlzbuEAYu4mrWhKqWjmpprinYgKJLgKHnbb8=
 cloud.google.com/go v0.81.0/go.mod h1:mk/AM35KwGk/Nm2YSeZbxXdrNK3KZOYHmLkOqC2V6E0=
-cloud.google.com/go v0.83.0 h1:bAMqZidYkmIsUqe6PtkEPT7Q+vfizScn+jfNA6jwK9c=
 cloud.google.com/go v0.83.0/go.mod h1:Z7MJUsANfY0pYPdw0lbnivPx4/vhy/e2FEkSkF7vAVY=
 cloud.google.com/go v0.84.0 h1:hVhK90DwCdOAYGME/FJd9vNIZye9HBR6Yy3fu4js3N8=
 cloud.google.com/go v0.84.0/go.mod h1:RazrYuxIK6Kb7YrzzhPoLmCVzl7Sup4NrbKPg8KHSUM=
@@ -1057,6 +1056,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter 
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.28.1-0.20210622144532-a1c3cdc676ee/go.mod h1:8BoMGhzstzXCIuJmn4wXz8xQm46ImoemA9+YRq4Ds+A=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.28.1-0.20210622144532-a1c3cdc676ee h1:av8392Od91QyLO4G3A0cKakVzGEoRypGf4RCeyc0rqA=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.28.1-0.20210622144532-a1c3cdc676ee/go.mod h1:4rxvEft0tY9+wAna2tjEd7F7vud1Ns6JX2jQS7rSs8E=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver v0.28.1-0.20210622144532-a1c3cdc676ee h1:Mz1vzB8AKhwpwu9f4VmmWcA5GJylp/kAbbZ4PMS4eDg=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver v0.28.1-0.20210622144532-a1c3cdc676ee/go.mod h1:KtAg5f4ru3/WFDsX9nRj7aMHjrNliH5RbYqkBeBnmYk=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.28.1-0.20210622144532-a1c3cdc676ee h1:QXSSWzqmijd/8J0Kyz5cz6aigFdMnfJB12PbGPJZd50=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.28.1-0.20210622144532-a1c3cdc676ee/go.mod h1:S19zx3bR7OiTBgFfHYxu1kNxQ2/YU/ejQAQamV8OLnU=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight v0.28.1-0.20210622144532-a1c3cdc676ee h1:gRu61z6ZpbOoylCllGxglteuyhaGwj3DqyCXSXfQYfg=
@@ -1484,8 +1485,9 @@ go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
-go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
+go.uber.org/multierr v1.7.0 h1:zaiO/rmgFjbmCXdSYJWQcdvOCsthmdaHfr3Gm2Kx4Ec=
+go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
@@ -1742,7 +1744,6 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 h1:JWgyZ1qgdTaF3N3oxC+MdTV7qvEEgHo3otj+HB5CM7Q=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644 h1:CA1DEQ4NdKphKeL70tvsWNdT5oFh1lOjihRcEDROi0I=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1972,7 +1973,6 @@ google.golang.org/genproto v0.0.0-20210312152112-fc591d9ea70f/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
-google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c h1:wtujag7C+4D6KMoulW9YauvK2lgdvCMS260jsqqBXr0=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210608205507-b6d2f5bf0d7d h1:KzwjikDymrEmYYbdyfievTwjEeGlu+OM6oiKBkF3Jfg=

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -25,6 +25,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/newrelicexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver"
@@ -51,6 +52,20 @@ func Components() (component.Factories, error) {
 	factories, err := defaultcomponents.Components()
 	if err != nil {
 		return component.Factories{}, err
+	}
+
+	// enable extensions
+	extensions := []component.ExtensionFactory{
+		ecsobserver.NewFactory(),
+	}
+
+	for _, ext := range factories.Extensions {
+		extensions = append(extensions, ext)
+	}
+
+	factories.Extensions, err = component.MakeExtensionFactoryMap(extensions...)
+	if err != nil {
+		errs = append(errs, err)
 	}
 
 	// enable the selected receivers


### PR DESCRIPTION
**Description:** 

- Enable ECS observer #412 

**Link to tracking Issue:** 

#412 

**Testing:** 

- Integ test https://github.com/aws-observability/aws-otel-test-framework/pull/308

**Documentation:** 

- Pending PR to the doc repo, an outdated version is in #435 
