### PR TITLE
Update docs with instructions for windows build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,10 @@ amd64-build: install-tools lint multimod-verify
 arm64-build: install-tools lint multimod-verify
 	GOOS=linux GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o ./build/linux/arm64/aoc ./cmd/awscollector
 
+.PHONY: windows-build
+windows-build: install-tools lint multimod-verify
+	GOOS=windows GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o ./build/windows/amd64/aoc ./cmd/awscollector
+
 # For building container image during development, no lint nor other platforms
 .PHONY: amd64-build-only
 amd64-build-only:

--- a/docs/developers/build-aoc.md
+++ b/docs/developers/build-aoc.md
@@ -1,6 +1,6 @@
 ### Build Artifacts
 
-aws-otel-collector is an open source project, we’re looking for the contributions from the open source community to make it better. You can build your own executable binaries for your own customization. We provide the following command for you the build your own executables.
+aws-otel-collector is an open source project, we’re looking for contributions from the open source community to make it better. You can build your own executable binaries for your own customization. We provide the following commands for you to build your own executables.
 
 #### Build RPM file
 ```
@@ -20,5 +20,7 @@ make package-deb
 ```
 git clone https://github.com/aws-observability/aws-otel-collector.git  
 cd aws-otel-collector
+choco install make
+make windows-build
 .\tools\packaging\windows\create_msi.ps1 
 ```


### PR DESCRIPTION
**Description:** Added make target for windows build. Chocolatey is already required for `create_msi.ps1`, so it can likely be used to install `make` as well. https://community.chocolatey.org/packages/make

https://github.com/aws-observability/aws-otel-collector/blob/7a824b59c8b23d5eaca820e914ebc1cbec93d37e/tools/packaging/windows/create_msi.ps1#L16

**Link to tracking Issue:** https://github.com/aws-observability/aws-otel-collector/issues/893
