### PR TITLE
Cancel PR-build workflow on new push.

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -27,6 +27,7 @@ concurrency:
   group: pr-build-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+
 jobs:
 
   build:

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -27,9 +27,7 @@ concurrency:
   group: pr-build-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-
 jobs:
-
   build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -23,6 +23,10 @@ env:
   IMAGE_NAME: aws-otel-collector
   PACKAGING_ROOT: build/packages 
 
+concurrency:
+  group: pr-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
 
   build:


### PR DESCRIPTION
**Description:** Cancels old running PR-builds for a PR.

**Link to tracking Issue:** https://github.com/aws-observability/aws-otel-collector/issues/717
