### PR TITLE
Fix the lumberjack logger to ensure that all context fields are recorded

### DIFF
--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -51,9 +51,6 @@ func main() {
 		log.Fatalf("failed to build components: %v", err)
 	}
 
-	// init lumberFunc for zap logger
-	lumberHook := logger.GetLumberHook()
-
 	// set the collector config from extracfg file
 	if extraConfig != nil {
 		setCollectorConfigFromExtraCfg(extraConfig)
@@ -69,8 +66,8 @@ func main() {
 		Factories: factories,
 		BuildInfo: info,
 	}
-	if lumberHook != nil {
-		params.LoggingOptions = []zap.Option{zap.Hooks(lumberHook)}
+	if lumberOpt := logger.WrapCoreOpt(); lumberOpt != nil {
+		params.LoggingOptions = []zap.Option{lumberOpt}
 	}
 	if err = run(params); err != nil {
 		logFatal(err)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
 
@@ -50,21 +51,28 @@ func tryNewLumberJackLogger() *lumberjack.Logger {
 	return nil
 }
 
-// GetLumberHook returns lumberjackLogger as a Zap hook
-// for processing log size and log rotation
-func GetLumberHook() func(e zapcore.Entry) error {
-	if lumberjackLogger != nil {
-		return func(e zapcore.Entry) error {
-			_, err := lumberjackLogger.Write(
-				[]byte(fmt.Sprintf("{%+v, Level:%+v, Caller:%+v, Message:%+v, Stack:%+v}\r\n",
-					e.Time, e.Level, e.Caller, e.Message, e.Stack)))
-			if err != nil {
-				return err
-			}
-			return nil
+// WrapCoreOpt returns a zap.Option that wraps the provided core, teeing the output to the lumberjack writer.
+// It uses a JSON encoder and the same level as the provided core.
+// If the lumberjack logger is not configured returns the provided core unmodified.
+func WrapCoreOpt() zap.Option {
+	return zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+		if lumberjackLogger == nil {
+			return core
 		}
-	}
-	return nil
+
+		encoderConfig := zapcore.EncoderConfig{
+			MessageKey:     "message",
+			LevelKey:       "level",
+			TimeKey:        "timestamp",
+			CallerKey:      "caller",
+			StacktraceKey:  "stack",
+			EncodeLevel:    zapcore.LowercaseLevelEncoder,
+			EncodeTime:     zapcore.ISO8601TimeEncoder,
+			EncodeDuration: zapcore.MillisDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		}
+		return zapcore.NewTee(core, zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), zapcore.AddSync(lumberjackLogger), core.(zapcore.LevelEnabler)))
+	})
 }
 
 // SetupErrorLogger setup lumberjackLogger for go logger

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -23,24 +23,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 func setupLogEnv() {
 	logfile = getLogFilePath()
 	lumberjackLogger = tryNewLumberJackLogger()
-}
-
-func TestGetLumberHook(t *testing.T) {
-	setupLogEnv()
-	entry := zapcore.Entry{
-		Message: "test",
-	}
-	funcCall := GetLumberHook()
-	err := funcCall(entry)
-	require.NoError(t, err)
 }
 
 func TestSetupErrorLogger(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>

**Description:** The auto-rotating file writer added by the `logger` package is integrated with the collector's `zap` logger as a hook, which does not give it access to additional context fields on the logger.  This changes the integration to use a core wrapper that tees the log events to the collector's logger and to the `lumberjack` file writer.