### PR TITLE
Change operation per runs to  cover all the issues

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -41,3 +41,4 @@ jobs:
           days-before-pr-close: -1 #Never close down the PR and keep the label stall on the PR
           #Optionals
           enable-statistics: true #Show the statistics of what have done so far
+          operations-per-run: 100 #Max number of operations per run


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Currently, our stale bot are not reaching to the old issues but it reaching from the newest one to oldest one first. Therefore, it cannot reach the old issues when [its out of operation per run](https://github.com/aws-observability/aws-otel-collector/runs/4637606546?check_suite_focus=true). So it would be best for us to [change the quota](https://github.com/actions/stale#operations-per-run%E2%80%8B)) and let's it reach those issues.

**Documentation:** <Describe the documentation added.>
Stale bot: https://github.com/actions/stale#operations-per-run%E2%80%8B)