### PR TITLE
Add test case for otlp and send metrics,traces to cloudwatch, AMP, XRAY with ECS on EC2

### DIFF
--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -52,6 +52,10 @@
 		"platforms": ["ECS"]
 	},
 	{
+		"case_name": "otlp_grpc_exporter_cw_amp_xray_ecs",
+		"platforms": ["ECS"]
+	},
+	{
 		"case_name": "otlp_grpc_exporter_metric_mock",
 		"platforms": ["EC2", "ECS", "EKS", "LOCAL", "SOAKING", "NEG_SOAKING", "CANARY"]
 	},


### PR DESCRIPTION
**Description**:
Adding test case for adot collector to use otlp and validate metrics when sending from adot to the corresponding backend: CW, AMP, XRay.
Use case:
+ Can replace the CD test cases since the test case CD only need to make sure the integrations with backends are working instead of the same as CI, while baking one plan per config
+ Support the validation for the ECS EC2 console.

**Test case link**:
https://github.com/aws-observability/aws-otel-test-framework/tree/terraform/terraform/testcases/otlp_grpc_exporter_cw_amp_xray_ecs

**Test case PR**:
https://github.com/aws-observability/aws-otel-test-framework/pull/412


