### PR TITLE
Add Max Stats To Performance Tests

### DIFF
--- a/e2etest/get-performance-model-table.py
+++ b/e2etest/get-performance-model-table.py
@@ -16,6 +16,8 @@ def add_performance_model(model):
     # process model values
     model["avgCpu"] = "{:.2f}".format(model["avgCpu"])
     model["avgMem"] = "{:.2f}".format(model["avgMem"])
+    model["maxCpu"] = "{:.2f}".format(model["maxCpu"])
+    model["maxMem"] = "{:.2f}".format(model["maxMem"])
     model["receivers"].sort()
     model["processors"].sort()
     model["exporters"].sort()

--- a/e2etest/templates/performance_model.tpl
+++ b/e2etest/templates/performance_model.tpl
@@ -8,9 +8,9 @@
 
 {% for models in models_list %}
 ### {{ models.data_mode }} (TPS: {{ models.data_rate }})
-| Receivers | Processors | Exporters | Test Case | Data Type | Instance Type | Avg CPU Usage (Percent) | Avg Memory Usage (Megabytes) |
-|:---------:|:----------:|:---------:|:---------:|:---------:|:-------------:|:-----------------------:|:----------------------------:|
+| Receivers | Processors | Exporters | Test Case | Data Type | Instance Type | Avg CPU Usage (Percent) | Avg Memory Usage (Megabytes) | Max CPU Usage (Percent) | Max Memory Usage (Megabytes) |
+|:---------:|:----------:|:---------:|:---------:|:---------:|:-------------:|:-----------------------:|:----------------------------:|:-----------------------:|:----------------------------:|
 {% for model in models.models -%}
-| {{ model.receivers }} | {{ model.processors }} | {{ model.exporters }} | {{ model.testcase }} | {{ model.dataType }} | {{ model.instanceType }} | {{ model.avgCpu }} | {{ model.avgMem }} |
+| {{ model.receivers }} | {{ model.processors }} | {{ model.exporters }} | {{ model.testcase }} | {{ model.dataType }} | {{ model.instanceType }} | {{ model.avgCpu }} | {{ model.avgMem }} | {{ model.maxCpu }} | {{ model.maxMem }} |
 {% endfor %}
 {%- endfor -%}


### PR DESCRIPTION
**Description:** 
Add Max Stats To Performance Tests

**Testing:**
run terraform apply -auto-approve -lock=false -var="data_rate=1000" -var="commit_id=cc8eb315135bdfed89782ee2f1368e5445df5ed3" $opts -var="aoc_version=v0.14.0-1425926427" -var="testcase=../testcases/otlp_metric" -var="ssh_key_name=aoc-ssh-key-2020-07-22" -var="sshkey_s3_bucket=aoc-ssh-key" -var="sshkey_s3_private_key=aoc-ssh-key-2020-07-22.txt" -var="testing_ami=soaking_linux"
run cat output/performance.json
output {"testcase":"otlp_metric","instanceType":"m5.2xlarge","receivers":["otlp"],"processors":["batch"],"exporters":["logging","awsemf"],"dataType":"otlp","dataMode":"metric","dataRate":1000,"avgCpu":0.041666388726423156,"avgMem":57.2450816,"maxCpu":0.19999649156154697,"maxMem":57.360384,"commitId":"cc8eb315135bdfed89782ee2f1368e5445df5ed3","collectionPeriod":10,"testingAmi":"soaking_linux"}
