### PR TITLE
Add a new CI workflow job to test the ADOT Operator

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -883,6 +883,60 @@ jobs:
         run: |
           cd testing-framework/terraform/eks && terraform destroy -auto-approve
 
+  e2etest-eks-adot-operator:
+    runs-on: ubuntu-latest
+    needs: [ get-testing-suites, e2etest-release, e2etest-preparation ]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.eks-adot-operator-matrix) }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache if success
+        id: e2etest-eks-adot-operator
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: e2etest-eks-adot-operator-${{ github.run_id }}-${{ matrix.testcase }}
+
+      - name: Configure AWS Credentials
+        if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Set up JDK 1.11
+        if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+
+      - name: Set up terraform
+        if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v1
+
+      - name: Check out testing framework
+        if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
+        uses: actions/checkout@v2
+        with:
+          repository: 'aws-observability/aws-otel-collector-test-framework'
+          path: testing-framework
+
+      - name: Run ADOT Operator testing suite on eks
+        if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
+        run: |
+          if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
+          cd testing-framework/terraform/eks && terraform init && terraform apply -auto-approve $opts -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}"
+
+      - name: Destroy resources
+        if: ${{ always() && steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true' }}
+        run: |
+          cd testing-framework/terraform/eks && terraform destroy -auto-approve
+
   release-candidate:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' # only create the artifact when there's a push, not for dispatch.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -574,7 +574,9 @@ jobs:
           ec2_matrix_3=$(python e2etest/get-testcases.py ec2_matrix_3)
           ecs_matrix=$(python e2etest/get-testcases.py ecs_matrix)
           eks_matrix=$(python e2etest/get-testcases.py eks_matrix)
+          eks_adot_operator_matrix=$(python e2etest/get-testcases.py eks_adot_operator_matrix)
           echo "::set-output name=eks-matrix::$eks_matrix"
+          echo "::set-output name=eks-adot-operator-matrix::$eks_adot_operator_matrix"
           echo "::set-output name=ecs-matrix::$ecs_matrix"
           echo "::set-output name=ec2-matrix-1::$ec2_matrix_1"
           echo "::set-output name=ec2-matrix-2::$ec2_matrix_2"
@@ -582,6 +584,7 @@ jobs:
       - name: List testing suites
         run: |
           echo ${{ steps.set-matrix.outputs.eks-matrix }}
+          echo ${{ steps.set-matrix.outputs.eks-adot-operator-matrix }}
           echo ${{ steps.set-matrix.outputs.ecs-matrix }}
           echo ${{ steps.set-matrix.outputs.ec2-matrix-1 }}
           echo ${{ steps.set-matrix.outputs.ec2-matrix-2 }}
@@ -888,6 +891,7 @@ jobs:
     needs: [ get-testing-suites, e2etest-release, e2etest-preparation ]
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.eks-adot-operator-matrix) }}
 
     steps:

--- a/e2etest/get-testcases.py
+++ b/e2etest/get-testcases.py
@@ -65,8 +65,8 @@ if __name__ == "__main__":
                 ecs_matrix["testcase"].append(testcase["case_name"])
             if 'EKS' in testcase["platforms"]:
                 eks_matrix["testcase"].append(testcase["case_name"])
-            if 'EKS_ADOT_OPERATOR' in testcase["platform"]:
-                eks_adot_operator_matrix.append(testcase["case_name"])
+            if 'EKS_ADOT_OPERATOR' in testcase["platforms"]:
+                eks_adot_operator_matrix["testcase"].append(testcase["case_name"])
             if 'LOCAL' in testcase["platforms"]:
                 local_matrix["testcase"].append(testcase["case_name"])
             if 'SOAKING' in testcase["platforms"]:

--- a/e2etest/get-testcases.py
+++ b/e2etest/get-testcases.py
@@ -33,6 +33,7 @@ if __name__ == "__main__":
     ]}
     ecs_matrix = {"testcase": [], "launch_type": ["EC2", "FARGATE"]}
     eks_matrix = {"testcase": []}
+    eks_adot_operator_matrix = {"testcase": []}
     local_matrix = {"testcase": []}
     soaking_matrix = {"testcase": [], "testing_ami": ["soaking_linux", "soaking_windows"]}
     negative_soaking_matrix = {"testcase": [], "testing_ami": ["soaking_linux", "soaking_windows"]}
@@ -45,6 +46,7 @@ if __name__ == "__main__":
             "ec2_matrix_3": ec2_matrix_3,
             "ecs_matrix": ecs_matrix,
             "eks_matrix": eks_matrix,
+            "eks_adot_operator_matrix": eks_adot_operator_matrix,
             "local_matrix": local_matrix,
             "soaking_matrix": soaking_matrix,
             "negative_soaking_matrix": negative_soaking_matrix,
@@ -63,6 +65,8 @@ if __name__ == "__main__":
                 ecs_matrix["testcase"].append(testcase["case_name"])
             if 'EKS' in testcase["platforms"]:
                 eks_matrix["testcase"].append(testcase["case_name"])
+            if 'EKS_ADOT_OPERATOR' in testcase["platform"]:
+                eks_adot_operator_matrix.append(testcase["case_name"])
             if 'LOCAL' in testcase["platforms"]:
                 local_matrix["testcase"].append(testcase["case_name"])
             if 'SOAKING' in testcase["platforms"]:

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -21,7 +21,7 @@
 	},
 	{
 		"case_name": "otlp_trace_adot_operator",
-		"platforms": ["EKS"]
+		"platforms": ["EKS_ADOT_OPERATOR"]
 	},
 	{
 		"case_name": "otlp_mock",
@@ -85,7 +85,7 @@
 	},
 	{
 		"case_name": "prometheus_static_adot_operator",
-		"platforms": ["EKS"]
+		"platforms": ["EKS_ADOT_OPERATOR"]
 	},
 	{
 		"case_name": "prometheus_sd",
@@ -93,7 +93,7 @@
 	},
 	{
 		"case_name": "prometheus_sd_adot_operator",
-		"platforms": ["EKS"]
+		"platforms": ["EKS_ADOT_OPERATOR"]
 	},
 	{
 		"case_name": "containerinsight_eks_prometheus",


### PR DESCRIPTION
**Description:**
This PR adds a new CI workflow job to run the ADOT Operator integration tests.

**Why do we add this job?**
We create this new job because we need to make sure the test cases for ADOT Operator testing don't run in parallel. At any time, there can be only one Operator running in a EKS/Kubernetes cluster because the Operator is installed to a specific namespace (see [here](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/templates/namespace.yaml#L7)).