### PR TITLE
Avoid building repetition docker image when doing PR Build Action

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -21,7 +21,14 @@ on:
 
 env:
   IMAGE_NAME: aws-otel-collector
-  PACKAGING_ROOT: build/packages 
+  PACKAGING_ROOT: build/packages
+  ECR_REPO: aws-observability/aws-otel-collector
+  IMAGE_LINK: "public.ecr.aws/aws-observability/aws-otel-collector"
+
+  TF_VAR_aws_access_key_id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+  TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+  TF_VAR_aoc_vpc_name: aoc-vpc-large
+  TF_VAR_aoc_vpc_security_group: aoc-vpc-security-group-large
 
 jobs:
 
@@ -134,9 +141,76 @@ jobs:
         run: |
           ARCH=amd64 TARGET_SUPPORTED_ARCH=x86_64 DEST=build/packages/debian/amd64 tools/packaging/debian/create_deb.sh
           ARCH=arm64 TARGET_SUPPORTED_ARCH=aarch64 DEST=build/packages/debian/arm64 tools/packaging/debian/create_deb.sh
-   
+
+  packaging-image:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Cache Docker Image
+        id: cached_image
+        uses: actions/cache@v2
+        with:
+          key: "cached_image_${{ github.run_id }}"
+          path: "${{ env.PACKAGING_ROOT }}"
+
+      - name: Build Docker Image
+        if: steps.cached_image.outputs.cache-hit != 'true'
+        run: docker build -t $IMAGE_NAME -f cmd/awscollector/Dockerfile .
+
+      #Save the image as a tar file and let the Cache Docker Image step cache for later use.
+      #More information about docker save: https://docs.docker.com/engine/reference/commandline/save/
+      - name: Extract the Image file
+        if: steps.cached_image.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p $PACKAGING_ROOT
+          docker save --output $PACKAGING_ROOT/$IMAGE_NAME.tar $IMAGE_NAME
+
+  versioning-image:
+    runs-on: ubuntu-latest
+    needs: packaging-image
+    steps:
+      - name: Versioning for testing
+        id: versioning
+        run: |
+          # build a version with github run id so that we can distingush each build for integ-test
+          Version="`cat VERSION`-$GITHUB_RUN_ID"
+          echo $Version > build/packages/VERSION
+          cat build/packages/VERSION
+          echo "::set-output name=version::$Version"
+
+  test-case-preparation:
+    runs-on: ubuntu-latest
+    needs: versioning-image
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Restore Docker Cached Image
+        uses: actions/cache@v2
+        with:
+          key: "cached_image_${{ github.run_id }}"
+          path: "${{ env.PACKAGING_ROOT }}"
+
+      #Login to ECR and upload the workflow cached image with the version equals to github_id
+      - name: Login ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - run: ls -R
+
+      - name: Upload To ECR
+        run: |
+          docker load < $PACKAGING_ROOT/$IMAGE_NAME.tar
+          docker tag $IMAGE_NAME ${{ steps.login-ecr.outputs.registry }}/$ECR_REPO:${{ needs.versioning-image.outputs.version }}
+          docker push ${{ steps.login-ecr.outputs.registry }}/$ECR_REPO:${{ needs.versioning-image.outputs.version }}
+
   get-test-cases:
     runs-on: ubuntu-latest
+    needs: test-case-preparation
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -57,7 +57,7 @@ jobs:
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build
-        key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        key: go-pkg-mod-v1-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
 
 
     - name: Cache binaries

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -75,7 +75,7 @@ jobs:
       if: steps.cached_binaries.outputs.cache-hit != 'true'
       run: make build
 
-  - name: Upload Coverage report to CodeCov
+    - name: Upload Coverage report to CodeCov
       uses: codecov/codecov-action@v1.0.12
       if: steps.cached_binaries.outputs.cache-hit != 'true'
       with:

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -215,7 +215,7 @@ jobs:
 
   get-test-cases:
     runs-on: ubuntu-latest
-    needs: test-case-preparation
+    needs: packaging-pushing-image
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # Set up building environment, patch the dev repo code on dispatch events.  
+    # Set up building environment, patch the dev repo code on dispatch events.
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
@@ -198,8 +198,9 @@ jobs:
       - name: Versioning for testing
         run: |
           Version="`cat VERSION`-$GITHUB_RUN_ID"
-          echo $Version > build/packages/VERSION
-          cat build/packages/VERSION
+          mkdir -p $PACKAGING_ROOT
+          echo $Version > $PACKAGING_ROOT/VERSION
+          cat $PACKAGING_ROOT/VERSION
           echo "::set-output name=version::$Version"
 
   test-case-preparation:

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -164,7 +164,7 @@ jobs:
           ARCH=amd64 TARGET_SUPPORTED_ARCH=x86_64 DEST=build/packages/debian/amd64 tools/packaging/debian/create_deb.sh
           ARCH=arm64 TARGET_SUPPORTED_ARCH=aarch64 DEST=build/packages/debian/arm64 tools/packaging/debian/create_deb.sh
 
-  packaging-image:
+  packaging-pushing-image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -179,23 +179,11 @@ jobs:
         if: steps.cached_image.outputs.cache-hit != 'true'
         run: docker build -t $IMAGE_NAME -f cmd/awscollector/Dockerfile .
 
-      #Save the image as a tar file and let the Cache Docker Image step cache for later use.
-      #Documentation: https://docs.docker.com/engine/reference/commandline/save/
-      - name: Extract the Image file
-        if: steps.cached_image.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p $PACKAGING_ROOT
-          docker save --output $PACKAGING_ROOT/$IMAGE_NAME.tar $IMAGE_NAME
-
-  versioning-image:
-    runs-on: ubuntu-latest
-    needs: packaging-image
-    steps:
-      - uses: actions/checkout@v2
-      #To ensure each PR build is having different tag and for the re-run when the same workflow will have the same tag,
-      #Using github.run_id would fit into our use case
-      #Documentation: https://docs.github.com/en/actions/learn-github-actions/contexts
+        #To ensure each PR build is having different tag and for the re-run when the same workflow will have the same tag,
+        #Using github.run_id would fit into our use case
+        #Documentation: https://docs.github.com/en/actions/learn-github-actions/contexts
       - name: Versioning for testing
+        if: steps.cached_image.outputs.cache-hit != 'true'
         run: |
           Version="`cat VERSION`-$GITHUB_RUN_ID"
           mkdir -p $PACKAGING_ROOT
@@ -203,20 +191,6 @@ jobs:
           cat $PACKAGING_ROOT/VERSION
           echo "::set-output name=version::$Version"
 
-  test-case-preparation:
-    runs-on: ubuntu-latest
-    needs: versioning-image
-    steps:
-
-      - uses: actions/checkout@v2
-      #To avoid repetition in tagging and uploading the docker image to ECR, we use file VERSION to become an intermediate
-      - name: Cache preparation
-        id: cached-preparation
-        uses: actions/cache@v2
-        with:
-          path: |
-            VERSION
-          key: test-preparation-${{ github.run_id }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -226,14 +200,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
           aws-region: us-west-2
 
-      - name: Restore Docker Cached Image
-        uses: actions/cache@v2
-        if: steps.cached-preparation.outputs.cache-hit != 'true'
-        with:
-          key: "cached_image_${{ github.run_id }}"
-          path: "${{ env.PACKAGING_ROOT }}"
-
-      #Load the previous cache image when using docker build and upload it to ECR with the github_id tag version
+        #Load the previous cache image when using docker build and upload it to ECR with the github_id tag version
       - name: Login ECR
         id: login-ecr
         if: steps.cached-preparation.outputs.cache-hit != 'true'
@@ -242,9 +209,9 @@ jobs:
       - name: Upload To ECR
         if: steps.cached-preparation.outputs.cache-hit != 'true'
         run: |
-          docker load < $PACKAGING_ROOT/$IMAGE_NAME.tar
           docker tag $IMAGE_NAME ${{ steps.login-ecr.outputs.registry }}/$ECR_REPO:${{ needs.versioning-image.outputs.version }}
           docker push ${{ steps.login-ecr.outputs.registry }}/$ECR_REPO:${{ needs.versioning-image.outputs.version }}
+
 
   get-test-cases:
     runs-on: ubuntu-latest

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -166,8 +166,8 @@ jobs:
 
   packaging-image:
     runs-on: ubuntu-latest
-    needs: build
     steps:
+      - uses: actions/checkout@v2
       - name: Cache Docker Image
         id: cached_image
         uses: actions/cache@v2
@@ -191,6 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: packaging-image
     steps:
+      - uses: actions/checkout@v2
       #To ensure each PR build is having different tag and for the re-run when the same workflow will have the same tag,
       #Using github.run_id would fit into our use case
       #Documentation: https://docs.github.com/en/actions/learn-github-actions/contexts
@@ -205,6 +206,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: versioning-image
     steps:
+
+      - uses: actions/checkout@v2
       #To avoid repetition in tagging and uploading the docker image to ECR, we use file VERSION to become an intermediate
       - name: Cache preparation
         id: cached-preparation

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -158,7 +158,7 @@ jobs:
         run: docker build -t $IMAGE_NAME -f cmd/awscollector/Dockerfile .
 
       #Save the image as a tar file and let the Cache Docker Image step cache for later use.
-      #More information about docker save: https://docs.docker.com/engine/reference/commandline/save/
+      #Documentation: https://docs.docker.com/engine/reference/commandline/save/
       - name: Extract the Image file
         if: steps.cached_image.outputs.cache-hit != 'true'
         run: |
@@ -169,10 +169,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: packaging-image
     steps:
+      - name: Cache
+      #To ensure each PR build is having different tag and for the re-run when the same workflow will have the same tag,
+      #Using github.run_id would fit into our use case
+      #Documentation: https://docs.github.com/en/actions/learn-github-actions/contexts
       - name: Versioning for testing
-        id: versioning
         run: |
-          # build a version with github run id so that we can distingush each build for integ-test
           Version="`cat VERSION`-$GITHUB_RUN_ID"
           echo $Version > build/packages/VERSION
           cat build/packages/VERSION
@@ -182,8 +184,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: versioning-image
     steps:
+      #To avoid repetition in tagging and uploading the docker image to ECR, we use file VERSION to become an intermediate
+      - name: Cache preparation
+        id: cached-preparation
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: test-preparation-${{ github.run_id }}
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
+        if: steps.cached-preparation.outputs.cache-hit != 'true'
         with:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
@@ -191,18 +203,19 @@ jobs:
 
       - name: Restore Docker Cached Image
         uses: actions/cache@v2
+        if: steps.cached-preparation.outputs.cache-hit != 'true'
         with:
           key: "cached_image_${{ github.run_id }}"
           path: "${{ env.PACKAGING_ROOT }}"
 
-      #Login to ECR and upload the workflow cached image with the version equals to github_id
+      #Load the previous cache image when using docker build and upload it to ECR with the github_id tag version
       - name: Login ECR
         id: login-ecr
+        if: steps.cached-preparation.outputs.cache-hit != 'true'
         uses: aws-actions/amazon-ecr-login@v1
 
-      - run: ls -R
-
       - name: Upload To ECR
+        if: steps.cached-preparation.outputs.cache-hit != 'true'
         run: |
           docker load < $PACKAGING_ROOT/$IMAGE_NAME.tar
           docker tag $IMAGE_NAME ${{ steps.login-ecr.outputs.registry }}/$ECR_REPO:${{ needs.versioning-image.outputs.version }}

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -44,14 +44,10 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    # Unit Test and attach test coverage badge
-    - name: Unit Test
-      run: make test
-
-    #Cache go build and dependencies before making unit testing and build
-    #Samples codes for different OS: https://github.com/actions/cache/blob/main/examples.md#go---modules
-    #Since we are using Linux, the go packages are in /go/pkg/mod and build are in /.cache/go-build
-    #Also speed up unit testing since go test uses the go build cache and also speed up the go build.
+      #Cache go build and dependencies before making unit testing and build
+      #Samples codes for different OS: https://github.com/actions/cache/blob/main/examples.md#go---modules
+      #Since we are using Linux, the go packages are in /go/pkg/mod and build are in /.cache/go-build
+      #Also speed up unit testing since go test uses the go build cache and also speed up the go build.
     - name: Cache go
       id: cached_go
       uses: actions/cache@v2
@@ -63,6 +59,7 @@ jobs:
           ~/.cache/go-build
         key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
 
+
     - name: Cache binaries
       id: cached_binaries
       uses: actions/cache@v2
@@ -70,16 +67,23 @@ jobs:
         key: "cached_binaries_${{ github.run_id }}"
         path: build
 
-    # Build and archive binaries into cache.
-    - name: Build Binaries
+      # Unit Test and attach test coverage badge
+    - name: Unit Test
       if: steps.cached_binaries.outputs.cache-hit != 'true'
-      run: make build
+      run: make test
 
     - name: Upload Coverage report to CodeCov
       uses: codecov/codecov-action@v1.0.12
       if: steps.cached_binaries.outputs.cache-hit != 'true'
       with:
         file: ./coverage.txt
+
+    # Build and archive binaries into cache.
+    - name: Build Binaries
+      if: steps.cached_binaries.outputs.cache-hit != 'true'
+      run: make build
+
+
 
     # upload the binaries to artifact as well because cache@v2 hasn't support windows
     - name: Upload

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -22,7 +22,7 @@ on:
 env:
   IMAGE_NAME: aws-otel-collector
   PACKAGING_ROOT: build/packages
-  ECR_REPO: aws-observability/aws-otel-collector
+  ECR_REPO: aws-adot-pr-build/aws-otel-collector
   IMAGE_LINK: "public.ecr.aws/aws-observability/aws-otel-collector"
 
   TF_VAR_aws_access_key_id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -169,7 +169,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: packaging-image
     steps:
-      - name: Cache
       #To ensure each PR build is having different tag and for the re-run when the same workflow will have the same tag,
       #Using github.run_id would fit into our use case
       #Documentation: https://docs.github.com/en/actions/learn-github-actions/contexts

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -48,20 +48,38 @@ jobs:
     - name: Unit Test
       run: make test
 
-    - name: Upload Coverage report to CodeCov
-      uses: codecov/codecov-action@v1.0.12
+    #Cache go build and dependencies before making unit testing and build
+    #Samples codes for different OS: https://github.com/actions/cache/blob/main/examples.md#go---modules
+    #Since we are using Linux, the go packages are in /go/pkg/mod and build are in /.cache/go-build
+    #Also speed up unit testing since go test uses the go build cache and also speed up the go build.
+    - name: Cache go
+      id: cached_go
+      uses: actions/cache@v2
+      env:
+        cache-name: cached_go_modules
       with:
-        file: ./coverage.txt
-
-    # Build and archive binaries into cache.
-    - name: Build Binaries
-      run: make build
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
 
     - name: Cache binaries
+      id: cached_binaries
       uses: actions/cache@v2
       with:
         key: "cached_binaries_${{ github.run_id }}"
         path: build
+
+    # Build and archive binaries into cache.
+    - name: Build Binaries
+      if: steps.cached_binaries.outputs.cache-hit != 'true'
+      run: make build
+
+  - name: Upload Coverage report to CodeCov
+      uses: codecov/codecov-action@v1.0.12
+      if: steps.cached_binaries.outputs.cache-hit != 'true'
+      with:
+        file: ./coverage.txt
 
     # upload the binaries to artifact as well because cache@v2 hasn't support windows
     - name: Upload


### PR DESCRIPTION
**Description:** <Describe what has changed. 
To avoid repetition of building docker image amongst test case (avoid wasting resources and improve time), we need to ** add a step for PR Build Actions **: publishing docker image to ECR and let's the test framework pull the image. 
Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.>

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/aws-observability/aws-otel-collector/issues/716

**Testing:** 

**Documentation:** < Describe the documentation added.>
