### PR TITLE
change max parralel for eks from 10 to 5

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -869,7 +869,7 @@ jobs:
     needs: [get-testing-suites, e2etest-release, e2etest-preparation]
     strategy:
       fail-fast: false
-      max-parallel: 10
+      max-parallel: 5
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.eks-matrix) }}
 
     steps:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Currently, one test case in EKS consumes 2 classic load balancer. However, we are running [10 eks test case per CI ](https://github.com/aws-observability/aws-otel-collector/blob/main/.github/workflows/CI.yml#L867-L873) so up to 20 per CI in maximum. So the test case would be crash if up to 2 Ci are running simultaneously because of [reaching Load balancer quota](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-limits.html) (in this case, I am assuming other test cases are using LB as well such as ECS and EC2). 

**Link to tracking Issue:** <Issue number if applicable>
Seeing 102 load balancers created on Friday, December 24th.
![image](https://user-images.githubusercontent.com/91758108/147614624-3846b21f-a1c0-4bb1-8fcc-22f1aa2d2eb3.png)

**Note**:
CD has already used [5 max-parallel with eks test case](https://github.com/aws-observability/aws-otel-collector/blob/main/.github/workflows/CD.yml#L423-L429)