### PR TITLE
Update aws-otel-emitter container image

### DIFF
--- a/examples/eks/aws-cloudwatch/otel-sidecar.yaml
+++ b/examples/eks/aws-cloudwatch/otel-sidecar.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: aws-otel-emitter
-          image: "aottestbed/aws-otel-collector-sample-app:java-0.1.0"
+          image: "aottestbed/aws-otel-collector-java-sample-app:0.9.0"
           env:
           - name: OTEL_OTLP_ENDPOINT
             value: "localhost:4317"


### PR DESCRIPTION
aottestbed/aws-otel-collector-sample-app:java-0.1.0 defaults to using `localhost/127.0.0.1:55680` and setting `OTEL_OTLP_ENDPOINT` does not change anything.

```shell
Caused by: io.grpc.netty.shaded.io.netty.channel.AbstractChannel$AnnotatedConnectException: finishConnect(..) failed: Connection refused: localhost/127.0.0.1:55680
```

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

We are evaluating AWS Distro for OpenTelemetry and had some issues getting the demo app working correctly. Changing the container image solved our problem. 

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

Just apply the example Kubernetes config. At least for everyone on our team that tried this, the emitter tried to connect to the collector on port 55680 and we could not change that with `OTEL_OTLP_ENDPOINT`

**Documentation:** <Describe the documentation added.>
