### PR TITLE
Add two test cases for ADOT Operator

### DIFF
--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -20,6 +20,10 @@
 		"platforms": ["EC2", "ECS", "EKS", "SOAKING", "CANARY"]
 	},
 	{
+		"case_name": "otlp_trace_adot_operator",
+		"platforms": ["EKS"]
+	},
+	{
 		"case_name": "otlp_mock",
 		"platforms": ["LOCAL", "SOAKING", "NEG_SOAKING", "CANARY"]
 	},

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -80,7 +80,15 @@
 		"platforms": ["EC2", "ECS", "EKS", "SOAKING"]
 	},
 	{
+		"case_name": "prometheus_static_adot_operator",
+		"platforms": ["EKS"]
+	},
+	{
 		"case_name": "prometheus_sd",
+		"platforms": ["EKS"]
+	},
+	{
+		"case_name": "prometheus_sd_adot_operator",
 		"platforms": ["EKS"]
 	},
 	{


### PR DESCRIPTION
**Description:**
This is the company PR which modifies the `testcases.json` to add two test cases for ADOT Operator. For more detailed info, please refer to the [PR](https://github.com/aws-observability/aws-otel-test-framework/pull/318) in the aws-otel-test-framework repo.
