### PR TITLE
Destroy terraform.tfstate in all test cases 

### DIFF
--- a/.github/workflows/resources-clean.yml
+++ b/.github/workflows/resources-clean.yml
@@ -23,7 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      
+
+      - name: Check out testing framework
+        uses: actions/checkout@v2
+        with:
+          repository: 'aws-observability/aws-otel-collector-test-framework'
+          path: testing-framework
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -35,14 +41,4 @@ jobs:
         uses: hashicorp/setup-terraform@v1
       
       - name: Clean resources which are created before yesterday
-        id: clean-resources
         run: sh tools/workflow/clean-terraform-resources.sh
-
-      - name: Re-upload terraform state on failure
-        if: ${{ failure() || cancelled() }}
-        run: |
-          key_name="${{ steps.clean-resources.outputs.key-name }}"
-          package="downloaded_terraform/$key_name"
-          if [[ -f $package ]]; then
-            aws s3 cp $package s3://soaking-terraform-state/$key_name
-          fi

--- a/.github/workflows/resources-clean.yml
+++ b/.github/workflows/resources-clean.yml
@@ -11,11 +11,11 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-name: Hourly Resources Cleaner
+name: Daily Resources Cleaner
 
 on:
   schedule:
-    - cron: "0 */1 * * *"
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:

--- a/tools/workflow/clean-terraform-resources.sh
+++ b/tools/workflow/clean-terraform-resources.sh
@@ -44,10 +44,6 @@ function terraform_destroy_state() {
 	  if [[ $key_name == *"/ecs/"* ]]; then platform_folder="ecs"; fi
 	  if [[ $key_name == *"/eks/"* ]]; then platform_folder="eks"; fi
 
-	  # Set output in case the destroy fails
-    echo "::set-output name=key-name::${key_name}"
-    echo "remove s3 key: ${key_name}"
-
     # Download the terraform state from s3 bucket
     echo "download terraform state from s3 bucket: ${terraform_state_s3_bucket}/${key_name}"
     aws s3 cp "s3://${terraform_state_s3_bucket}/${key_name}" "testing-framework/terraform/${platform_folder}/terraform.tfstate"

--- a/tools/workflow/clean-terraform-resources.sh
+++ b/tools/workflow/clean-terraform-resources.sh
@@ -15,8 +15,12 @@
 
 set -ex
 
-# ensure we are using gnudate
-yesterday=$(docker run --rm ubuntu date -d "yesterday" "+%Y-%m-%d")
+#Set environment variables
+terraform_state_s3_bucket="aws-otel-test-terraform-state"
+
+#Ensure we are using gnudate
+yesterday=$(docker run --rm ubuntu date -d "yesterday" "+%Y-%m-22")
+
 
 terraform_destroy() {
 	key_name=$1
@@ -24,27 +28,15 @@ terraform_destroy() {
 	# check if the object still exists
 	still_exists=$(aws s3api head-object --bucket soaking-terraform-state --key "${key_name}" || echo '')
 	if [ -n "${still_exists}" ]; then
-    echo "download s3 object: soaking-terraform-state/${key_name}"
-    aws s3 cp "s3://soaking-terraform-state/${key_name}" "downloaded_terraform/${key_name}"
-    tar xvf "downloaded_terraform/${key_name}"
+	  platform_folder=""
+	  if "${key_name}" =~ "ec2"; then platform_folder="ec2"; else { if "${key_name}" =~ "eks"; then platform_folder="eks"; else platform_folder="ecs"; fi; }; fi
+	  echo "${platform_folder}"
 
-    # Set output in case the destroy fails
-    echo "::set-output name=key-name::${key_name}"
-    echo "remove s3 key: ${key_name}"
-    aws s3 rm "s3://soaking-terraform-state/${key_name}"
 
-    if [ -d testing-framework/terraform/soaking ]; then
-      cd testing-framework/terraform/soaking
-      terraform init
-      terraform destroy -auto-approve
-      cd -
-    fi
-    rm -rf testing-framework
-    rm -rf "downloaded_terraform/${key_name}"
 	fi
 }
 
-s3_keys=$(aws s3api list-objects-v2 --bucket "soaking-terraform-state" --query "Contents[?LastModified < '${yesterday}'].Key")
+s3_keys=$(aws s3api list-objects-v2 --bucket "${terraform_state_s3_bucket}" --query "Contents[?LastModified < '${yesterday}'].Key")
 
 echo "${s3_keys}" | docker run --rm -i stedolan/jq -c -r '.[]' | while read -r s3_key; do
   terraform_destroy "${s3_key}"

--- a/tools/workflow/clean-terraform-resources.sh
+++ b/tools/workflow/clean-terraform-resources.sh
@@ -17,7 +17,7 @@ set -ex
 
 #Set environment variables
 terraform_state_s3_bucket="aws-otel-test-terraform-state"
-yesterday=$(docker run --rm ubuntu date -d "yesterday" "+%Y-%m-23") #Ensure we are using gnudate
+yesterday=$(docker run --rm ubuntu date -d "yesterday" "+%Y-%m-%d") # ensure we are using gnudate
 
 function check_deps() {
   test -f $(which aws) || error_exit "aws command not detected in path, please install it"

--- a/tools/workflow/clean-terraform-resources.sh
+++ b/tools/workflow/clean-terraform-resources.sh
@@ -40,6 +40,8 @@ terraform_destroy() {
     # Download the terraform state from s3 bucket
     echo "download terraform state from s3 bucket: ${terraform_state_s3_bucket}/${key_name}"
     aws s3 cp "s3://${terraform_state_s3_bucket}/${key_name}" "testing-framework/terraform/${platform_folder}/terraform.tfstate"
+
+    #Destroy resources created by test case
     if [ -d "testing-framework/terraform/${platform_folder}" ]; then
         cd "testing-framework/terraform/${platform_folder}"
         terraform init
@@ -49,6 +51,8 @@ terraform_destroy() {
 
     #Remove terraform state after destroying
     rm -rf "testing-framework/terraform/${platform_folder}/terraform.tfstate"
+
+
 
 	fi
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
After uploading the [terraform state to s3 by this PR](https://github.com/aws-observability/aws-otel-collector/pull/891), we would need to decide when we destroy it. Therefore by using existing clean-terraform-resources script, we would able to destroy the resources created by test case a second time.
**Link to tracking Issue:** <Issue number if applicable>
N/A
**Testing:** <Describe what testing was performed and which tests were added.>
Run the script locally and run without any issues so far.
**Documentation:** <Describe the documentation added.>
N/A