### PR TITLE
e2e: Enable Container Insight ECS Prometheus

### DIFF
--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -106,5 +106,9 @@
 	{
 		"case_name": "ssm_package",
 		"platforms": ["EC2", "CANARY"]
+	},
+	{
+		"case_name": "containerinsight_ecs_prometheus",
+		"platforms": ["ECS"]
 	}
 ]


### PR DESCRIPTION
**Description:** 

From 

- https://github.com/aws-observability/aws-otel-test-framework/pull/308

**Link to tracking Issue:** 

- https://github.com/aws-observability/aws-otel-collector/issues/412

**Testing:** 

```
 python3 e2etest/get-testcases.py ecs_matrix                                                                                                                                               

{"testcase": ["xrayreceiver", "statsd", "statsd_mock", "otlp_metric", "otlp_trace", "ecsmetrics", "otlp_grpc_exporter_metric_mock", "otlp_grpc_exporter_trace_mock", "otlp_http_exporter_metric_mock", "otlp_http_exporter_trace_mock", "sapm_exporter_trace_mock", "signalfx_exporter_metric_mock", "dynatrace_exporter_metric_mock", "datadog_exporter_metric_mock", "datadog_exporter_trace_mock", "newrelic_exporter_trace_mock", "newrelic_exporter_metric_mock", "prometheus_mock", "prometheus_static", "zipkin_mock", "jaeger_mock", "logzio_exporter_trace_mock", "containerinsight_ecs_prometheus"], "launch_type": ["EC2", "FARGATE"]}
```

Only tested when launching collector on fargate, but it should work when launching collector on EC2 as long as it's same VPC and security group has right setting.

**Documentation:** 

- https://github.com/aws-otel/aws-otel.github.io/pull/128
