### PR TITLE
Move Out Binary Build From Dockerfile

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -37,6 +37,14 @@ jobs:
 
     - uses: actions/checkout@v2
 
+    - name: Cache Build
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
     # Unit Test and attach test coverage badge
     - name: Unit Test
       run: make test
@@ -170,7 +178,7 @@ jobs:
           
   run-test-case:
     runs-on: ubuntu-latest
-    needs: [get-test-cases]
+    needs: [get-test-cases, build]
     strategy:
       matrix: ${{ fromJson(needs.get-test-cases.outputs.matrix) }}
     
@@ -180,7 +188,7 @@ jobs:
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
-          
+
       - name: Check out Collector
         uses: actions/checkout@v2
         with:
@@ -193,7 +201,16 @@ jobs:
       
       - name: Set up terraform
         uses: hashicorp/setup-terraform@v1.2.1
-        
+
+      - name: restore cached binaries
+        uses: actions/cache@v2
+        with:
+          key: "cached_binaries_${{ github.run_id }}"
+          path: build
+
+      - name: copy binary
+        run: cp -R build aws-otel-collector/build
+
       - name: Run test
         run: | 
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ package-deb: build
 	ARCH=arm64 TARGET_SUPPORTED_ARCH=aarch64 DEST=build/packages/debian/arm64 tools/packaging/debian/create_deb.sh
 
 .PHONY: docker-build
-docker-build: 
+docker-build: amd64-build
 	docker build -t $(DOCKER_NAMESPACE)/$(COMPONENT):$(VERSION) -f ./cmd/$(COMPONENT)/Dockerfile .
 
 .PHONY: docker-push

--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -16,11 +16,7 @@ RUN apk add --update bash git make build-base
 COPY --from=golang:1.17-alpine /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
 
-# download go modules ahead to speed up the building
 WORKDIR /workspace
-COPY go.mod /workspace/go.mod
-COPY go.sum /workspace/go.sum
-RUN go mod download
 
 # copy artifacts
 COPY cmd  /workspace/cmd
@@ -32,8 +28,18 @@ COPY .git /workspace/.git
 COPY Makefile /workspace/Makefile
 COPY config /workspace/config
 
-# build binary
-RUN make amd64-build
+#Copy binary if exist else build binary
+COPY go.* build/linux/aoc_linux_x86_6* /workspace/
+RUN if [[ -f /workspace/aoc_linux_x86_64 ]] ; \
+    then \
+        echo Copying binary \
+        && mkdir -p /workspace/build/linux \
+        && cp /workspace/aoc_linux_x86_64 /workspace/build/linux/aoc_linux_x86_64 ; \
+    else \
+        echo Building binary \
+        && go mod download  \
+        && make amd64-build ; \
+    fi
 
 ################################
 #	Final Stage            #	


### PR DESCRIPTION
Co-authored-by: Khanh Nguyen <khanhntd@amazon.com>

**Description:** 
Move out binary build from docker file so it can be cached

**Link to tracking Issue:** 
#716

**Testing:** 
Github action run
