### PR TITLE
Added back the ability to run the collector with a different user

### DIFF
--- a/pkg/userutils/userutil_linux.go
+++ b/pkg/userutils/userutil_linux.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var aocUserName = "aoc"
+var defaultUser = "aoc"
 var defaultInstallPath = "/opt/aws/aws-otel-collector/"
 
 type ChownFunc func(name string, uid, gid int) error
@@ -79,6 +79,8 @@ func getRunAsExecUser(runasuser string) (*user.ExecUser, error) {
 // ChangeUser allow customers to run the collector in selected user
 // by default it ran as 'aoc' user but can be set by environment variable
 func ChangeUser() (string, error) {
+
+	var aocUserName = getCustomUser()
 
 	_, err := user.LookupUser(aocUserName)
 	if err != nil {
@@ -159,4 +161,12 @@ func chownRecursive(uid, gid int, dir string) error {
 		return fmt.Errorf("error change owner of dir %s to %v:%v due to error: %w", dir, uid, gid, err)
 	}
 	return nil
+}
+
+// getCustomUser allows to override the default user
+func getCustomUser() string {
+	if user, ok := os.LookupEnv("AOT_RUN_USER"); ok {
+		defaultUser = user
+	}
+	return defaultUser
 }

--- a/pkg/userutils/userutil_test.go
+++ b/pkg/userutils/userutil_test.go
@@ -3,6 +3,7 @@
 package userutils
 
 import (
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -78,6 +79,20 @@ func TestChangeFileOwner(t *testing.T) {
 	if !reflect.DeepEqual(mc.chowns, expected) {
 		t.Errorf("wrong files has been changed ownership, expecting\n%v\n\n but got\n%v", expected, mc.chowns)
 	}
+}
+
+func TestGetCustomUser(t *testing.T) {
+	defer os.Clearenv()
+
+	os.Unsetenv("AOT_RUN_USER")
+
+	user := getCustomUser()
+	assert.Equal(t, user, "aoc")
+
+	os.Setenv("AOT_RUN_USER", "test123")
+
+	user = getCustomUser()
+	assert.Equal(t, user, "test123")
 }
 
 func mkdir(t *testing.T, path string) {


### PR DESCRIPTION
**Description:** 
Added back the possibility to run the collector with a different user than default `aoc`.

Reused the previous environment variable from version 0.9.0 `AOT_RUN_USER`


**Link to tracking Issue:**
https://github.com/aws-observability/aws-otel-collector/issues/618

**Testing:** 
Added a test case. Validated is properly working on an Amazon Linux 2 machine (Cloud9).


**Documentation:**

In the configuration of the agent, add the option to override the default user passing the environment variable 'AOT_RUN_USER'

i.e.: 

```
export AOT_RUN_USER=root
sudo --preserve-env=AOT_RUN_USER /opt/aws/aws-otel-collector/bin/aws-otel-collector --config ./config.yaml
```
