### PR TITLE
Delete launch configuration

### DIFF
--- a/tools/workflow/clean_aws_resources.go
+++ b/tools/workflow/clean_aws_resources.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 )
@@ -36,7 +37,7 @@ const (
 )
 
 func main() {
-	log.Printf("Begin terminating EC2 Instances")
+	log.Printf("Begin to terminate EC2 Instances")
 	terminateEc2Instances()
 
 	log.Printf("Begin to destroy ECS's AutoScaling")
@@ -46,17 +47,14 @@ func main() {
 	destroyECSLaunchConfiguration()
 	
 	log.Printf("Begin to destroy Load Balancer resources")
-	destroyLoadBalancerResource()
+	destroyLoadBalancerResource()=
 
-	
 	log.Printf("Finish destroy AWS resources")
 }
 
 func terminateEc2Instances() {
-	// set up aws go sdk ec2 client
-	testSession, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
+	//Set up aws go sdk ec2 client
+	testSession, err := session.NewSession()
 
 	if err != nil {
 		log.Fatalf("Error creating session %v", err)
@@ -110,9 +108,8 @@ func terminateEc2Instances() {
 }
 
 func destroyECSAutoScaling(){
-	testSession, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
+	//Set up aws go sdk ec2 client
+	testSession, err := session.NewSession()
 
 	if err != nil {
 		log.Fatalf("Error creating session %v", err)
@@ -137,8 +134,6 @@ func destroyECSAutoScaling(){
 			log.Fatalf("Failed to get metadata from launch configuration because of %v", err)
 		}
 
-		
-
 		for _, asg := range describeAutoScalingOutputs.AutoScalingGroups {
 			//Skipping lc that does not older than 5 days
 			if !time.Now().UTC().Add(pastDayDeleteCalculation).After(*asg.CreatedTime) {
@@ -146,7 +141,7 @@ func destroyECSAutoScaling(){
 			}
 
 			deleteAutoScalingGroupInput := &autoscaling.DeleteAutoScalingGroupInput{
-				AutoScalingGroupName: asg.AutoScalingGroupName:,
+				AutoScalingGroupName: asg.AutoScalingGroupName,
 				ForceDelete:          aws.Bool(true),
 			}
 
@@ -157,7 +152,7 @@ func destroyECSAutoScaling(){
 			}
 
 			deleteLaunchConfigurationInput := &autoscaling.DeleteLaunchConfigurationInput{
-				LaunchConfigurationName: asg.LaunchConfigurationName:,
+				LaunchConfigurationName: asg.LaunchConfigurationName,
 			}
 
 			_, err = autoscalingclient.DeleteLaunchConfiguration(deleteLaunchConfigurationInput)
@@ -178,9 +173,8 @@ func destroyECSAutoScaling(){
 }
 
 func destroyECSLaunchConfiguration(){
-	testSession, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
+	//Set up aws go sdk ec2 client
+	testSession, err := session.NewSession()
 
 	if err != nil {
 		log.Fatalf("Error creating session %v", err)
@@ -270,36 +264,10 @@ func destroyECSLaunchConfiguration(){
 	}
 
 }
-func terminateECSCluster(){
-	// set up aws go sdk ec2 client
-	testSession, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
-
-	if err != nil {
-		log.Fatalf("Error creating session %v", err)
-	}
-
-	svc := autoscaling.New(testSession)
-
-	input := &autoscaling.DescribeAutoScalingGroupsInput{
-		AutoScalingGroupNames: []*string{
-			aws.String("asg-aoc-testing-2bb6e83fb82428af-20210922001014183200000006"),
-		},
-	}
-
-	result, err := svc.DescribeAutoScalingGroups(input)
-
-	fmt.Println(result)
-}
 
 func destroyLoadBalancerResource() {
-	// Set up aws go sdk session
-	// Only using default environment variables instead of loading other metadata from session.NewSessionWithOptions
-	//Documents: https://docs.aws.amazon.com/ja_jp/sdk-for-go/v1/developer-guide/configuring-sdk.html
-	testSession, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2")},
-	)
+	//Set up aws go sdk ec2 client
+	testSession, err := session.NewSession()
 
 	if err != nil {
 		log.Fatalf("Error creating session %v", err)

--- a/tools/workflow/clean_aws_resources.go
+++ b/tools/workflow/clean_aws_resources.go
@@ -28,11 +28,11 @@ import (
 )
 
 const (
-	requiredIAMInstanceProfile = 6
-	containLcName            = "cluster-aoc-testing"
-	containLbName            = "aoc-lb"
-	pastDayDelete            = 5
-	pastDayDeleteCalculation = -1 * time.Hour * 24 * pastDayDelete //Currently, deleting resources over 5 days
+	containLcName                    = "cluster-aoc-testing"
+	containLbName                    = "aoc-lb"
+	pastDayDelete                    = 5
+	requiredIAMInstanceProfileLength = 6
+	pastDayDeleteCalculation         = -1 * time.Hour * 24 * pastDayDelete //Currently, deleting resources over 5 days
 )
 
 func main() {
@@ -212,7 +212,7 @@ func destroyECSLaunchConfiguration() {
 			//Split the instance profile to get the testing ID associate with the testing framework
 			splitLcIamInstanceProfile := strings.Split(*lc.IamInstanceProfile, "-")
 
-			if len(splitLcIamInstanceProfile) != 6 {
+			if len(splitLcIamInstanceProfile) != requiredIAMInstanceProfileLength {
 				continue
 			}
 

--- a/tools/workflow/clean_aws_resources.go
+++ b/tools/workflow/clean_aws_resources.go
@@ -16,16 +16,14 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 )
 

--- a/tools/workflow/clean_aws_resources.go
+++ b/tools/workflow/clean_aws_resources.go
@@ -47,7 +47,7 @@ func main() {
 	destroyECSLaunchConfiguration()
 	
 	log.Printf("Begin to destroy Load Balancer resources")
-	destroyLoadBalancerResource()=
+	destroyLoadBalancerResource()
 
 	log.Printf("Finish destroy AWS resources")
 }

--- a/tools/workflow/clean_aws_resources.go
+++ b/tools/workflow/clean_aws_resources.go
@@ -197,7 +197,7 @@ func destroyECSLaunchConfiguration(){
 
 	for {
 		//Launch Configuration Go SDK currently does not support filter tag or filter wildcard. Only supports with matching name
-		//Documentation: https://github.com/aws/aws-sdk-go/blob/02266ed24221ac21bb37d6ac614d1ced95407556/service/elbv2/api.go#L5879-L5895
+		//Documentation: https://github.com/aws/aws-sdk-go/blob/02266ed24221ac21bb37d6ac614d1ced95407556/service/autoscaling/api.go#L9577-L9593
 		describeLaunchConfigurationInputs := &autoscaling.DescribeLaunchConfigurationsInput{NextToken: nextToken}
 		describeLaunchConfigurationOutputs, err := autoscalingclient.DescribeLaunchConfigurations(describeLaunchConfigurationInputs)
 

--- a/tools/workflow/clean_aws_resources.go
+++ b/tools/workflow/clean_aws_resources.go
@@ -120,7 +120,7 @@ func destroyECSAutoScaling() {
 	//Autoscaling's tag filter
 	autoscalingTagFilter := autoscaling.Filter{Name: aws.String("tag:Component"), Values: []*string{aws.String("aoc")}}
 
-	//Allow to load all the launch configurations since the default respond is paginated launch configurations.
+	//Allow to load all the auto scaling groups since the default respond is paginated auto scaling groups.
 	//Look into the documentations and read the starting-token for more details
 	//Documentation: https://docs.aws.amazon.com/cli/latest/reference/autoscaling/describe-auto-scaling-groups.html#options
 	var nextToken *string
@@ -134,7 +134,7 @@ func destroyECSAutoScaling() {
 		}
 
 		for _, asg := range describeAutoScalingOutputs.AutoScalingGroups {
-			//Skipping lc that does not older than 5 days
+			//Skipping asg that does not older than 5 days
 			if !time.Now().UTC().Add(pastDayDeleteCalculation).After(*asg.CreatedTime) {
 				continue
 			}

--- a/tools/workflow/clean_aws_resources.go
+++ b/tools/workflow/clean_aws_resources.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	containLcName 			 = "cluster-aoc-testing"
+	containLcName            = "cluster-aoc-testing"
 	containLbName            = "aoc-lb"
 	pastDayDelete            = 5
 	pastDayDeleteCalculation = -1 * time.Hour * 24 * pastDayDelete //Currently, deleting resources over 5 days
@@ -43,7 +43,7 @@ func main() {
 
 	log.Printf("Begin to destroy ECS's Launch Configuration")
 	destroyECSLaunchConfiguration()
-	
+
 	log.Printf("Begin to destroy Load Balancer resources")
 	destroyLoadBalancerResource()
 
@@ -105,7 +105,7 @@ func terminateEc2Instances() {
 	}
 }
 
-func destroyECSAutoScaling(){
+func destroyECSAutoScaling() {
 	//Set up aws go sdk ec2 client
 	testSession, err := session.NewSession()
 
@@ -125,7 +125,7 @@ func destroyECSAutoScaling(){
 	var nextToken *string
 
 	for {
-		describeAutoScalingInputs := &autoscaling.DescribeAutoScalingGroupsInput{Filters:[]*autoscaling.Filter{&autoscalingTagFilter} ,NextToken: nextToken}
+		describeAutoScalingInputs := &autoscaling.DescribeAutoScalingGroupsInput{Filters: []*autoscaling.Filter{&autoscalingTagFilter}, NextToken: nextToken}
 		describeAutoScalingOutputs, err := autoscalingclient.DescribeAutoScalingGroups(describeAutoScalingInputs)
 
 		if err != nil {
@@ -158,7 +158,7 @@ func destroyECSAutoScaling(){
 			if err != nil {
 				log.Fatalf("Failed to delete lc of asg %s  because of %v", *asg.AutoScalingGroupName, err)
 			}
-			
+
 			log.Printf("Delete asg %s successfully", *asg.AutoScalingGroupName)
 		}
 
@@ -170,7 +170,7 @@ func destroyECSAutoScaling(){
 	}
 }
 
-func destroyECSLaunchConfiguration(){
+func destroyECSLaunchConfiguration() {
 	//Set up aws go sdk ec2 client
 	testSession, err := session.NewSession()
 
@@ -180,8 +180,7 @@ func destroyECSLaunchConfiguration(){
 
 	ec2client := ec2.New(testSession)
 	autoscalingclient := autoscaling.New(testSession)
-	
-	
+
 	//Allow to load all the launch configurations since the default respond is paginated launch configurations.
 	//Look into the documentations and read the starting-token for more details
 	//Documentation: https://docs.aws.amazon.com/cli/latest/reference/autoscaling/describe-launch-configurations.html#options
@@ -231,10 +230,10 @@ func destroyECSLaunchConfiguration(){
 			describeInstancesOutput, err := ec2client.DescribeInstances(&describeInstancesInput)
 
 			if err != nil {
-				log.Fatalf("Failed to get metadata from EC2 instance", err)
+				log.Fatalf("Failed to get metadata from EC2 instance because of %v", err)
 			}
 
-			if  len(describeInstancesOutput.Reservations) != 0 {
+			if len(describeInstancesOutput.Reservations) != 0 {
 				continue
 			}
 
@@ -257,7 +256,7 @@ func destroyECSLaunchConfiguration(){
 		if describeLaunchConfigurationOutputs.NextToken == nil {
 			break
 		}
-		
+
 		nextToken = describeLaunchConfigurationOutputs.NextToken
 	}
 
@@ -287,7 +286,7 @@ func destroyLoadBalancerResource() {
 		if err != nil {
 			log.Fatalf("Failed to get metadata from load balancer because of %v", err)
 		}
-		
+
 		for _, lb := range describeLoadBalancerOutputs.LoadBalancers {
 
 			//Skipping lb that does not contain aoc-lb string (relating to aws-otel-test-framework)

--- a/tools/workflow/clean_aws_resources.go
+++ b/tools/workflow/clean_aws_resources.go
@@ -28,6 +28,7 @@ import (
 )
 
 const (
+	requiredIAMInstanceProfile = 6
 	containLcName            = "cluster-aoc-testing"
 	containLbName            = "aoc-lb"
 	pastDayDelete            = 5
@@ -233,6 +234,7 @@ func destroyECSLaunchConfiguration() {
 				log.Fatalf("Failed to get metadata from EC2 instance because of %v", err)
 			}
 
+			//Confirm whether the ec2 associaed with the ecs is still exist or not
 			if len(describeInstancesOutput.Reservations) != 0 {
 				continue
 			}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Currently, the integration test account's launch configuration has reached its quota. Therefore, deleting old launch configuration and auto-scaling group is compulsory.

**Link to tracking Issue:** <Issue number if applicable>
N/A

**Testing:** <Describe what testing was performed and which tests were added.>
Testing locally.

**Documentation:** <Describe the documentation added.>
N/A