### PR TITLE
Update aws-otel-emitter in all examples

### DIFF
--- a/deployment-template/eks/otel-cloudwatch-sidecar.yaml
+++ b/deployment-template/eks/otel-cloudwatch-sidecar.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: aws-otel-emitter
-          image: "aottestbed/aws-otel-collector-sample-app:java-0.1.0"
+          image: "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
           env:
             - name: OTEL_OTLP_ENDPOINT
               value: "localhost:4317"

--- a/examples/ec2/aws-cloudwatch/ecs-ec2-sidecar.json
+++ b/examples/ec2/aws-cloudwatch/ecs-ec2-sidecar.json
@@ -6,7 +6,7 @@
   "containerDefinitions": [
     {
       "name": "aws-otel-emitter",
-      "image": "aottestbed/aws-otel-collector-sample-app:java-0.1.0",
+      "image": "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest",
       "essential": true,
       "entryPoint": [],
       "command": [],

--- a/examples/eks/aws-cloudwatch/otel-sidecar.yaml
+++ b/examples/eks/aws-cloudwatch/otel-sidecar.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: aws-otel-emitter
-          image: "aottestbed/aws-otel-collector-sample-app:java-0.1.0"
+          image: "public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest"
           env:
           - name: OTEL_OTLP_ENDPOINT
             value: "localhost:4317"


### PR DESCRIPTION
This PR address the issue #831 and updates the aws-otel-emitter in the examples 

Replacing with the latest image `public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest` of the sample app.