### PR TITLE
Change CI to always run create SSM package if it doesn't exist.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -519,7 +519,6 @@ jobs:
           key: e2etest-release-${{ github.run_id }}
 
       - name: Configure AWS Credentials
-        if: steps.e2etest-release.outputs.cache-hit != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
@@ -527,22 +526,25 @@ jobs:
           aws-region: us-west-2
 
       - name: restore cached rpms
-        if: steps.e2etest-release.outputs.cache-hit != 'true'
         uses: actions/cache@v2
         with:
           path: build/packages
           key: "cached_packages_${{ github.run_id }}"
 
       - name: Create SSM package
-        if: steps.e2etest-release.outputs.cache-hit != 'true'
         run: |
-          pip3 install boto3
           ssm_pkg_version=`cat build/packages/VERSION`
-          python3 tools/ssm/ssm_manifest.py ${ssm_pkg_version}
-          aws s3 cp build/packages/ssm s3://aws-otel-collector-test/ssm/${ssm_pkg_version} --recursive
-          python3 tools/ssm/ssm_create.py --no-default testAWSDistroOTel-Collector ${ssm_pkg_version} aws-otel-collector-test/ssm/${ssm_pkg_version} us-west-2
+          aws ssm describe-document --name "testAWSDistroOTel-Collector" --version-name ${ssm_pkg_version} >/dev/null 2>&1
+          if [ $? -ne 0 ]; then
+            pip3 install boto3
+            python3 tools/ssm/ssm_manifest.py ${ssm_pkg_version}
+            aws s3 cp build/packages/ssm s3://aws-otel-collector-test/ssm/${ssm_pkg_version} --recursive
+            python3 tools/ssm/ssm_create.py --no-default testAWSDistroOTel-Collector ${ssm_pkg_version} aws-otel-collector-test/ssm/${ssm_pkg_version} us-west-2
+          else
+            echo "SSM package ($ssm_pkg_version) already exists"
+          fi
 
-      - name: upload to s3 in the testing stack
+      - name: Upload to S3 in the testing stack
         if: steps.e2etest-release.outputs.cache-hit != 'true'
         run: s3_bucket_name=aws-otel-collector-test upload_to_latest=0 bash tools/release/s3-release.sh
 


### PR DESCRIPTION
**Description:** The SSM document was being removed at the end of each run and not being recreated on a re-run of the CI. This was causing SSM tests that weren't cached to fail on these re-run attempts. Changed the CI to always check if the version exists before skipping the step.

**Link to tracking Issue:** https://github.com/aws-observability/aws-otel-collector/issues/695#issuecomment-964316357