### PR TITLE
Add prometheusremotewriteexporter in aws-otel-collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This table represents the supported components of AWS OTel Collector in 2020. Th
 | zipkinreceiver                  | probabilisticsamplerprocessor | fileexporter                       |                        |
 | jaegerreceiver                  | spanprocessor                 | otlphttpexporter                   |                        |
 | `awscontainerinsightreceiver`   | filterprocessor               | prometheusexporter                 |                        |
+|                                 | filterprocessor               | prometheusremotewriteexporter      |                        |
 |                                 | metricstransformprocessor     | datadogexporter                    |                        |
 |                                 | resourcedetectionprocessor    | dynatraceexporter                  |                        |
 |                                 |                               | sapmexporter                       |                        |

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.38.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter v0.38.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.38.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.38.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.38.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.38.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy v0.38.0

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -24,6 +24,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy"
@@ -117,6 +118,7 @@ func Components() (component.Factories, error) {
 		awsemfexporter.NewFactory(),
 		awsprometheusremotewriteexporter.NewFactory(),
 		prometheusexporter.NewFactory(),
+		prometheusremotewriteexporter.NewFactory(),
 		loggingexporter.NewFactory(),
 		fileexporter.NewFactory(),
 		otlpexporter.NewFactory(),

--- a/pkg/lambdacomponents/defaults.go
+++ b/pkg/lambdacomponents/defaults.go
@@ -20,6 +20,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsprometheusremotewriteexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter/loggingexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
@@ -48,6 +49,7 @@ func Components() (
 		awsemfexporter.NewFactory(),
 		awsprometheusremotewriteexporter.NewFactory(),
 		prometheusexporter.NewFactory(),
+		prometheusremotewriteexporter.NewFactory(),
 		loggingexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),

--- a/pkg/lambdacomponents/go.mod
+++ b/pkg/lambdacomponents/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsprometheusremotewriteexporter v0.38.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.38.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.38.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.38.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.38.0
 	go.uber.org/multierr v1.7.0


### PR DESCRIPTION
**Description:** 

Good morning, I'm creating this PR because I needed to adapt the code of aws-otel to support an exporter that exists in OpenTelemetry Collector. This exporter is prometheusremotewriteexporter. Although I have solved the problem using an own image, there are automatic processes that I do in which it is much easier for this to be in official aws-otel-collector. 

**Testing:** 

As I said earlier, I created an image of my own from this PR. This image has been tested to collect ECS metrics and send to a local Prometheus from this exporter. As you can see in the following image, there are ECS metrics that are being collected and displayed in my prometheus.

![image](https://user-images.githubusercontent.com/32776046/142420269-9a3f75bf-778c-4c71-836b-0d7200e81ccd.png)
