### PR TITLE
Delete EC2 Instances That Are Running Over 30 Days For Name Integ-tes…

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,3 +1,15 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
 name: Nightly Build
 
 on:

--- a/.github/workflows/weekly-resources-clean.yml
+++ b/.github/workflows/weekly-resources-clean.yml
@@ -11,27 +11,27 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-name: Hourly Resources Cleaner
+name: Weekly Resources Cleaner
 
 on:
   schedule:
-    - cron: "0 */1 * * *"
+    - cron: "0 0 * * SAT" # Run every saturday at midnight
+  workflow_dispatch:
 
 jobs:
   clean-soaking-resources:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
           aws-region: us-west-2
-          
-      - name: Set up terraform
-        uses: hashicorp/setup-terraform@v1
-      
-      - name: Clean resources which are created before yesterday
-        run: sh tools/workflow/clean-terraform-resources.sh
+
+      - name: Clean old ec2
+        run: go run tools/workflow/clean_ec2.go
+        env:
+          AWS_SDK_LOAD_CONFIG: true

--- a/tools/workflow/clean_ec2.go
+++ b/tools/workflow/clean_ec2.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"log"
+	"time"
+)
+
+func main() {
+	// set up aws go sdk ec2 client
+	testSession, err := session.NewSession()
+	if err != nil {
+		log.Fatalf("Error creating session %v", err)
+	}
+	ec2client := ec2.New(testSession)
+
+	// Get list of instance
+	//State filter
+	instanceStateFilter := ec2.Filter{Name: aws.String("instance-state-name"), Values: []*string{aws.String("running")}}
+
+	//Tag filter
+	instanceTagFilter := ec2.Filter{Name: aws.String("tag:Name"), Values: []*string{aws.String("Integ-test-Sample-App"), aws.String("Integ-test-aoc")}}
+
+	//get instances to delete
+	var deleteInstanceIds []*string
+	var nextToken *string
+	for {
+		describeInstancesInput := ec2.DescribeInstancesInput{Filters: []*ec2.Filter{&instanceStateFilter, &instanceTagFilter}, NextToken: nextToken}
+		describeInstancesOutput, err := ec2client.DescribeInstances(&describeInstancesInput)
+		if err != nil {
+			log.Fatalf("Failed to get instance for error %v", err)
+		}
+		for _, reservation := range describeInstancesOutput.Reservations {
+			for _, instance := range reservation.Instances {
+				//only delete instance if older than 30 days
+				if time.Now().UTC().Add(-1 * time.Hour * 24 * 30).After(*instance.LaunchTime) {
+					log.Printf("Try to delete instance %s tags %v launch-date %v", *instance.InstanceId, instance.Tags, instance.LaunchTime)
+					deleteInstanceIds = append(deleteInstanceIds, instance.InstanceId)
+				}
+			}
+		}
+		if describeInstancesOutput.NextToken == nil {
+			break
+		}
+		nextToken = describeInstancesOutput.NextToken
+	}
+
+	if len(deleteInstanceIds) < 1 {
+		log.Print("No instances to delete")
+		return
+	}
+
+	terminateInstancesInput := ec2.TerminateInstancesInput{InstanceIds: deleteInstanceIds}
+	_, err = ec2client.TerminateInstances(&terminateInstancesInput)
+	if err != nil {
+		log.Fatalf("Failed to terminate instance %v", err)
+	}
+}


### PR DESCRIPTION
…t-Sample-App And Integ-test-aoc

**Description:** 
EC2 instances are staying alive too long. Thus reducing the amount of open subnets. This fails the soaking test

**Link to tracking Issue:** 
(#711 )

**Testing:** 
Only dry run since someone deleted the old instance manually and I did not want to delete any new instances. 

