### PR TITLE
Support buildx for amd64 and arm64 builds (#766)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -464,10 +464,6 @@ jobs:
           key: "cached_binaries_${{ github.run_id }}"
           path: build
 
-      - name: Set up Docker Buildx
-        if: steps.e2etest-release.outputs.cache-hit != 'true'
-        uses: docker/setup-buildx-action@v1
-
       - name: Login to Public Integration Test ECR
         if: steps.e2etest-release.outputs.cache-hit != 'true'
         uses: docker/login-action@v1
@@ -499,6 +495,20 @@ jobs:
         if: steps.e2etest-release.outputs.cache-hit != 'true'
         run: s3_bucket_name=aws-otel-collector-test upload_to_latest=0 bash tools/release/image-binary-release/s3-release.sh
 
+      - name: Set up Docker Buildx
+        if: steps.e2etest-release.outputs.cache-hit != 'true'
+        uses: docker/setup-buildx-action@v1
+
+      - name: Set up QEMU
+        if: steps.e2etest-release.outputs.cache-hit != 'true'
+        uses: docker/setup-qemu-action@v1
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: public.ecr.aws/${{ env.ECR_REPO }}
+
       #Build the adot collector image for two primary reasons:
       #-Using the adot collector image to do the integration test
       #-Export it for delivery version image in CD
@@ -515,8 +525,8 @@ jobs:
             public.ecr.aws/${{ env.ECR_REPO }}:latest
           cache-from: type=registry
           cache-to: type=inline
-
-
+          platforms : linux/amd64, linux/arm64
+          labels: ${{ steps.meta.outputs.labels }}
 
   get-testing-suites:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ build: install-tools lint multimod-verify
 amd64-build: install-tools lint multimod-verify
 	GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o ./build/linux/aoc_linux_x86_64 ./cmd/awscollector
 
+.PHONY: arm64-build
+arm64-build: install-tools lint multimod-verify
+	GOOS=linux GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o ./build/linux/aoc_linux_aarch64 ./cmd/awscollector
+
 # For building container image during development, no lint nor other platforms
 .PHONY: amd64-build-only
 amd64-build-only:
@@ -107,7 +111,11 @@ package-deb: build
 
 .PHONY: docker-build
 docker-build: amd64-build
-	docker build -t $(DOCKER_NAMESPACE)/$(COMPONENT):$(VERSION) -f ./cmd/$(COMPONENT)/Dockerfile .
+	docker buildx build --platform linux/amd64 -t $(DOCKER_NAMESPACE)/$(COMPONENT):$(VERSION) -f ./cmd/$(COMPONENT)/Dockerfile .
+
+.PHONY: docker-build-arm
+docker-build-arm: arm64-build
+	docker buildx build --platform linux/arm64 -t $(DOCKER_NAMESPACE)/$(COMPONENT):$(VERSION) -f ./cmd/$(COMPONENT)/Dockerfile .
 
 .PHONY: docker-push
 docker-push:

--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -4,42 +4,19 @@
 ################################
 FROM alpine:latest as build 
 
-ENV GOPROXY=direct
-
 # update cert
 RUN apk --update add ca-certificates
 
-# install libs
-RUN apk add --update bash git make build-base
-
-# config go
-COPY --from=golang:1.17-alpine /usr/local/go/ /usr/local/go/
-ENV PATH="/usr/local/go/bin:${PATH}"
-
 WORKDIR /workspace
 
-# copy artifacts
-COPY cmd  /workspace/cmd
-COPY config.yaml /workspace/config.yaml
-COPY pkg /workspace/pkg
-COPY tools /workspace/tools
-COPY VERSION /workspace/VERSION
-COPY .git /workspace/.git
-COPY Makefile /workspace/Makefile
-COPY config /workspace/config
+ARG TARGETPLATFORM
+RUN echo "Targate platform is $TARGETPLATFORM"
 
-#Copy binary if exist else build binary
-COPY go.* build/linux/aoc_linux_x86_6* /workspace/
-RUN if [[ -f /workspace/aoc_linux_x86_64 ]] ; \
-    then \
-        echo Copying binary \
-        && mkdir -p /workspace/build/linux \
-        && cp /workspace/aoc_linux_x86_64 /workspace/build/linux/aoc_linux_x86_64 ; \
-    else \
-        echo Building binary \
-        && go mod download  \
-        && make amd64-build ; \
-    fi
+# copy artifacts
+# always assume binary is created
+COPY build/linux/* /workspace/
+COPY cmd/awscollector/copy_docker_binary.sh  /workspace/cmd/awscollector/copy_docker_binary.sh
+RUN cmd/awscollector/copy_docker_binary.sh
 
 ################################
 #	Final Stage            #	
@@ -48,19 +25,19 @@ RUN if [[ -f /workspace/aoc_linux_x86_64 ]] ; \
 FROM scratch
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=build /workspace/build/linux/aoc_linux_x86_64 /awscollector
-COPY --from=build /workspace/config.yaml /etc/otel-config.yaml
-COPY --from=build /workspace/config/eks/prometheus/config-appmesh.yaml /etc/eks/prometheus/config-appmesh.yaml
-COPY --from=build /workspace/config/eks/prometheus/config-haproxy.yaml /etc/eks/prometheus/config-haproxy.yaml
-COPY --from=build /workspace/config/eks/prometheus/config-jmx.yaml /etc/eks/prometheus/config-jmx.yaml
-COPY --from=build /workspace/config/eks/prometheus/config-memcached.yaml /etc/eks/prometheus/config-memcached.yaml
-COPY --from=build /workspace/config/eks/prometheus/config-nginx.yaml /etc/eks/prometheus/config-nginx.yaml
-COPY --from=build /workspace/config/eks/prometheus/config-redis.yaml /etc/eks/prometheus/config-redis.yaml
-COPY --from=build /workspace/config/eks/prometheus/config-all.yaml /etc/eks/prometheus/config-all.yaml
-COPY --from=build /workspace/config/ecs/container-insights/otel-task-metrics-config.yaml /etc/ecs/container-insights/otel-task-metrics-config.yaml
-COPY --from=build /workspace/config/ecs/ecs-*.yaml /etc/ecs/
-COPY --from=build /workspace/config/ecs/otel-instance-metrics-config.yaml /etc/ecs/otel-instance-metrics-config.yaml
-COPY --from=build /workspace/config/apprunner/apprunner-default-config.yaml /etc/apprunner/apprunner-default-config.yaml
+COPY --from=build /workspace/build/linux/aoc_linux /awscollector
+COPY config.yaml /etc/otel-config.yaml
+COPY config/eks/prometheus/config-appmesh.yaml /etc/eks/prometheus/config-appmesh.yaml
+COPY config/eks/prometheus/config-haproxy.yaml /etc/eks/prometheus/config-haproxy.yaml
+COPY config/eks/prometheus/config-jmx.yaml /etc/eks/prometheus/config-jmx.yaml
+COPY config/eks/prometheus/config-memcached.yaml /etc/eks/prometheus/config-memcached.yaml
+COPY config/eks/prometheus/config-nginx.yaml /etc/eks/prometheus/config-nginx.yaml
+COPY config/eks/prometheus/config-redis.yaml /etc/eks/prometheus/config-redis.yaml
+COPY config/eks/prometheus/config-all.yaml /etc/eks/prometheus/config-all.yaml
+COPY config/ecs/container-insights/otel-task-metrics-config.yaml /etc/ecs/container-insights/otel-task-metrics-config.yaml
+COPY config/ecs/ecs-*.yaml /etc/ecs/
+COPY config/ecs/otel-instance-metrics-config.yaml /etc/ecs/otel-instance-metrics-config.yaml
+COPY config/apprunner/apprunner-default-config.yaml /etc/apprunner/apprunner-default-config.yaml
 
 ENV RUN_IN_CONTAINER="True"
 # aws-sdk-go needs $HOME to look up shared credentials

--- a/cmd/awscollector/copy_docker_binary.sh
+++ b/cmd/awscollector/copy_docker_binary.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+BINARY=aoc_linux_x86_64
+if [[ $TARGETPLATFORM == "linux/arm64" ]]; then
+  BINARY=aoc_linux_aarch64
+fi
+echo binary name is ${BINARY}
+mkdir -p /workspace/build/linux
+if [[ ! -f /workspace/${BINARY} ]]; then
+  echo binary does not exsit
+  exit 1
+fi
+echo copying binary
+cp /workspace/${BINARY} /workspace/build/linux/aoc_linux


### PR DESCRIPTION
**Description:** 
Support Buildx for amd64 and arm64 builds 

**Link to tracking Issue:** 
#766

**Testing:**
(Make creates binaries) 
make docker-build
make docker-build-arm

(With binary not created -takes a very long time since it requires go mod download-)
docker buildx build --platform linux/amd64 -t amazon/awscollector:v0.15.0 -f ./cmd/awscollector/Dockerfile .
docker buildx build --platform linux/arm64 -t amazon/awscollector:v0.15.0 -f ./cmd/awscollector/Dockerfile .

(defaults to amd64)
docker build -t amazon/awscollector:latest -f ./cmd/awscollector/Dockerfile .
