### PR TITLE
Add workflow dispatch for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -491,6 +491,10 @@ jobs:
           fi
           echo "::set-output name=commit_id::$commit_id"
 
+      - name: Checking branch for testing
+        run: |
+          echo ${{ steps.get_sha.outputs.commit_id }}
+
       - name: prepare CI&CD stack
         run: |
           cp .aoc-stack-test.yml build/packages/

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,6 @@ on:
         required: true
 
 env:
-  CI_DEFAULT_BRANCH: 'main'
   IMAGE_NAME: aws-otel-collector
   PACKAGING_ROOT: build/packages
   ECR_REPO: aws/aws-otel-collector
@@ -483,7 +482,7 @@ jobs:
         id: get_sha
         run: |
           # Checking whether it is for integration testing or for the merge pull request from CI
-          commit_id="$CI_DEFAULT_BRANCH"
+          commit_id="$GITHUB_REF_NAME"
           if [ "${{ github.event.inputs.sha }}" != "" ]
           then
             commit_id = "${{ github.event.inputs.sha }}"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -565,11 +565,11 @@ jobs:
       ec2-matrix-3: ${{ steps.set-matrix.outputs.ec2-matrix-3 }}
     steps:
       - name: Checkout main
-        if: github.event.inputs.sha == ''
+        if: ${{ github.event.inputs.sha == '' }}
         uses: actions/checkout@v2
 
       - name: Checkout sha
-        if: github.event.inputs.sha != ''
+        if: ${{ github.event.inputs.sha != '' }}
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.sha }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -565,11 +565,11 @@ jobs:
       ec2-matrix-3: ${{ steps.set-matrix.outputs.ec2-matrix-3 }}
     steps:
       - name: Checkout main
-        if: ${{ github.event.inputs.sha == '' }}
+        if: ${{ github.event.inputs.sha == null }}
         uses: actions/checkout@v2
 
       - name: Checkout sha
-        if: ${{ github.event.inputs.sha != '' }}
+        if: ${{ github.event.inputs.sha != null }}
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.sha }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,12 @@ on:
   repository_dispatch:
     types: [dependency-build, workflow-run]
 
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'the commit hash to CI test (must be full SHA)'
+        required: true
+
 env:
   IMAGE_NAME: aws-otel-collector
   PACKAGING_ROOT: build/packages

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,15 +26,14 @@ on:
   # from collector and contrib repo
   repository_dispatch:
     types: [dependency-build, workflow-run]
-
-  #Adding workflow dispatch for easier in testing with integration test in aws-otel-test-framework repo
   workflow_dispatch:
     inputs:
       sha:
-        description: 'the commit hash to CI test (must be full SHA)'
+        description: 'the commit hash to CI (must be full SHA)'
         required: true
 
 env:
+  CI_DEFAULT_BRANCH: 'main'
   IMAGE_NAME: aws-otel-collector
   PACKAGING_ROOT: build/packages
   ECR_REPO: aws/aws-otel-collector
@@ -480,6 +479,17 @@ jobs:
           cat build/packages/VERSION
           echo "::set-output name=version::$Version"
 
+      - name: Setting branch for testing
+        id: get_sha
+        run: |
+          # Checking whether it is for integration testing or for the merge pull request from CI
+          commit_id="$CI_DEFAULT_BRANCH"
+          if [ "${{ github.event.inputs.an_input }}" != "" ]
+          then
+            commit_id = "${{ github.event.inputs.an_input }}"
+          fi
+          echo "::set-output name=branch::$commit_id"
+
       - name: prepare CI&CD stack
         run: |
           cp .aoc-stack-test.yml build/packages/
@@ -564,15 +574,9 @@ jobs:
       ec2-matrix-2: ${{ steps.set-matrix.outputs.ec2-matrix-2 }}
       ec2-matrix-3: ${{ steps.set-matrix.outputs.ec2-matrix-3 }}
     steps:
-      - name: Checkout main
-        if: ${{ github.event.inputs.sha == null }}
-        uses: actions/checkout@v2
-
-      - name: Checkout sha
-        if: ${{ github.event.inputs.sha != null }}
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.inputs.sha }}
+          ref: ${{ needs.e2etest-preparation.outputs.branch }}
 
       - name: Setup Python
         uses: actions/setup-python@v2.1.4
@@ -611,6 +615,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.e2etest-preparation.outputs.branch }}
 
       - name: Cache if success
         id: e2etest-ec2-1
@@ -672,6 +678,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.e2etest-preparation.outputs.branch }}
 
       - name: Cache if success
         id: e2etest-ec2-2
@@ -733,6 +741,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.e2etest-preparation.outputs.branch }}
 
       - name: Cache if success
         id: e2etest-ec2-3
@@ -795,6 +805,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.e2etest-preparation.outputs.branch }}
 
       - name: Cache if success
         id: e2etest-ecs
@@ -850,6 +862,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.e2etest-preparation.outputs.branch }}
 
       - name: Cache if success
         id: e2etest-eks
@@ -905,6 +919,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.e2etest-preparation.outputs.branch }}
 
       - name: Cache if success
         id: e2etest-eks-adot-operator

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -482,6 +482,8 @@ jobs:
         id: get_sha
         run: |
           # Checking whether it is for integration testing or for the merge pull request from CI
+          # Instead of use the default main branch, will use the $GITHUB_REF_NAME to run the test case on other branchs as well
+          # Documentation: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
           commit_id="$GITHUB_REF_NAME"
           if [ "${{ github.event.inputs.sha }}" != "" ]
           then

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -484,11 +484,11 @@ jobs:
         run: |
           # Checking whether it is for integration testing or for the merge pull request from CI
           commit_id="$CI_DEFAULT_BRANCH"
-          if [ "${{ github.event.inputs.an_input }}" != "" ]
+          if [ "${{ github.event.inputs.sha }}" != "" ]
           then
-            commit_id = "${{ github.event.inputs.an_input }}"
+            commit_id = "${{ github.event.inputs.sha }}"
           fi
-          echo "::set-output name=branch::$commit_id"
+          echo "::set-output name=commit_id::$commit_id"
 
       - name: prepare CI&CD stack
         run: |
@@ -576,7 +576,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.e2etest-preparation.outputs.branch }}
+          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
 
       - name: Setup Python
         uses: actions/setup-python@v2.1.4
@@ -616,7 +616,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.e2etest-preparation.outputs.branch }}
+          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-ec2-1
@@ -679,7 +679,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.e2etest-preparation.outputs.branch }}
+          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-ec2-2
@@ -742,7 +742,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.e2etest-preparation.outputs.branch }}
+          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-ec2-3
@@ -806,7 +806,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.e2etest-preparation.outputs.branch }}
+          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-ecs
@@ -863,7 +863,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.e2etest-preparation.outputs.branch }}
+          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-eks
@@ -920,7 +920,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.e2etest-preparation.outputs.branch }}
+          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-eks-adot-operator

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -576,7 +576,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
+          ref: ${{ needs.get_sha.outputs.commit_id }}
 
       - name: Setup Python
         uses: actions/setup-python@v2.1.4
@@ -616,7 +616,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
+          ref: ${{ needs.get_sha.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-ec2-1
@@ -679,7 +679,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
+          ref: ${{ needs.get_sha.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-ec2-2
@@ -742,7 +742,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
+          ref: ${{ needs.get_sha.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-ec2-3
@@ -806,7 +806,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
+          ref: ${{ needs.get_sha.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-ecs
@@ -863,7 +863,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
+          ref: ${{ needs.get_sha.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-eks
@@ -920,7 +920,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
+          ref: ${{ needs.get_sha.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-eks-adot-operator

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -576,7 +576,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.get_sha.outputs.commit_id }}
+          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
 
       - name: Setup Python
         uses: actions/setup-python@v2.1.4
@@ -616,7 +616,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.get_sha.outputs.commit_id }}
+          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-ec2-1
@@ -679,7 +679,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.get_sha.outputs.commit_id }}
+          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-ec2-2
@@ -742,7 +742,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.get_sha.outputs.commit_id }}
+          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-ec2-3
@@ -806,7 +806,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.get_sha.outputs.commit_id }}
+          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-ecs
@@ -863,7 +863,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.get_sha.outputs.commit_id }}
+          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-eks
@@ -920,7 +920,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.get_sha.outputs.commit_id }}
+          ref: ${{ needs.e2etest-preparation.outputs.commit_id }}
 
       - name: Cache if success
         id: e2etest-eks-adot-operator

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,7 @@ on:
   repository_dispatch:
     types: [dependency-build, workflow-run]
 
+  #Adding workflow dispatch for easier in testing with integration test in aws-otel-test-framework repo
   workflow_dispatch:
     inputs:
       sha:
@@ -563,8 +564,15 @@ jobs:
       ec2-matrix-2: ${{ steps.set-matrix.outputs.ec2-matrix-2 }}
       ec2-matrix-3: ${{ steps.set-matrix.outputs.ec2-matrix-3 }}
     steps:
-      - name: Checkout
+      - name: Checkout main
+        if: github.event.inputs.sha == ''
         uses: actions/checkout@v2
+
+      - name: Checkout sha
+        if: github.event.inputs.sha != ''
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.sha }}
 
       - name: Setup Python
         uses: actions/setup-python@v2.1.4


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Currently to test the integration test, one needs to merge it from the PR. In order to easier testing with the CI, adding a workflow dispatch with the committed SHA would not only decrease un-necessary PR but it could also avoid impact to our customer who is using the main branch.

**Link to tracking Issue:** 
https://github.com/aws-observability/aws-otel-collector/issues/793

