### PR TITLE
Use Correct Path For docker-version-compare.sh In CD Release Image Compare

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -340,7 +340,7 @@ jobs:
         id: version
         run: |
           TAG=`cat build/packages/VERSION`
-          TARGET_VERSION=$TAG bash tools/workflow/docker-version-compare.sh
+          TARGET_VERSION=$TAG bash adot/tools/workflow/docker-version-compare.sh
 
       - name: Load Image
         run: docker load < build/packages/$IMAGE_NAME.tar


### PR DESCRIPTION
**Description:** 
Bug fix. Can't run docker-version-compare.sh