### PR TITLE
Use the stable lint tool on code check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,8 @@ lint: lint-static-check
 .PHONY: install-tools
 install-tools:
 	cd tools/linters && GOBIN=$(PWD)/bin go install golang.org/x/tools/cmd/goimports
-	cd tools/linters && GOBIN=$(PWD)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint
-	cd tools/linters && GOBIN=$(PWD)/bin go install honnef.co/go/tools/cmd/staticcheck
+	cd tools/linters && GOBIN=$(PWD)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.0
+	cd tools/linters && GOBIN=$(PWD)/bin go install honnef.co/go/tools/cmd/staticcheck@v0.2.0
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
**Description:** <Describe what has changed. 
Use the stable lint tool on code check

**Issue**
False alarm on new version of golang lint/static check tool
```
cd tools/linters && GOBIN=/Users/xiami/Documents/workspace/otel/aws-otel-collector/bin go install honnef.co/go/tools/cmd/staticcheck
/Users/xiami/Documents/workspace/otel/aws-otel-collector/bin/staticcheck FAILED => static check errors:

../../../../go/pkg/mod/github.com/dustin/go-humanize@v1.0.0/number.go:76:9: constant  overflow (compile)
```
