### PR TITLE
Share build's dependencies cache by using same keys between CI and PR Build

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -57,52 +57,59 @@ jobs:
     # Set up building environment, patch the dev repo code on dispatch events.  
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
+      if: ${{ needs.changes.outputs.changed == 'true' }}
       with:
         go-version: 1.17
-      if: ${{ needs.changes.outputs.changed == 'true' }}
+
 
     - uses: actions/checkout@v2
       if: ${{ needs.changes.outputs.changed == 'true' }}
 
     - name: Cache Build
       uses: actions/cache@v2
+      if: ${{ needs.changes.outputs.changed == 'true' }}
       with:
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-      if: ${{ needs.changes.outputs.changed == 'true' }}
+        key: v1-go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+
 
     # Unit Test and attach test coverage badge
     - name: Unit Test
-      run: make test
       if: ${{ needs.changes.outputs.changed == 'true' }}
+      run: make test
+
 
     - name: Upload Coverage report to CodeCov
       uses: codecov/codecov-action@v2
+      if: ${{ needs.changes.outputs.changed == 'true' }}
       with:
         file: ./coverage.txt
-      if: ${{ needs.changes.outputs.changed == 'true' }}
+
 
     # Build and archive binaries into cache.
     - name: Build Binaries
-      run: make build
       if: ${{ needs.changes.outputs.changed == 'true' }}
+      run: make build
+
 
     - name: Cache binaries
       uses: actions/cache@v2
+      if: ${{ needs.changes.outputs.changed == 'true' }}
       with:
         key: "cached_binaries_${{ github.run_id }}"
         path: build
-      if: ${{ needs.changes.outputs.changed == 'true' }}
+
 
     # upload the binaries to artifact as well because cache@v2 hasn't support windows
     - name: Upload
       uses: actions/upload-artifact@v2
+      if: ${{ needs.changes.outputs.changed == 'true' }}
       with:
         name: binary_artifacts
         path: build
-      if: ${{ needs.changes.outputs.changed == 'true' }}
+
 
   packaging-msi:
     runs-on: windows-latest


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
As stated in the [cache dependencies documents](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache), **multiple workflows within a repository share cache entries**.  So my propose solution is to [use the same key when cache go build dependencies in CI with the PR build.](https://github.com/aws-observability/aws-otel-collector/blob/main/.github/workflows/CI.yml#L116-L125) Therefore, it would benefit us in decreasing time to execute the workflow and decrease size need for storing cache in entire GitHub workflow since [Github Workflow only allows 10GB cache size.](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy).

**Documentation:** <Describe the documentation added.>
Cache dependencies between workflows: https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache