### PR TITLE
Support roll back with releasing SSM for validation test

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -36,6 +36,9 @@ env:
   TF_VAR_aoc_vpc_name: aoc-vpc-large
   TF_VAR_aoc_vpc_security_group: aoc-vpc-security-group-large
   TESTING_FRAMEWORK_REPO: 'aws-observability/aws-otel-collector-test-framework'
+  SSM_RELEASE_S3_BUCKET: "aws-otel-collector-ssm"
+  SSM_RELEASE_PACKAGE_NAME: "AWSDistroOTel-Collector"
+  RELEASE_S3_BUCKET: "aws-otel-collector"
 
 jobs:
   release-checking: 
@@ -144,6 +147,21 @@ jobs:
       - name: Release to S3
         run: s3_bucket_name=aws-otel-collector upload_to_latest=1 bash tools/release/image-binary-release/s3-release.sh
 
+      #Create ssm package and binaries/artifacts for validation test which is similar to SSM workflow release
+      - name: Copy SSM package to SSM Release S3 Bucket for global regions
+        run: aws s3 cp build/packages/ssm s3://${{ env.SSM_RELEASE_S3_BUCKET }}/ssmfile/${{ needs.release-checking.outputs.version }} --recursive
+
+      - name: Create SSM packages for validation test and set permission to public
+        run: |
+            ( aws ssm describe-document --name ${{ env.SSM_RELEASE_PACKAGE_NAME }} --version-name ${{ needs.release-checking.outputs.version }} >/dev/null 2>&1 ) || {
+                  python3 tools/ssm/ssm_create.py ${{ env.SSM_RELEASE_PACKAGE_NAME }} ${{ needs.release-checking.outputs.version }} \
+                      ${{ env.SSM_RELEASE_S3_BUCKET }}/ssmfile/${{ needs.release-checking.outputs.version }} us-west-2
+                  aws --region us-west-2 ssm modify-document-permission \
+                      --name ${{ env.SSM_RELEASE_PACKAGE_NAME }} \
+                      --permission-type "Share" \
+                      --account-ids-to-add "All"
+            }
+
   s3-release-validation-1:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, release-to-s3, release-checking]
@@ -195,7 +213,7 @@ jobs:
         if: steps.s3-release-validation-1.outputs.cache-hit != 'true'
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
-          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=aws-otel-collector" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=AWSDistroOTel-Collector"
+          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=aws-otel-collector" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }}"
           
       - name: Destroy resources
         if: ${{ always() && steps.s3-release-validation-1.outputs.cache-hit != 'true' }}
@@ -253,7 +271,7 @@ jobs:
         if: steps.s3-release-validation-2.outputs.cache-hit != 'true'
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
-          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=aws-otel-collector" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=AWSDistroOTel-Collector"
+          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=aws-otel-collector" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }}"
           
       - name: Destroy resources
         if: ${{ always() && steps.s3-release-validation-2.outputs.cache-hit != 'true' }}
@@ -311,7 +329,7 @@ jobs:
         if: steps.s3-release-validation-3.outputs.cache-hit != 'true'
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
-          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=aws-otel-collector" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=AWSDistroOTel-Collector"
+          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=aws-otel-collector" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }}"
           
       - name: Destroy resources
         if: ${{ always() && steps.s3-release-validation-3.outputs.cache-hit != 'true' }}
@@ -550,7 +568,7 @@ jobs:
 
   release-to-github:
     runs-on: ubuntu-latest
-    needs: [s3-release-validation-1, s3-release-validation-2, s3-release-validation-3,release-validation-ecs, release-validation-eks, release-checking]
+    needs: [ s3-release-validation-1, s3-release-validation-2, s3-release-validation-3,release-validation-ecs, release-validation-eks, release-checking ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -577,4 +595,38 @@ jobs:
         with:
           workflow: release SSM package
           token: ${{ secrets.REPO_WRITE_ACCESS_TOKEN }}
-          inputs: '{ "version": "${{ needs.release-checking.outputs.version }}", "sha": "${{ github.event.inputs.sha }}", "public": "true", "pkgname": "AWSDistroOTel-Collector" }'
+          inputs: '{ "version": "${{ needs.release-checking.outputs.version }}", "sha": "${{ github.event.inputs.sha }}", "public": "true", "pkgname": "${{ env.SSM_RELEASE_PACKAGE_NAME }}" }'
+
+  clean-ssm-package:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [ s3-release-validation-1, s3-release-validation-2, s3-release-validation-3, release-checking ]
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{fromJson(needs.get-release-region.outputs.region-matrix)}}
+    steps:
+      #Delete ssm package and binaries/artifacts which is created on s3 bucket for validation test regardless of these two scenarios:
+      #-if the validation test failed, then we will delete the SSM package since we don't want to roll out the unstable version
+      #-if the validation successes, then we will trigger the release SSM package workflow to replace all of this with the appropriate region
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.RELEASE_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.RELEASE_SECRET }}
+          aws-region: ${{ matrix.region }}
+
+      - name: Restore cached packages
+        uses: actions/cache@v2
+        with:
+          key: "${{ env.PACKAGE_CACHE_KEY }}"
+          path: "${{ env.PACKAGING_ROOT }}"
+
+      - name: Clean up SSM release package created for validation testing
+        if: steps.cache_packages.outputs.cache-hit == 'true'
+        run: |
+          aws ssm describe-document --name ${SSM_RELEASE_PACKAGE_NAME} --version-name ${{ needs.release-checking.outputs.version }} >/dev/null 2>&1 && \
+              aws ssm delete-document --name ${SSM_RELEASE_PACKAGE_NAME} --version-name ${{ needs.release-checking.outputs.version }}
+      - name: Delete s3 bucket linked to SSM release package created for validation testing
+        if: steps.cache_packages.outputs.cache-hit == 'true'
+        run: aws s3 rm s3://${{ env.SSM_RELEASE_S3_BUCKET }}/ssmfile/${{ needs.release-checking.outputs.version }} --recursive

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -568,7 +568,7 @@ jobs:
 
   release-to-github:
     runs-on: ubuntu-latest
-    needs: [ s3-release-validation-1, s3-release-validation-2, s3-release-validation-3,release-validation-ecs, release-validation-eks, release-checking ]
+    needs: [ s3-release-validation-1, s3-release-validation-2, s3-release-validation-3,release-validation-ecs, release-validation-eks, release-checking, clean-ssm-package ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -566,37 +566,6 @@ jobs:
         if: ${{ steps.release-latest-image.outputs.cache-hit != 'true' && (steps.version.outputs.major-update == 'true' || steps.version.outputs.minor-update == 'true') }}
         run: cd tools/release/adot-operator-images-mirror && go run ./
 
-  release-to-github:
-    runs-on: ubuntu-latest
-    needs: [ s3-release-validation-1, s3-release-validation-2, s3-release-validation-3,release-validation-ecs, release-validation-eks, release-checking, clean-ssm-package ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.sha }}  
-             
-      - name: Generate release-note
-        run: sh tools/release/generate-release-note.sh "`cat VERSION`"
-        
-      - name: Create release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: ${{ needs.release-checking.outputs.version }}
-          commitish: ${{ github.event.inputs.sha }}
-          release_name: Release ${{ needs.release-checking.outputs.version }}
-          body_path: release-note
-          draft: true
-          prerelease: true
-
-      - name: Trigger SSM package build and public
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: release SSM package
-          token: ${{ secrets.REPO_WRITE_ACCESS_TOKEN }}
-          inputs: '{ "version": "${{ needs.release-checking.outputs.version }}", "sha": "${{ github.event.inputs.sha }}", "public": "true", "pkgname": "${{ env.SSM_RELEASE_PACKAGE_NAME }}" }'
-
   clean-ssm-package:
     runs-on: ubuntu-latest
     if: ${{ always() }}
@@ -630,3 +599,34 @@ jobs:
       - name: Delete s3 bucket linked to SSM release package created for validation testing
         if: steps.cache_packages.outputs.cache-hit == 'true'
         run: aws s3 rm s3://${{ env.SSM_RELEASE_S3_BUCKET }}/ssmfile/${{ needs.release-checking.outputs.version }} --recursive
+
+  release-to-github:
+    runs-on: ubuntu-latest
+    needs: [ s3-release-validation-1, s3-release-validation-2, s3-release-validation-3,release-validation-ecs, release-validation-eks, release-checking, clean-ssm-package ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.sha }}
+
+      - name: Generate release-note
+        run: sh tools/release/generate-release-note.sh "`cat VERSION`"
+
+      - name: Create release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ needs.release-checking.outputs.version }}
+          commitish: ${{ github.event.inputs.sha }}
+          release_name: Release ${{ needs.release-checking.outputs.version }}
+          body_path: release-note
+          draft: true
+          prerelease: true
+
+      - name: Trigger SSM package build and public
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: release SSM package
+          token: ${{ secrets.REPO_WRITE_ACCESS_TOKEN }}
+          inputs: '{ "version": "${{ needs.release-checking.outputs.version }}", "sha": "${{ github.event.inputs.sha }}", "public": "true", "pkgname": "${{ env.SSM_RELEASE_PACKAGE_NAME }}" }'

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -152,10 +152,9 @@ jobs:
         run: |
             ( aws ssm describe-document --name ${{ env.SSM_RELEASE_PACKAGE_NAME }} --version-name ${{ needs.release-checking.outputs.version }} >/dev/null 2>&1 ) || {
                   pip3 install boto3
-                  python3 tools/ssm/ssm_manifest.py ${ssm_pkg_version}
+                  python3 tools/ssm/ssm_manifest.py ${{ needs.release-checking.outputs.version }}
                   aws s3 cp $PACKAGING_ROOT/ssm s3://${{ env.SSM_RELEASE_S3_BUCKET }}/ssmfile/${{ needs.release-checking.outputs.version }} --recursive
-                  python3 tools/ssm/ssm_create.py ${{ env.SSM_RELEASE_PACKAGE_NAME }} ${{ needs.release-checking.outputs.version }} \
-                      ${{ env.SSM_RELEASE_S3_BUCKET }}/ssmfile/${{ needs.release-checking.outputs.version }} us-west-2
+                  python3 tools/ssm/ssm_create.py ${{ env.SSM_RELEASE_PACKAGE_NAME }} ${{ needs.release-checking.outputs.version }} ${{ env.SSM_RELEASE_S3_BUCKET }}/ssmfile/${{ needs.release-checking.outputs.version }} us-west-2
                   aws --region us-west-2 ssm modify-document-permission \
                       --name ${{ env.SSM_RELEASE_PACKAGE_NAME }} \
                       --permission-type "Share" \

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -145,15 +145,15 @@ jobs:
           aws-region: us-west-2
 
       - name: Release to S3
-        run: s3_bucket_name=aws-otel-collector upload_to_latest=1 bash tools/release/image-binary-release/s3-release.sh
+        run: s3_bucket_name=${{ env.RELEASE_S3_BUCKET }} upload_to_latest=1 bash tools/release/image-binary-release/s3-release.sh
 
       #Create ssm package and binaries/artifacts for validation test which is similar to SSM workflow release
-      - name: Copy SSM package to SSM Release S3 Bucket for global regions
-        run: aws s3 cp build/packages/ssm s3://${{ env.SSM_RELEASE_S3_BUCKET }}/ssmfile/${{ needs.release-checking.outputs.version }} --recursive
-
       - name: Create SSM packages for validation test and set permission to public
         run: |
             ( aws ssm describe-document --name ${{ env.SSM_RELEASE_PACKAGE_NAME }} --version-name ${{ needs.release-checking.outputs.version }} >/dev/null 2>&1 ) || {
+                  pip3 install boto3
+                  python3 tools/ssm/ssm_manifest.py ${ssm_pkg_version}
+                  aws s3 cp $PACKAGING_ROOT/ssm s3://${{ env.SSM_RELEASE_S3_BUCKET }}/ssmfile/${{ needs.release-checking.outputs.version }} --recursive
                   python3 tools/ssm/ssm_create.py ${{ env.SSM_RELEASE_PACKAGE_NAME }} ${{ needs.release-checking.outputs.version }} \
                       ${{ env.SSM_RELEASE_S3_BUCKET }}/ssmfile/${{ needs.release-checking.outputs.version }} us-west-2
                   aws --region us-west-2 ssm modify-document-permission \
@@ -213,7 +213,7 @@ jobs:
         if: steps.s3-release-validation-1.outputs.cache-hit != 'true'
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
-          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=aws-otel-collector" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }}"
+          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=${{ env.RELEASE_S3_BUCKET }}" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }}"
           
       - name: Destroy resources
         if: ${{ always() && steps.s3-release-validation-1.outputs.cache-hit != 'true' }}
@@ -271,7 +271,7 @@ jobs:
         if: steps.s3-release-validation-2.outputs.cache-hit != 'true'
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
-          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=aws-otel-collector" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }}"
+          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=${{ env.RELEASE_S3_BUCKET }}" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }}"
           
       - name: Destroy resources
         if: ${{ always() && steps.s3-release-validation-2.outputs.cache-hit != 'true' }}
@@ -329,7 +329,7 @@ jobs:
         if: steps.s3-release-validation-3.outputs.cache-hit != 'true'
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
-          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=aws-otel-collector" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }}"
+          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=${{ env.RELEASE_S3_BUCKET }}" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }}"
           
       - name: Destroy resources
         if: ${{ always() && steps.s3-release-validation-3.outputs.cache-hit != 'true' }}

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -501,7 +501,7 @@ jobs:
 
       - name: Delete version image from ecr
         run: |
-          aws ecr-public batch-delete-image --repository-name public.ecr.aws/$ECR_REPO --image-ids imageTag=${{ needs.release-checking.outputs.version }} --region us-east-1
+          aws ecr-public batch-delete-image --repository-name $IMAGE_NAME --image-ids imageTag=${{ needs.release-checking.outputs.version }} --region us-east-1
 
 
   release-latest-image:
@@ -595,6 +595,7 @@ jobs:
         run: |
           aws ssm describe-document --name ${SSM_RELEASE_PACKAGE_NAME} --version-name ${{ needs.release-checking.outputs.version }} >/dev/null 2>&1 && \
               aws ssm delete-document --name ${SSM_RELEASE_PACKAGE_NAME} --version-name ${{ needs.release-checking.outputs.version }}
+
       - name: Delete s3 bucket linked to SSM release package created for validation testing
         if: steps.cache_packages.outputs.cache-hit == 'true'
         run: aws s3 rm s3://${{ env.SSM_RELEASE_S3_BUCKET }}/ssmfile/${{ needs.release-checking.outputs.version }} --recursive

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -489,6 +489,7 @@ jobs:
           ssm_pkg_version=`cat build/packages/VERSION`
           (aws ssm describe-document --name ${SSM_PACKAGE_NAME} --version-name ${ssm_pkg_version} >/dev/null 2>&1) || {
             pip3 install boto3
+            python3 tools/ssm/ssm_manifest.py ${ssm_pkg_version}
             aws s3 cp build/packages/ssm s3://aws-otel-collector-test/ssm/${ssm_pkg_version} --recursive
             python3 tools/ssm/ssm_create.py --no-default ${SSM_PACKAGE_NAME} ${ssm_pkg_version} aws-otel-collector-test/ssm/${ssm_pkg_version} us-west-2
           }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Previously, the validation test for SSM release are running alongside with the validation test. However, after [this PR](https://github.com/aws-observability/aws-otel-collector/pull/823), the SSM release package is running after the validation test; therefore, the SSM validation test is not able to checkout the expected SSM. In order to solve this, we need to simulate the SSM release package in [SSM workflow](https://github.com/aws-observability/aws-otel-collector/blob/main/.github/workflows/ssm-release.yml) and always delete it after validation test. After all of these validation tests and delete simulated SSM package, then we release to GitHub and release SSM workflow.

**Link to tracking Issue:** <Issue number if applicable>
N/A
**Testing:** <Describe what testing was performed and which tests were added.>
N/A
**Documentation:** <Describe the documentation added.>
N/a