### PR TITLE
Remove config and deployment-template from PR-build file filter.

### DIFF
--- a/.github/config/file-filters.yml
+++ b/.github/config/file-filters.yml
@@ -1,8 +1,6 @@
 changed:
   - '.github/workflows/PR-build.yml'
   - 'cmd/**'
-  - 'config/**'
-  - 'deployment-template/**'
   - 'e2etest/**'
   - 'pkg/**'
   - 'tools/**'


### PR DESCRIPTION
**Description:** Since they don't affect either process, the PR-build shouldn't need to run.
