### PR TITLE
Revert "Added the prometheus receiver to the ECS AMP config files."

### DIFF
--- a/config/ecs/ecs-amp-xray.yaml
+++ b/config/ecs/ecs-amp-xray.yaml
@@ -9,15 +9,6 @@ receivers:
       http:
         endpoint: 0.0.0.0:4318
   awsecscontainermetrics:
-  prometheus:
-    config:
-      global:
-        scrape_interval: 20s
-        scrape_timeout: 10s
-      scrape_configs:
-        - job_name: "otel-collector"
-          static_configs:
-            - targets: [$AWS_PROMETHEUS_SCRAPING_ENDPOINT]
 
 processors:
   batch/traces:
@@ -48,12 +39,8 @@ processors:
 
 exporters:
   awsxray:
-    region: $AWS_REGION
   awsprometheusremotewrite:
     endpoint: $AWS_PROMETHEUS_ENDPOINT
-    aws_auth:
-      region: $AWS_REGION
-      service: "aps"
 
 service:
   pipelines:
@@ -62,12 +49,12 @@ service:
       processors: [resourcedetection, batch/traces]
       exporters: [awsxray]
     metrics/application:
-      receivers: [otlp, prometheus]
+      receivers: [otlp]
       processors: [resourcedetection, batch/metrics]
       exporters: [awsprometheusremotewrite]
     metrics:
-      receivers: [awsecscontainermetrics]
+      receivers: [awsecscontainermetrics ]
       processors: [filter]
-      exporters: [awsprometheusremotewrite]
+      exporters: [ awsprometheusremotewrite ]
 
   extensions: [health_check]

--- a/config/ecs/ecs-amp.yaml
+++ b/config/ecs/ecs-amp.yaml
@@ -9,15 +9,6 @@ receivers:
       http:
         endpoint: 0.0.0.0:4318
   awsecscontainermetrics:
-  prometheus:
-    config:
-      global:
-        scrape_interval: 20s
-        scrape_timeout: 10s
-      scrape_configs:
-        - job_name: "otel-collector"
-          static_configs:
-            - targets: [$AWS_PROMETHEUS_SCRAPING_ENDPOINT]
 
 processors:
   batch/metrics:
@@ -46,19 +37,16 @@ processors:
 exporters:
   awsprometheusremotewrite:
     endpoint: $AWS_PROMETHEUS_ENDPOINT
-    aws_auth:
-      region: $AWS_REGION
-      service: "aps"
 
 service:
   pipelines:
     metrics/application:
-      receivers: [otlp, prometheus]
+      receivers: [otlp]
       processors: [resourcedetection, batch/metrics]
       exporters: [awsprometheusremotewrite]
     metrics:
-      receivers: [awsecscontainermetrics]
+      receivers: [awsecscontainermetrics ]
       processors: [filter]
-      exporters: [awsprometheusremotewrite]
+      exporters: [ awsprometheusremotewrite ]
 
   extensions: [health_check]


### PR DESCRIPTION
Reverts aws-observability/aws-otel-collector#682

Tentatively sending this out

- AWS_REGION is referenced automatically by all aws-related code in the collector (@mxiamxia Alolita mentioned you saying the reference in the yaml is needed, but it isn't right?)
- There seems to be confusion about the prometheus receiver - it is not needed when exporting metrics to AMP, it's only for interfacing with legacy apps. There definitely doesn't seem to be a reason to have it in the default configs, though there could be `-legacy-prometheus` type of configs to support such apps (at that point we definitely need the configuration auto-generated rather than hard-baked).

Currently confirming the second point