### PR TITLE
Fix config environment variable expansion for AOT_CONFIG_CONTENT

### DIFF
--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -72,10 +72,9 @@ func main() {
 	if lumberHook != nil {
 		params.LoggingOptions = []zap.Option{zap.Hooks(lumberHook)}
 	}
-	if err := run(params); err != nil {
+	if err = run(params); err != nil {
 		logFatal(err)
 	}
-
 }
 
 func runInteractive(params service.CollectorSettings) error {

--- a/pkg/config/config_factory.go
+++ b/pkg/config/config_factory.go
@@ -32,7 +32,7 @@ func GetMapProvider() configmapprovider.Provider {
 	// including SSM parameter store for ECS use case
 	if configContent, ok := os.LookupEnv(envKey); ok {
 		log.Printf("Reading AOT config from environment: %v\n", configContent)
-		return configmapprovider.NewInMemory(strings.NewReader(configContent))
+		return configmapprovider.NewExpand(configmapprovider.NewInMemory(strings.NewReader(configContent)))
 	}
 
 	return configmapprovider.NewDefault(getConfigFlag(), getSetFlag())

--- a/pkg/config/testdata/config.yaml
+++ b/pkg/config/testdata/config.yaml
@@ -9,7 +9,7 @@ receivers:
       http:
         endpoint: 0.0.0.0:55681
   awsxray:
-    endpoint: 0.0.0.0:2000
+    endpoint: "${XRAY_ENDPOINT}"
     transport: udp
 
 processors:


### PR DESCRIPTION
**Description:** The configurations provided by `AOT_CONFIG_CONTENT` were not expanding their environment variables. It appears that this was factored out of the config unmarshalling in the upstream as part of v0.37.0. Wrapped the `NewInMemory` provider in the `NewExpand` provider to expand the environment variables.

**Link to tracking Issue:** https://github.com/aws-observability/aws-otel-collector/issues/748

**Testing:** Added environment variable expansion tests to `config_factory_test.go`
