### PR TITLE
Cancels the CI workflow on latest push.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,6 +42,10 @@ env:
   WIN_UNSIGNED_PKG_FOLDER: OTelCollectorAuthenticode/AuthenticodeSigner-SHA256-RSA
   WIN_SIGNED_PKG_FOLDER: OTelCollectorAuthenticode/AuthenticodeSigner-SHA256-RSA
 
+concurrency:
+  group: ci
+  cancel-in-progress: true
+
 jobs:
   build-aotutil:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Uses the `ci` group to cancel old pending or in progress CI workflows.