### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ AWS OTel Collector supports all AWS computing platforms and Docker/Kubernetes. H
 * [Run it with Docker](docs/developers/docker-demo.md)
 * [Run it with ECS](docs/developers/ecs-demo.md)
 * [Run it with EKS](docs/developers/eks-demo.md)
-* [Run it on AWS Linux EC2](docs/developers/linux-rpm-demo.md)
-* [Run it on AWS Windows EC2](docs/developers/windows-other-demo.md)
-* [Run it on AWS Debian EC2](docs/developers/debian-deb-demo.md)
+* [Run it on EC2 (Amazon Linux 2)](docs/developers/linux-rpm-demo.md)
+* [Run it on EC2 (Windows)](docs/developers/windows-other-demo.md)
+* [Run it on EC2 (Debian)](docs/developers/debian-deb-demo.md)
 
 #### Build Your Own Artifacts
 

--- a/docs/developers/debian-deb-demo.md
+++ b/docs/developers/debian-deb-demo.md
@@ -1,10 +1,10 @@
-### Run AWSOTelCollector Beta on AWS EC2 Debian(ubuntu)
+### Run AWSOTelCollector Beta on Debian and Ubuntu
 
-To run AWSOTelCollector on AWS EC2 debian host, you can choose to install AWSOTelCollector Debian on your host by the following steps.
+To run AWSOTelCollector on Debian (or Ubuntu) EC2 host, you can choose to install AWSOTelCollector on your host by the following steps.
 
 **Steps,**
 
-1. Login on AWS Debian EC2 host and download aws-otel-collector installation file.
+1. Login on Debian EC2 host and download aws-otel-collector installation file.
 ```
 wget https://aws-otel-collector.s3.amazonaws.com/ubuntu/amd64/latest/aws-otel-collector.deb
 ```

--- a/docs/developers/linux-rpm-demo.md
+++ b/docs/developers/linux-rpm-demo.md
@@ -1,10 +1,10 @@
-### Run AWSOTelCollector Beta on AWS EC2 Linux
+### Run AWSOTelCollector Beta on Amazon Linux 2
 
-To run AWSOTelCollector on AWS EC2 Linux host, you can choose to install AWSOTelCollector RPM on your host by the following steps.
+To run AWSOTelCollector on Amazon Linux 2 EC2 host, you can choose to install AWSOTelCollector RPM on your host by the following steps.
 
 **Steps,**
 
-1. Login on AWS Linux EC2 host and download aws-otel-collector installation file.
+1. Login on Amazon Linux 2 EC2 host and download aws-otel-collector installation file.
 ```
 wget https://aws-otel-collector.s3.amazonaws.com/amazon_linux/amd64/latest/aws-otel-collector.rpm
 ```

--- a/docs/developers/windows-other-demo.md
+++ b/docs/developers/windows-other-demo.md
@@ -1,6 +1,6 @@
-### Run AWSOTelCollector on AWS Windows Ec2 Host
+### Run AWSOTelCollector on Windows EC2 Host
 
-To run AWSOTelCollector on AWS windows ec2 host, you can choose to install AWSOTelCollector MSI on your host by the following steps.
+To run AWSOTelCollector on Windows EC2 host, you can choose to install AWSOTelCollector MSI on your host by the following steps.
 
 **Steps,**
 1. Login on AWS Windows EC2 host and download aws-otel-collector installation file.


### PR DESCRIPTION
- Amazon Linux 2 is not "AWS Linux"
- We shouldn't put AWS before other brands such as Debian.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

**Description:** <Describe what has changed.>

Fixed some typos around brand names.

**Link to tracking Issue:** <Issue number if applicable>

NA

**Testing:** <Describe what testing was performed and which tests were added.>

NA

**Documentation:** <Describe the documentation added.>

NA