### PR TITLE
Add script to compare target version with latest Docker Hub tag.

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -22,14 +22,6 @@ on:
       sha:
         description: 'the github sha to release'
         required: true
-      update-latest:
-        description: 'update the latest tag in the repos (default: true)'
-        required: false
-        default: 'true'
-      mirror-operator:
-        description: 'mirror the operator (default: true)'
-        required: false
-        default: 'true'
     
 env:
   IMAGE_NAME: aws-otel-collector
@@ -344,10 +336,14 @@ jobs:
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip awscliv2.zip
           sudo ./aws/install --update
-          
-      - name: Load Image
+      - name: Compare version with Dockerhub latest
+        id: version
         run: |
-          docker load < build/packages/$IMAGE_NAME.tar
+          TAG=`cat build/packages/VERSION`
+          TARGET_VERSION=$TAG bash tools/workflow/docker-version-compare.sh
+
+      - name: Load Image
+        run: docker load < build/packages/$IMAGE_NAME.tar
         
       - name: upload to ECR
         run: |
@@ -355,11 +351,11 @@ jobs:
           aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/aws-observability
           docker tag $IMAGE_NAME public.ecr.aws/$ECR_REPO:$TAG
           docker push public.ecr.aws/$ECR_REPO:$TAG
-          if [ ${{ github.event.inputs.update-latest }} == 'true' ]; then
+          if [ ${{ steps.version.outputs.any-update }} == 'true' ]; then
             docker tag $IMAGE_NAME public.ecr.aws/$ECR_REPO:latest
             docker push public.ecr.aws/$ECR_REPO:latest
           fi
-          if [ ${{ github.event.inputs.mirror-operator }} == 'true' ]; then
+          if [ ${{ steps.version.outputs.major-update }} == 'true' ] || [ ${{ steps.version.outputs.minor-update }} == 'true' ]; then
             cd adot/tools/release/adot-operator-images-mirror && go run ./
           fi
 
@@ -376,11 +372,10 @@ jobs:
           REPO_NAME="$IMAGE_NAMESPACE/$IMAGE_NAME"
           docker tag $IMAGE_NAME $REPO_NAME:$TAG
           docker push $REPO_NAME:$TAG
-          if [ ${{ github.event.inputs.update-latest }} == 'true' ]; then
+          if [ ${{ steps.version.outputs.any-update }} == 'true' ]; then
             docker tag $IMAGE_NAME $REPO_NAME:latest
             docker push $REPO_NAME:latest
           fi
-
 
   release-validation-ecs:
     runs-on: ubuntu-latest
@@ -495,7 +490,6 @@ jobs:
         if: ${{ always() && steps.release-validation-eks.outputs.cache-hit != 'true' }}
         run: |
           cd testing-framework/terraform/eks && terraform destroy -auto-approve       
-
 
   release-to-github:
     runs-on: ubuntu-latest

--- a/tools/release/s3-release.sh
+++ b/tools/release/s3-release.sh
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -10,9 +12,6 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-
-
-#! /bin/bash
 
 set -e
 

--- a/tools/workflow/clean-artifact.sh
+++ b/tools/workflow/clean-artifact.sh
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -10,8 +12,6 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-
-#! /bin/bash
 
 # this is the command to send the dispatch event to the nightly-clean-artifact workflow
 # please specify the TOKEN with the github token

--- a/tools/workflow/clean-terraform-resources.sh
+++ b/tools/workflow/clean-terraform-resources.sh
@@ -1,10 +1,23 @@
 #! /bin/bash
 
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 set -ex
 
 bucket_name="soaking-terraform-state" 
 # ensure we are using gnudate
-yesterday=`docker run ubuntu date -d 'yesterday' '+%Y-%m-%d'`
+yesterday=$(docker run ubuntu date -d 'yesterday' '+%Y-%m-%d')
 
 terraform_destroy() {
 	key_name=${1}
@@ -20,16 +33,16 @@ terraform_destroy() {
 	fi	
 	echo "remove s3 key: ${key_name}"
 	# use hard code bucket name here in case we mistakenly delete false bucket
-	aws s3 rm s3://soaking-terraform-state/${key_name}
+	aws s3 rm s3://soaking-terraform-state/"${key_name}"
 	rm -rf testing-framework
 }
 
 
-s3_keys=$(aws s3api list-objects-v2 --bucket ${bucket_name} --query 'Contents[?LastModified < `${yesterday}`].Key')
+s3_keys=$(aws s3api list-objects-v2 --bucket ${bucket_name} --query "Contents[?LastModified < ${yesterday}].Key")
 
 
-echo ${s3_keys} | docker run -i stedolan/jq -c '.[]' | while read i; do
+echo "${s3_keys}" | docker run --rm -i stedolan/jq -c '.[]' | while read i; do
 	key_name=${i:1:$((${#i}-2))}
-	terraform_destroy ${key_name}
+	terraform_destroy "${key_name}"
 done 
 

--- a/tools/workflow/docker-version-compare.sh
+++ b/tools/workflow/docker-version-compare.sh
@@ -1,0 +1,95 @@
+#! /bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -e
+
+##########################################
+# This script is used in CD workflow
+# to check to see what type of version
+# release is being done
+#
+# Env vars
+# 1. TARGET_VERSION
+# 2. REPO_NAME
+#
+# Step outputs
+# (All booleans: true/false)
+# 1. any-update
+# 2. major-update
+# 3. minor-update
+# 4. patch-update
+##########################################
+
+# splits the semver v{major}.{minor}.{patch}
+split_version() {
+  if [[ $1 =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    echo "${BASH_REMATCH[1]} ${BASH_REMATCH[2]} ${BASH_REMATCH[3]}"
+  fi
+}
+
+# check environment vars
+if [ -z "${TARGET_VERSION}" ]; then
+  echo "Must have TARGET_VERSION set"
+  exit 1
+fi
+
+if [ -z "${REPO_NAME}" ]; then
+  REPO_NAME="amazon/aws-otel-collector"
+fi
+
+TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${REPO_NAME}:pull" | docker run --rm -i stedolan/jq -c ".token" | sed 's/"//g')
+# retrieves all the available tags and sorts them in reverse version order
+TAGS=$(curl -s "https://registry.hub.docker.com/v2/${REPO_NAME}/tags/list" -H "Authorization: Bearer ${TOKEN}" | docker run --rm -i stedolan/jq -c ".tags[]" | sed 's/"//g' | sort -V -r)
+# get the first tag in the reversed list
+LATEST_VERSION=$(echo "${TAGS}" | sed -n '1p')
+
+echo "Comparing ${LATEST_VERSION}(latest) / ${TARGET_VERSION}(target)"
+
+LATEST_PARTS=($(split_version "${LATEST_VERSION}"))
+TARGET_PARTS=($(split_version "${TARGET_VERSION}"))
+
+if [ -z "${LATEST_PARTS}" ] || [ -z "${TARGET_PARTS}" ]; then
+  echo "Unable to split versions: ${LATEST_VERSION}(latest) / ${TARGET_VERSION}(target)"
+  exit 1
+fi
+
+LATEST_MAJOR=${LATEST_PARTS[0]}
+LATEST_MINOR=${LATEST_PARTS[1]}
+LATEST_PATCH=${LATEST_PARTS[2]}
+
+TARGET_MAJOR=${TARGET_PARTS[0]}
+TARGET_MINOR=${TARGET_PARTS[1]}
+TARGET_PATCH=${TARGET_PARTS[2]}
+
+MAJOR_UPDATE=false
+MINOR_UPDATE=false
+PATCH_UPDATE=false
+
+if [ "${TARGET_MAJOR}" -gt "${LATEST_MAJOR}" ]; then
+  MAJOR_UPDATE=true
+elif [ "${TARGET_MAJOR}" -eq "${LATEST_MAJOR}" ]; then
+  if [ "${TARGET_MINOR}" -gt "${LATEST_MINOR}" ]; then
+    MINOR_UPDATE=true
+  elif [ "${TARGET_MINOR}" -eq "${LATEST_MINOR}" ] && [ "${TARGET_PATCH}" -gt "${LATEST_PATCH}" ]; then
+    PATCH_UPDATE=true
+  fi
+fi
+
+[ ${MAJOR_UPDATE} == "true" ] || [ ${MINOR_UPDATE} == "true" ] || [ ${PATCH_UPDATE} == "true" ] && ANY_UPDATE=true || ANY_UPDATE=false
+
+echo "::set-output name=major-update::${MAJOR_UPDATE}"
+echo "::set-output name=minor-update::${MINOR_UPDATE}"
+echo "::set-output name=patch-update::${PATCH_UPDATE}"
+echo "::set-output name=any-update::${ANY_UPDATE}"


### PR DESCRIPTION
**Description:** Replaced workflow dispatch inputs with script. The script pulls all the tags for the repo from Docker Hub and gets the latest version from there. Compares that to the target version and emits github workflow step variables that are used to determine whether to tag the new release as latest or mirror the operator.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Ran the script locally.

**Documentation:** <Describe the documentation added.>
