### PR TITLE
Change clean ec2 resources from 30 days to 5 days

### DIFF
--- a/tools/workflow/clean_ec2.go
+++ b/tools/workflow/clean_ec2.go
@@ -34,8 +34,8 @@ func main() {
 		}
 		for _, reservation := range describeInstancesOutput.Reservations {
 			for _, instance := range reservation.Instances {
-				//only delete instance if older than 30 days
-				if time.Now().UTC().Add(-1 * time.Hour * 24 * 30).After(*instance.LaunchTime) {
+				//only delete instance if older than 5 days
+				if time.Now().UTC().Add(-1 * time.Hour * 24 * 5).After(*instance.LaunchTime) {
 					log.Printf("Try to delete instance %s tags %v launch-date %v", *instance.InstanceId, instance.Tags, instance.LaunchTime)
 					deleteInstanceIds = append(deleteInstanceIds, instance.InstanceId)
 				}


### PR DESCRIPTION
**Description:** 
Two main reasons: 
* The test case are not supposed to run over 30 days, maximum 3 days for the soaking test 
* Destroy resources more sooner since some of the test are not destroyed properly and leads to the resources's problem. 
https://github.com/aws-observability/aws-otel-collector/runs/4433737723?check_suite_focus=true

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/aws-observability/aws-otel-collector/issues/785

**Testing:** 
Has been tested before https://github.com/aws-observability/aws-otel-collector/pull/712

