### PR TITLE
Add collector configs for ECS deployment variants

### DIFF
--- a/config/ecs/ecs-amp-xray.yaml
+++ b/config/ecs/ecs-amp-xray.yaml
@@ -1,0 +1,54 @@
+extensions:
+  health_check:
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+  awsecscontainermetrics:
+
+processors:
+  batch/traces:
+    timeout: 1s
+    send_batch_size: 50
+  batch/metrics:
+    timeout: 60s
+  filter:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+          - ecs.task.memory.reserved
+          - ecs.task.memory.utilized
+          - ecs.task.cpu.reserved
+          - ecs.task.cpu.utilized
+          - ecs.task.network.rate.rx
+          - ecs.task.network.rate.tx
+          - ecs.task.storage.read_bytes
+          - ecs.task.storage.write_bytes
+          - container.duration
+
+exporters:
+  awsxray:
+  awsprometheusremotewrite:
+    endpoint: $AWS_PROMETHEUS_ENDPOINT
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch/traces]
+      exporters: [awsxray]
+    metrics/application:
+      receivers: [otlp]
+      processors: [batch/metrics]
+      exporters: [awsprometheusremotewrite]
+    metrics:
+      receivers: [awsecscontainermetrics ]
+      processors: [filter]
+      exporters: [ awsprometheusremotewrite ]
+
+  extensions: [health_check]

--- a/config/ecs/ecs-amp.yaml
+++ b/config/ecs/ecs-amp.yaml
@@ -1,0 +1,46 @@
+extensions:
+  health_check:
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+  awsecscontainermetrics:
+
+processors:
+  batch/metrics:
+    timeout: 60s
+  filter:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+          - ecs.task.memory.reserved
+          - ecs.task.memory.utilized
+          - ecs.task.cpu.reserved
+          - ecs.task.cpu.utilized
+          - ecs.task.network.rate.rx
+          - ecs.task.network.rate.tx
+          - ecs.task.storage.read_bytes
+          - ecs.task.storage.write_bytes
+          - container.duration
+
+exporters:
+  awsprometheusremotewrite:
+    endpoint: $AWS_PROMETHEUS_ENDPOINT
+
+service:
+  pipelines:
+    metrics/application:
+      receivers: [otlp]
+      processors: [batch/metrics]
+      exporters: [awsprometheusremotewrite]
+    metrics:
+      receivers: [awsecscontainermetrics ]
+      processors: [filter]
+      exporters: [ awsprometheusremotewrite ]
+
+  extensions: [health_check]

--- a/config/ecs/ecs-cloudwatch-xray.yaml
+++ b/config/ecs/ecs-cloudwatch-xray.yaml
@@ -1,0 +1,213 @@
+extensions:
+  health_check:
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+  awsecscontainermetrics:
+
+processors:
+  batch/traces:
+    timeout: 1s
+    send_batch_size: 50
+  batch/metrics:
+    timeout: 60s
+  filter:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+          - ecs.task.memory.reserved
+          - ecs.task.memory.utilized
+          - ecs.task.cpu.reserved
+          - ecs.task.cpu.utilized
+          - ecs.task.network.rate.rx
+          - ecs.task.network.rate.tx
+          - ecs.task.storage.read_bytes
+          - ecs.task.storage.write_bytes
+          - container.duration
+  metricstransform:
+    transforms:
+      - metric_name: ecs.task.memory.utilized
+        action: update
+        new_name: MemoryUtilized
+      - metric_name: ecs.task.memory.reserved
+        action: update
+        new_name: MemoryReserved
+      - metric_name: ecs.task.cpu.utilized
+        action: update
+        new_name: CpuUtilized
+      - metric_name: ecs.task.cpu.reserved
+        action: update
+        new_name: CpuReserved
+      - metric_name: ecs.task.network.rate.rx
+        action: update
+        new_name: NetworkRxBytes
+      - metric_name: ecs.task.network.rate.tx
+        action: update
+        new_name: NetworkTxBytes
+      - metric_name: ecs.task.storage.read_bytes
+        action: update
+        new_name: StorageReadBytes
+      - metric_name: ecs.task.storage.write_bytes
+        action: update
+        new_name: StorageWriteBytes
+
+  resource:
+    attributes:
+      - key: ClusterName
+        from_attribute: aws.ecs.cluster.name
+        action: insert
+      - key: aws.ecs.cluster.name
+        action: delete
+      - key: ServiceName
+        from_attribute: aws.ecs.service.name
+        action: insert
+      - key: aws.ecs.service.name
+        action: delete
+      - key: TaskId
+        from_attribute: aws.ecs.task.id
+        action: insert
+      - key: aws.ecs.task.id
+        action: delete
+      - key: TaskDefinitionFamily
+        from_attribute: aws.ecs.task.family
+        action: insert
+      - key: aws.ecs.task.family
+        action: delete
+      - key: TaskARN
+        from_attribute: aws.ecs.task.arn
+        action: insert
+      - key: aws.ecs.task.arn
+        action: delete
+      - key: DockerName
+        from_attribute: aws.ecs.docker.name
+        action: insert
+      - key: aws.ecs.docker.name
+        action: delete
+      - key: TaskDefinitionRevision
+        from_attribute: aws.ecs.task.version
+        action: insert
+      - key: aws.ecs.task.version
+        action: delete
+      - key: PullStartedAt
+        from_attribute: aws.ecs.task.pull_started_at
+        action: insert
+      - key: aws.ecs.task.pull_started_at
+        action: delete
+      - key: PullStoppedAt
+        from_attribute: aws.ecs.task.pull_stopped_at
+        action: insert
+      - key: aws.ecs.task.pull_stopped_at
+        action: delete
+      - key: AvailabilityZone
+        from_attribute: cloud.zone
+        action: insert
+      - key: cloud.zone
+        action: delete
+      - key: LaunchType
+        from_attribute: aws.ecs.task.launch_type
+        action: insert
+      - key: aws.ecs.task.launch_type
+        action: delete
+      - key: Region
+        from_attribute: cloud.region
+        action: insert
+      - key: cloud.region
+        action: delete
+      - key: AccountId
+        from_attribute: cloud.account.id
+        action: insert
+      - key: cloud.account.id
+        action: delete
+      - key: DockerId
+        from_attribute: container.id
+        action: insert
+      - key: container.id
+        action: delete
+      - key: ContainerName
+        from_attribute: container.name
+        action: insert
+      - key: container.name
+        action: delete
+      - key: Image
+        from_attribute: container.image.name
+        action: insert
+      - key: container.image.name
+        action: delete
+      - key: ImageId
+        from_attribute: aws.ecs.container.image.id
+        action: insert
+      - key: aws.ecs.container.image.id
+        action: delete
+      - key: ExitCode
+        from_attribute: aws.ecs.container.exit_code
+        action: insert
+      - key: aws.ecs.container.exit_code
+        action: delete
+      - key: CreatedAt
+        from_attribute: aws.ecs.container.created_at
+        action: insert
+      - key: aws.ecs.container.created_at
+        action: delete
+      - key: StartedAt
+        from_attribute: aws.ecs.container.started_at
+        action: insert
+      - key: aws.ecs.container.started_at
+        action: delete
+      - key: FinishedAt
+        from_attribute: aws.ecs.container.finished_at
+        action: insert
+      - key: aws.ecs.container.finished_at
+        action: delete
+      - key: ImageTag
+        from_attribute: container.image.tag
+        action: insert
+      - key: container.image.tag
+        action: delete
+
+exporters:
+  awsxray:
+  awsemf/application:
+    namespace: ECS/AWSOTel/Application
+    log_group_name: '/aws/ecs/application/metrics'
+  awsemf/performance:
+    namespace: ECS/ContainerInsights
+    log_group_name: '/aws/ecs/containerinsights/{ClusterName}/performance'
+    log_stream_name: '{TaskId}'
+    resource_to_telemetry_conversion:
+      enabled: true
+    dimension_rollup_option: NoDimensionRollup
+    metric_declarations:
+      - dimensions: [ [ ClusterName ], [ ClusterName, TaskDefinitionFamily ] ]
+        metric_name_selectors:
+          - MemoryUtilized
+          - MemoryReserved
+          - CpuUtilized
+          - CpuReserved
+          - NetworkRxBytes
+          - NetworkTxBytes
+          - StorageReadBytes
+          - StorageWriteBytes
+      - metric_name_selectors: [container.*]
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch/traces]
+      exporters: [awsxray]
+    metrics/application:
+      receivers: [otlp]
+      processors: [batch/metrics]
+      exporters: [awsemf/application]
+    metrics/performance:
+      receivers: [awsecscontainermetrics ]
+      processors: [filter, metricstransform, resource]
+      exporters: [ awsemf/performance ]
+
+  extensions: [health_check]

--- a/config/ecs/ecs-cloudwatch.yaml
+++ b/config/ecs/ecs-cloudwatch.yaml
@@ -1,0 +1,205 @@
+extensions:
+  health_check:
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+  awsecscontainermetrics:
+
+processors:
+  batch/metrics:
+    timeout: 60s
+  filter:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+          - ecs.task.memory.reserved
+          - ecs.task.memory.utilized
+          - ecs.task.cpu.reserved
+          - ecs.task.cpu.utilized
+          - ecs.task.network.rate.rx
+          - ecs.task.network.rate.tx
+          - ecs.task.storage.read_bytes
+          - ecs.task.storage.write_bytes
+          - container.duration
+  metricstransform:
+    transforms:
+      - metric_name: ecs.task.memory.utilized
+        action: update
+        new_name: MemoryUtilized
+      - metric_name: ecs.task.memory.reserved
+        action: update
+        new_name: MemoryReserved
+      - metric_name: ecs.task.cpu.utilized
+        action: update
+        new_name: CpuUtilized
+      - metric_name: ecs.task.cpu.reserved
+        action: update
+        new_name: CpuReserved
+      - metric_name: ecs.task.network.rate.rx
+        action: update
+        new_name: NetworkRxBytes
+      - metric_name: ecs.task.network.rate.tx
+        action: update
+        new_name: NetworkTxBytes
+      - metric_name: ecs.task.storage.read_bytes
+        action: update
+        new_name: StorageReadBytes
+      - metric_name: ecs.task.storage.write_bytes
+        action: update
+        new_name: StorageWriteBytes
+
+  resource:
+    attributes:
+      - key: ClusterName
+        from_attribute: aws.ecs.cluster.name
+        action: insert
+      - key: aws.ecs.cluster.name
+        action: delete
+      - key: ServiceName
+        from_attribute: aws.ecs.service.name
+        action: insert
+      - key: aws.ecs.service.name
+        action: delete
+      - key: TaskId
+        from_attribute: aws.ecs.task.id
+        action: insert
+      - key: aws.ecs.task.id
+        action: delete
+      - key: TaskDefinitionFamily
+        from_attribute: aws.ecs.task.family
+        action: insert
+      - key: aws.ecs.task.family
+        action: delete
+      - key: TaskARN
+        from_attribute: aws.ecs.task.arn
+        action: insert
+      - key: aws.ecs.task.arn
+        action: delete
+      - key: DockerName
+        from_attribute: aws.ecs.docker.name
+        action: insert
+      - key: aws.ecs.docker.name
+        action: delete
+      - key: TaskDefinitionRevision
+        from_attribute: aws.ecs.task.version
+        action: insert
+      - key: aws.ecs.task.version
+        action: delete
+      - key: PullStartedAt
+        from_attribute: aws.ecs.task.pull_started_at
+        action: insert
+      - key: aws.ecs.task.pull_started_at
+        action: delete
+      - key: PullStoppedAt
+        from_attribute: aws.ecs.task.pull_stopped_at
+        action: insert
+      - key: aws.ecs.task.pull_stopped_at
+        action: delete
+      - key: AvailabilityZone
+        from_attribute: cloud.zone
+        action: insert
+      - key: cloud.zone
+        action: delete
+      - key: LaunchType
+        from_attribute: aws.ecs.task.launch_type
+        action: insert
+      - key: aws.ecs.task.launch_type
+        action: delete
+      - key: Region
+        from_attribute: cloud.region
+        action: insert
+      - key: cloud.region
+        action: delete
+      - key: AccountId
+        from_attribute: cloud.account.id
+        action: insert
+      - key: cloud.account.id
+        action: delete
+      - key: DockerId
+        from_attribute: container.id
+        action: insert
+      - key: container.id
+        action: delete
+      - key: ContainerName
+        from_attribute: container.name
+        action: insert
+      - key: container.name
+        action: delete
+      - key: Image
+        from_attribute: container.image.name
+        action: insert
+      - key: container.image.name
+        action: delete
+      - key: ImageId
+        from_attribute: aws.ecs.container.image.id
+        action: insert
+      - key: aws.ecs.container.image.id
+        action: delete
+      - key: ExitCode
+        from_attribute: aws.ecs.container.exit_code
+        action: insert
+      - key: aws.ecs.container.exit_code
+        action: delete
+      - key: CreatedAt
+        from_attribute: aws.ecs.container.created_at
+        action: insert
+      - key: aws.ecs.container.created_at
+        action: delete
+      - key: StartedAt
+        from_attribute: aws.ecs.container.started_at
+        action: insert
+      - key: aws.ecs.container.started_at
+        action: delete
+      - key: FinishedAt
+        from_attribute: aws.ecs.container.finished_at
+        action: insert
+      - key: aws.ecs.container.finished_at
+        action: delete
+      - key: ImageTag
+        from_attribute: container.image.tag
+        action: insert
+      - key: container.image.tag
+        action: delete
+
+exporters:
+  awsemf/application:
+    namespace: ECS/AWSOTel/Application
+    log_group_name: '/aws/ecs/application/metrics'
+  awsemf/performance:
+    namespace: ECS/ContainerInsights
+    log_group_name: '/aws/ecs/containerinsights/{ClusterName}/performance'
+    log_stream_name: '{TaskId}'
+    resource_to_telemetry_conversion:
+      enabled: true
+    dimension_rollup_option: NoDimensionRollup
+    metric_declarations:
+      - dimensions: [ [ ClusterName ], [ ClusterName, TaskDefinitionFamily ] ]
+        metric_name_selectors:
+          - MemoryUtilized
+          - MemoryReserved
+          - CpuUtilized
+          - CpuReserved
+          - NetworkRxBytes
+          - NetworkTxBytes
+          - StorageReadBytes
+          - StorageWriteBytes
+      - metric_name_selectors: [container.*]
+
+service:
+  pipelines:
+    metrics/application:
+      receivers: [otlp]
+      processors: [batch/metrics]
+      exporters: [awsemf/application]
+    metrics/performance:
+      receivers: [awsecscontainermetrics ]
+      processors: [filter, metricstransform, resource]
+      exporters: [ awsemf/performance ]
+
+  extensions: [health_check]

--- a/config/ecs/ecs-xray.yaml
+++ b/config/ecs/ecs-xray.yaml
@@ -1,0 +1,27 @@
+extensions:
+  health_check:
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch/traces:
+    timeout: 1s
+    send_batch_size: 50
+
+exporters:
+  awsxray:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch/traces]
+      exporters: [awsxray]
+
+  extensions: [health_check]


### PR DESCRIPTION
**Description:** Adds canned collector configs for various possible backend scenarios for ECS containers.

- AMP only
- AMP and X-Ray
- Cloudwatch only
- Cloudwatch and X-Ray
- X-Ray only

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Currently just started the aws-collector docker image with each config to verify it starts up but haven't deployed to infrastructure yet for e2e tests.

**Documentation:** < Describe the documentation added.>
