### PR TITLE
Change release branch naming expectations in workflows.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ on:
   push:
     branches:
       - main
-      - release-branch-v*
+      - release/v*
       - dev
     paths-ignore:
       - '.github/**'
@@ -43,7 +43,7 @@ env:
   WIN_SIGNED_PKG_FOLDER: OTelCollectorAuthenticode/AuthenticodeSigner-SHA256-RSA
 
 concurrency:
-  group: ci
+  group: ci-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,12 @@ on:
   push:
     branches:
       - main
+      - release/v*
       - dev
+
+concurrency:
+  group: codeql-${{ github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   analyze:


### PR DESCRIPTION
**Description:** Changed release branch naming to follow `release/v*`. Updated the concurrency group to allow the CI to run on both the main and release branches without interfering with each other.
