### PR TITLE
Add ECS EC2 instance level metrics logic to AOC

### DIFF
--- a/config/ecs/otel-instance-metrics-config.yaml
+++ b/config/ecs/otel-instance-metrics-config.yaml
@@ -9,7 +9,7 @@ processors:
 
 exporters:
   awsemf:
-    namespace: ContainerInsightsEC2Instance
+    namespace: ECS/ContainerInsights
     log_group_name: '/aws/ecs/containerinsights/{ClusterName}/performance'
     log_stream_name: 'instanceTelemetry/{ContainerInstanceId}'
     resource_to_telemetry_conversion:

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -134,5 +134,9 @@
 	{
 		"case_name": "containerinsight_ecs_prometheus",
 		"platforms": ["ECS"]
+	},
+	{
+		"case_name": "ecs_instance_metrics",
+		"platforms": ["ECS"]
 	}
 ]


### PR DESCRIPTION
**Description:** 
1, Fix a small error for ecs ec2 config file for the namespace
2, Enable the ECS EC2 integration test logic to AOC.
