### PR TITLE
Separate CodeQL analysis into own workflow.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -152,31 +152,6 @@ jobs:
         name: binary_artifacts
         path: build
 
-  analyze:
-    name: CodeQL Analyze
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Cache if success
-        id: analyze
-        uses: actions/cache@v2
-        with:
-          path: |
-            VERSION
-          key: analyze-${{ github.run_id }}
-
-      - name: Initialize CodeQL
-        if: steps.analyze.outputs.cache-hit != 'true'
-        uses: github/codeql-action/init@v1
-        with:
-          languages: "go"
-
-      - name: Perform CodeQL Analysis
-        if: steps.analyze.outputs.cache-hit != 'true'
-        uses: github/codeql-action/analyze@v1
-
   packaging-msi:
     needs: build
     runs-on: windows-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1026,7 +1026,7 @@ jobs:
           path: build/packages
           key: "cached_packages_${{ github.run_id }}"
 
-      - name: clean up SSM test package which passed CI test
+      - name: clean up SSM test package
         run: |
           ssm_pkg_version=`cat build/packages/VERSION`
           aws ssm delete-document --name "testAWSDistroOTel-Collector" --version-name ${ssm_pkg_version}

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -104,25 +104,6 @@ jobs:
         path: build
       if: ${{ needs.changes.outputs.changed == 'true' }}
 
-  analyze:
-    name: CodeQL Analyze
-    runs-on: ubuntu-latest
-    needs: changes
-    steps:
-      - uses: actions/checkout@v2
-        if: ${{ needs.changes.outputs.changed == 'true' }}
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
-        with:
-          debug: true
-          languages: "go"
-        if: ${{ needs.changes.outputs.changed == 'true' }}
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
-        if: ${{ needs.changes.outputs.changed == 'true' }}
-
   packaging-msi:
     runs-on: windows-latest
     needs: [changes, build]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,34 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+name: CodeQL Analysis
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: go
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
**Description:** CodeQL slows down the PR process and re-runs on each PR update. Separated into its own workflow and set to only run on merges to `main` or `dev`.

