### PR TITLE
Fix version in performance report.

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -610,7 +610,7 @@ jobs:
           ref: ${{ github.event.inputs.sha }}
 
       - name: Generate release-note
-        run: sh tools/release/generate-release-note.sh "`cat VERSION`"
+        run: sh tools/release/generate-release-note.sh
 
       - name: Create release
         uses: actions/create-release@v1

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -32,7 +32,8 @@ env:
 jobs:
   get-testing-version:
     runs-on: ubuntu-latest
-    outputs: 
+    outputs:
+      version: ${{ steps.get-testing-version.outputs.version }}
       testing_version: ${{ steps.get-testing-version.outputs.testing_version }}
       commit_id: ${{ steps.get-testing-version.outputs.commit_id }}
     steps:
@@ -61,9 +62,11 @@ jobs:
       - name: Get testing version
         id: get-testing-version
         run: |
-          testing_version=`cat build/packages/TESTING_VERSION`
+          version=$(cat build/packages/VERSION)
+          testing_version=$(cat build/packages/TESTING_VERSION)
+          commit_id=$(cat build/packages/GITHUB_SHA)
+          echo "::set-output name=version::$version"
           echo "::set-output name=testing_version::$testing_version"
-          commit_id=`cat build/packages/GITHUB_SHA`
           echo "::set-output name=commit_id::$commit_id"
 
       - name: Check benchmarks for commit SHA
@@ -158,7 +161,7 @@ jobs:
           path: artifacts
           
       - name: Produce performance report
-        run: python e2etest/get-performance-model-table.py -v ${{ needs.get-testing-version.outputs.testing_version }}
+        run: python e2etest/get-performance-model-table.py -v ${{ needs.get-testing-version.outputs.version }}
 
       # Uses github-action-benchmark to update historic benchmark data
       # Temporarily using forked action in order to pass in commit SHA

--- a/tools/release/bump-version-and-create-release-note.sh
+++ b/tools/release/bump-version-and-create-release-note.sh
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -11,30 +13,28 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-#! /bin/bash
-
 ## this is the script to bump the version and create the release note
 ## please run this script whenever you want to bump the version instead of directly modifying the VERSION file
 ## below is an example to run this script: 
 ## RELEASE_VERSION=v0.1.8 GITHUB_TOKEN=e75***********fa3d0d ./tools/release/bump-version-and-create-release-note.sh
 
 # get the current version
-VERSION=`cat VERSION`
+VERSION=$(cat VERSION)
 OUTPUT="docs/releases/${RELEASE_VERSION}.md"
 
 # generate release note
-docker run --rm -it -v "`pwd`":/usr/local/src/your-app ferrarimarco/github-changelog-generator \
+docker run --rm -it -v "$(pwd)":/usr/local/src/your-app ferrarimarco/github-changelog-generator \
   --user aws-observability \
 	--project aws-otel-collector \
-	-t ${GITHUB_TOKEN} \
-	--since-tag ${VERSION} \
-	--future-release ${RELEASE_VERSION} \
-	--output ${OUTPUT} \
+	-t "${GITHUB_TOKEN}" \
+	--since-tag "${VERSION}" \
+	--future-release "${RELEASE_VERSION}" \
+	--output "${OUTPUT}" \
 	--exclude-labels bumpversion
 
 # bump the version
-echo ${RELEASE_VERSION} > VERSION
+echo "${RELEASE_VERSION}" > VERSION
 
 # git commit
-git add VERSION docs/releases/${RELEASE_VERSION}.md
+git add VERSION "docs/releases/${RELEASE_VERSION}.md"
 git commit -m "bump version to ${RELEASE_VERSION}"

--- a/tools/release/generate-release-note.sh
+++ b/tools/release/generate-release-note.sh
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -11,14 +13,12 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-#! /bin/bash
-
-VERSION=$1
+VERSION=$(cat VERSION)
 
 sed "s/__VERSION__/$VERSION/g" tools/release/header.md.template > header
 sed "s/__VERSION__/$VERSION/g" tools/release/downloading-links.md.template > downloading-links
 # Formats changelog sections: **<label>:** becomes ### <label>
 # Skips the first 4 lines (title and version number)
-sed -e 1,4d -e "s/^\*\*\(.*\)\:\*\*/### \1/g" docs/releases/${VERSION}.md > changelog
+sed -e 1,4d -e "s/^\*\*\(.*\)\:\*\*/### \1/g" "docs/releases/${VERSION}.md" > changelog
 
 cat header changelog downloading-links > release-note


### PR DESCRIPTION
**Description:** Use the actual version instead of the testing version in the performance report. Clean up release-notes scripts.

**Testing:** Ran scripts locally.
