### PR TITLE
Change input sha for testing version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -379,8 +379,9 @@ jobs:
         if: steps.cached_ssm.outputs.cache-hit != 'true'
         run: |
           # use a version with github run id as same as e2etest-preparation
+          ssm_pkg_version="`cat VERSION`-$GITHUB_SHA"
           rm -rf $PACKAGING_ROOT/ssm
-          python3 tools/ssm/ssm_manifest.py "`cat VERSION`-${{ github.run_id }}"
+          python3 tools/ssm/ssm_manifest.py ${ssm_pkg_version}
 
   e2etest-preparation:
     runs-on: ubuntu-latest
@@ -432,7 +433,7 @@ jobs:
         id: versioning
         run: |
           # build a version with github run id so that we can distingush each build for integ-test
-          Version="`cat VERSION`-$GITHUB_RUN_ID"
+          Version="`cat VERSION`-$GITHUB_SHA"
           echo $Version > $PACKAGING_ROOT/VERSION
           cat $PACKAGING_ROOT/VERSION
           echo "::set-output name=version::$Version"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -375,10 +375,7 @@ jobs:
 
       - run: ls -R
 
-        # Build the ssm package and manifest by using a version with github short sha as same as e2etest-preparationfor the following reasons:
-        # - Distingush each build for Integration test
-        # - Increase more visibility to the customer and also for the dev since we publish the image for integration test.
-        # - Avoid having similar layers image and only have a final result image.
+        # Build the ssm package and manifest by using a version with github short sha as same as e2etest-preparation.
       - name: Create zip file and manifest for SSM package
         if: steps.cached_ssm.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -439,10 +439,10 @@ jobs:
       - name: Versioning for testing
         id: versioning
         run: |
-          Version="$(cat VERSION)-$(git rev-parse --short HEAD)"
-          echo $Version > $PACKAGING_ROOT/VERSION
+          version="$(cat VERSION)-$(git rev-parse --short HEAD)"
+          echo $version > $PACKAGING_ROOT/VERSION
           cat $PACKAGING_ROOT/VERSION
-          echo "::set-output name=version::$Version"
+          echo "::set-output name=version::$version"
 
   e2etest-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -379,7 +379,7 @@ jobs:
         if: steps.cached_ssm.outputs.cache-hit != 'true'
         run: |
           # use a version with github run id as same as e2etest-preparation
-          ssm_pkg_version="`cat VERSION`-$GITHUB_SHA"
+          ssm_pkg_version="$(cat VERSION)-$(git rev-parse --short HEAD)"
           rm -rf $PACKAGING_ROOT/ssm
           python3 tools/ssm/ssm_manifest.py ${ssm_pkg_version}
 
@@ -433,7 +433,7 @@ jobs:
         id: versioning
         run: |
           # build a version with github run id so that we can distingush each build for integ-test
-          Version="`cat VERSION`-$GITHUB_SHA"
+          Version="$(cat VERSION)-$(git rev-parse --short HEAD)"
           echo $Version > $PACKAGING_ROOT/VERSION
           cat $PACKAGING_ROOT/VERSION
           echo "::set-output name=version::$Version"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -375,10 +375,13 @@ jobs:
 
       - run: ls -R
 
+        # Build the ssm package and manifest by using a version with github short sha as same as e2etest-preparationfor the following reasons:
+        # - Distingush each build for Integration test
+        # - Increase more visibility to the customer and also for the dev since we publish the image for integration test.
+        # - Avoid having similar layers image and only have a final result image.
       - name: Create zip file and manifest for SSM package
         if: steps.cached_ssm.outputs.cache-hit != 'true'
         run: |
-          # use a version with github run id as same as e2etest-preparation
           ssm_pkg_version="$(cat VERSION)-$(git rev-parse --short HEAD)"
           rm -rf $PACKAGING_ROOT/ssm
           python3 tools/ssm/ssm_manifest.py ${ssm_pkg_version}
@@ -429,10 +432,13 @@ jobs:
 
       - run: ls -R
 
+      # Build a version with github short sha for the following reasons:
+      # - Distingush each build for Integration test
+      # - Increase more visibility to the customer and also for the dev since we publish the image for integration test.
+      # - Avoid having similar layers image and only have a final result image.
       - name: Versioning for testing
         id: versioning
         run: |
-          # build a version with github run id so that we can distingush each build for integ-test
           Version="$(cat VERSION)-$(git rev-parse --short HEAD)"
           echo $Version > $PACKAGING_ROOT/VERSION
           cat $PACKAGING_ROOT/VERSION

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ The performance test can be conducted by following the [instructions](https://gi
 
 ### Support
 
-For each merged pull request, a corresponding image in the naming convention: ```ADOT_COLLECTOR_VERSION - GITHUB_SHA```
-is pushed to [public.ecr.aws/aws-otel-test/adot-collector-integration-test](https://gallery.ecr.aws/aws-otel-test/adot-collector-integration-test). 
+For each merged pull request, a corresponding image with the naming convention of: 
+```[ADOT_COLLECTOR_VERSION]-[GITHUB_SHA]``` is pushed to [public.ecr.aws/aws-otel-test/adot-collector-integration-test](https://gallery.ecr.aws/aws-otel-test/adot-collector-integration-test). 
 This image is used for the integration tests. You can pull any 
 of the images from there, however, we will not support any issues and pull requests for these test 
 images.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The performance test can be conducted by following the [instructions](https://gi
 
 ### Support
 
-For each merged pull request, a corresponding image with the naming convention of: 
+For each merged pull request, a corresponding image with the naming convention of
 ```[ADOT_COLLECTOR_VERSION]-[GITHUB_SHA]``` is pushed to [public.ecr.aws/aws-otel-test/adot-collector-integration-test](https://gallery.ecr.aws/aws-otel-test/adot-collector-integration-test). 
 This image is used for the integration tests. You can pull any 
 of the images from there, however, we will not support any issues and pull requests for these test 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ The performance test can be conducted by following the [instructions](https://gi
 
 ### Support
 
-For each merged pull request, a corresponding image is pushed to [public.ecr.aws/aws-otel-test/adot-collector-integration-test](https://gallery.ecr.aws/aws-otel-test/adot-collector-integration-test). 
+For each merged pull request, a corresponding image in the naming convention: ```ADOT_COLLECTOR_VERSION - GITHUB_SHA```
+is pushed to [public.ecr.aws/aws-otel-test/adot-collector-integration-test](https://gallery.ecr.aws/aws-otel-test/adot-collector-integration-test). 
 This image is used for the integration tests. You can pull any 
 of the images from there, however, we will not support any issues and pull requests for these test 
 images.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
When we open a PR, the similar behavior is found across the PR. Therefore, we don't need to use the RUN_ID to tag the image but instead, using the COMMIT_ID (or COMMIT SHA). If we did it this way, it will give us two advantages:
* Increase more visibility to the customer and also for the dev  since we publish CI image public.
* Avoid having similar layers image and also wasting name. In this way, it would show us only the final success image.
