### PR TITLE
Fix config environment variable expansion for AOT_CONFIG_CONTENT

### DIFF
--- a/pkg/config/config_factory.go
+++ b/pkg/config/config_factory.go
@@ -33,7 +33,7 @@ func GetMapProvider() config.MapProvider {
 	// including SSM parameter store for ECS use case
 	if configContent, ok := os.LookupEnv(envKey); ok {
 		log.Printf("Reading AOT config from from environment: %v\n", configContent)
-		return parserprovider.NewInMemoryMapProvider(strings.NewReader(configContent))
+		return parserprovider.NewExpandMapProvider(parserprovider.NewInMemoryMapProvider(strings.NewReader(configContent)))
 	}
 
 	return parserprovider.NewDefaultMapProvider(getConfigFlag(), getSetFlag())

--- a/pkg/config/config_factory_test.go
+++ b/pkg/config/config_factory_test.go
@@ -16,17 +16,16 @@ package config
 
 import (
 	"context"
-	"github.com/spf13/cobra"
 	"os"
 	"testing"
 
+	"github.com/aws-observability/aws-otel-collector/pkg/defaultcomponents"
 	"github.com/crossdock/crossdock-go/require"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configunmarshaler"
 	"go.opentelemetry.io/collector/service"
-
-	"github.com/aws-observability/aws-otel-collector/pkg/defaultcomponents"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGetCfgFactoryConfig(t *testing.T) {
@@ -35,7 +34,7 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 		Factories: factories,
 	}
 
-	t.Run("test_invalid_config", func(t *testing.T) {
+	t.Run("test_invalid_path", func(t *testing.T) {
 		cmd := &cobra.Command{
 			Use:          params.BuildInfo.Command,
 			Version:      params.BuildInfo.Version,
@@ -51,7 +50,10 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("test_valid_config", func(t *testing.T) {
+	t.Run("test_config_with_env_var_set", func(t *testing.T) {
+		const expectedEndpoint = "0.0.0.0:2000"
+		os.Setenv("XRAY_ENDPOINT", expectedEndpoint)
+		defer os.Unsetenv("XRAY_ENDPOINT")
 		cmd := &cobra.Command{
 			Use:          params.BuildInfo.Command,
 			Version:      params.BuildInfo.Version,
@@ -63,19 +65,45 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 		})
 		require.NoError(t, err)
 		provider := GetMapProvider()
-		_, err = provider.Get(context.Background())
+		parser, err := provider.Get(context.Background())
 		require.NoError(t, err)
+		require.NotNil(t, parser)
+		require.Equal(t, expectedEndpoint, parser.Get("receivers::awsxray::endpoint"))
+	})
+
+	t.Run("test_config_without_env_var_set", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use:          params.BuildInfo.Command,
+			Version:      params.BuildInfo.Version,
+			SilenceUsage: true,
+		}
+		cmd.Flags().AddGoFlagSet(Flags())
+		err := cmd.ParseFlags([]string{
+			"--config=testdata/config.yaml",
+		})
+		require.NoError(t, err)
+		provider := GetMapProvider()
+		parser, err := provider.Get(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, parser)
+		require.Empty(t, parser.Get("receivers::awsxray::endpoint"))
 	})
 }
 
 func TestGetMapProviderContainer(t *testing.T) {
-	os.Setenv("AOT_CONFIG_CONTENT", "extensions:\n  health_check:\n  pprof:\n    endpoint: 0.0.0.0:1777\nreceivers:\n  otlp:\n    protocols:\n      grpc:\n        endpoint: 0.0.0.0:4317\nprocessors:\n  batch:\nexporters:\n  logging:\n    loglevel: debug\n  awsxray:\n    local_mode: true\n    region: 'us-west-2'\n  awsemf:\n    region: 'us-west-2'\nservice:\n  pipelines:\n    traces:\n      receivers: [prometheusreceiver]\n      exporters: [logging,awsxray]\n    metrics:\n      receivers: [prometheusreceiver]\n      exporters: [awsemf]\n  extensions: [pprof]")
+	const expectedEndpoint = "0.0.0.0:1777"
+	os.Setenv("PPROF_ENDPOINT", expectedEndpoint)
+	defer os.Unsetenv("PPROF_ENDPOINT")
+
+	os.Setenv("AOT_CONFIG_CONTENT", "extensions:\n  health_check:\n  pprof:\n    endpoint: '${PPROF_ENDPOINT}'\nreceivers:\n  otlp:\n    protocols:\n      grpc:\n        endpoint: 0.0.0.0:4317\nprocessors:\n  batch:\nexporters:\n  logging:\n    loglevel: debug\n  awsxray:\n    local_mode: true\n    region: 'us-west-2'\n  awsemf:\n    region: 'us-west-2'\nservice:\n  pipelines:\n    traces:\n      receivers: [prometheusreceiver]\n      exporters: [logging,awsxray]\n    metrics:\n      receivers: [prometheusreceiver]\n      exporters: [awsemf]\n  extensions: [pprof]")
 	defer os.Unsetenv("AOT_CONFIG_CONTENT")
 
 	factories, _ := defaultcomponents.Components()
 	provider := GetMapProvider()
 	parser, err := provider.Get(context.Background())
 	require.NoError(t, err)
+	require.NotNil(t, parser)
+	require.Equal(t, expectedEndpoint, parser.Get("extensions::pprof::endpoint"))
 	cfgModel, err := configunmarshaler.NewDefault().Unmarshal(parser, factories)
 	require.NoError(t, err)
 	assert.True(t, cfgModel.Receivers != nil && cfgModel.Receivers[config.NewComponentID("otlp")] != nil)

--- a/pkg/config/testdata/config.yaml
+++ b/pkg/config/testdata/config.yaml
@@ -9,7 +9,7 @@ receivers:
       http:
         endpoint: 0.0.0.0:55681
   awsxray:
-    endpoint: 0.0.0.0:2000
+    endpoint: "${XRAY_ENDPOINT}"
     transport: udp
 
 processors:


### PR DESCRIPTION
**Description:** The configurations provided by `AOT_CONFIG_CONTENT` were not expanding their environment variables. It appears that this was factored out of the config unmarshalling in the upstream as part of v0.37.0. Wrapped the `NewInMemoryMapProvider` in the `NewExpandMapProvider` to expand the environment variables.

**Link to tracking Issue:** https://github.com/aws-observability/aws-otel-collector/issues/748

**Testing:** Added environment variable expansion tests to `config_factory_test.go`
