### PR TITLE
Add retry to PR build with a random delay to prevent rate limiting

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -58,128 +58,126 @@ jobs:
     steps:
     # Set up building environment, patch the dev repo code on dispatch events.  
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
       if: ${{ needs.changes.outputs.changed == 'true' }}
+      uses: actions/setup-go@v2
       with:
         go-version: 1.17
 
-
-    - uses: actions/checkout@v2
+    - name: Checkout
       if: ${{ needs.changes.outputs.changed == 'true' }}
+      uses: actions/checkout@v2
 
-    - name: Cache Build
+    - name: Cache go
+      if: ${{ needs.changes.outputs.changed == 'true' }}
       uses: actions/cache@v2
-      if: ${{ needs.changes.outputs.changed == 'true' }}
       with:
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build
         key: v1-go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
 
-
-    # Unit Test and attach test coverage badge
-    - name: Unit Test
-      if: ${{ needs.changes.outputs.changed == 'true' }}
-      run: make test
-
-
-    - name: Upload Coverage report to CodeCov
-      uses: codecov/codecov-action@v2
-      if: ${{ needs.changes.outputs.changed == 'true' }}
-      with:
-        file: ./coverage.txt
-
-
-    # Build and archive binaries into cache.
-    - name: Build Binaries
-      if: ${{ needs.changes.outputs.changed == 'true' }}
-      run: make build
-
-
     - name: Cache binaries
-      uses: actions/cache@v2
+      id: cached_binaries
       if: ${{ needs.changes.outputs.changed == 'true' }}
+      uses: actions/cache@v2
       with:
         key: "cached_binaries_${{ github.run_id }}"
         path: build
 
+    # Unit Test and attach test coverage badge
+    - name: Unit Test
+      if: ${{ needs.changes.outputs.changed == 'true' && steps.cached_binaries.outputs.cache-hit != 'true' }}
+      run: make test
+
+    - name: Upload Coverage report to CodeCov
+      if: ${{ needs.changes.outputs.changed == 'true' && steps.cached_binaries.outputs.cache-hit != 'true' }}
+      uses: codecov/codecov-action@v2
+      with:
+        file: ./coverage.txt
+
+    # Build and archive binaries into cache.
+    - name: Build Binaries
+      if: ${{ needs.changes.outputs.changed == 'true' && steps.cached_binaries.outputs.cache-hit != 'true' }}
+      run: make build
 
     # upload the binaries to artifact as well because cache@v2 hasn't support windows
     - name: Upload
-      uses: actions/upload-artifact@v2
       if: ${{ needs.changes.outputs.changed == 'true' }}
+      uses: actions/upload-artifact@v2
       with:
         name: binary_artifacts
         path: build
-
 
   packaging-msi:
     runs-on: windows-latest
     needs: [changes, build]
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
         if: ${{ needs.changes.outputs.changed == 'true' }}
+        uses: actions/checkout@v2
 
       - name: Download built artifacts
+        if: ${{ needs.changes.outputs.changed == 'true' }}
         uses: actions/download-artifact@v2
         with:
           name: binary_artifacts
           path: build
-        if: ${{ needs.changes.outputs.changed == 'true' }}
 
       - name: Display structure of downloaded files
         run: ls -R
         if: ${{ needs.changes.outputs.changed == 'true' }}
 
       - name: Create msi file using candle and light
-        run: .\tools\packaging\windows\create_msi.ps1
         if: ${{ needs.changes.outputs.changed == 'true' }}
+        run: .\tools\packaging\windows\create_msi.ps1
 
   packaging-rpm:
     runs-on: ubuntu-latest
     needs: [changes, build]
     steps:
       # Build and archive RPMs into cache.
-      - uses: actions/checkout@v2
+      - name: Checkout
         if: ${{ needs.changes.outputs.changed == 'true' }}
+        uses: actions/checkout@v2
 
       - name: restore cached binaries
+        if: ${{ needs.changes.outputs.changed == 'true' }}
         uses: actions/cache@v2
         with:
           key: "cached_binaries_${{ github.run_id }}"
           path: build
-        if: ${{ needs.changes.outputs.changed == 'true' }}
 
       - name: Display structure of downloaded files
-        run: ls -R
         if: ${{ needs.changes.outputs.changed == 'true' }}
+        run: ls -R
 
       - name: Build RPM
+        if: ${{ needs.changes.outputs.changed == 'true' }}
         run: |
           ARCH=x86_64 SOURCE_ARCH=amd64 DEST=build/packages/linux/amd64 tools/packaging/linux/create_rpm.sh
           ARCH=aarch64 SOURCE_ARCH=arm64 DEST=build/packages/linux/arm64 tools/packaging/linux/create_rpm.sh
-        if: ${{ needs.changes.outputs.changed == 'true' }}
 
   packaging-deb:
     runs-on: ubuntu-latest
     needs: [changes, build]
     steps:
       # Build and archive debs into cache.
-      - uses: actions/checkout@v2
+      - name: Checkout
         if: ${{ needs.changes.outputs.changed == 'true' }}
+        uses: actions/checkout@v2
 
-      - name: restore cached binaries
+      - name: Restore cached binaries
+        if: ${{ needs.changes.outputs.changed == 'true' }}
         uses: actions/cache@v2
         with:
           key: "cached_binaries_${{ github.run_id }}"
           path: build
-        if: ${{ needs.changes.outputs.changed == 'true' }}
 
       - name: Build Debs
+        if: ${{ needs.changes.outputs.changed == 'true' }}
         run: |
           ARCH=amd64 DEST=build/packages/debian/amd64 tools/packaging/debian/create_deb.sh
           ARCH=arm64 DEST=build/packages/debian/arm64 tools/packaging/debian/create_deb.sh
-        if: ${{ needs.changes.outputs.changed == 'true' }}
 
   get-test-cases:
     runs-on: ubuntu-latest
@@ -209,44 +207,50 @@ jobs:
       matrix: ${{ fromJson(needs.get-test-cases.outputs.matrix) }}
     steps:
       - name: Check out testing framework
+        if: ${{ needs.changes.outputs.changed == 'true' }}
         uses: actions/checkout@v2
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
-        if: ${{ needs.changes.outputs.changed == 'true' }}
 
       - name: Check out Collector
+        if: ${{ needs.changes.outputs.changed == 'true' }}
         uses: actions/checkout@v2
         with:
           path: aws-otel-collector
-        if: ${{ needs.changes.outputs.changed == 'true' }}
 
       - name: Set up JDK 11
+        if: ${{ needs.changes.outputs.changed == 'true' }}
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
           java-version: '11'
-        if: ${{ needs.changes.outputs.changed == 'true' }}
 
       - name: Set up terraform
-        uses: hashicorp/setup-terraform@v1.2.1
         if: ${{ needs.changes.outputs.changed == 'true' }}
+        uses: hashicorp/setup-terraform@v1.2.1
 
       - name: restore cached binaries
+        if: ${{ needs.changes.outputs.changed == 'true' }}
         uses: actions/cache@v2
         with:
           key: "cached_binaries_${{ github.run_id }}"
           path: build
-        if: ${{ needs.changes.outputs.changed == 'true' }}
 
       - name: copy binary
-        run: cp -R build aws-otel-collector/build
         if: ${{ needs.changes.outputs.changed == 'true' }}
+        run: cp -R build aws-otel-collector/build
 
       - name: Run test
-        run: | 
-          if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
-          cd testing-framework/terraform/mock && terraform init && terraform apply -auto-approve -var="testcase=../testcases/${{ matrix.testcase }}" $opts
         if: ${{ needs.changes.outputs.changed == 'true' }}
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 2
+          timeout_minutes: 10
+          command: |
+            if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
+            cd testing-framework/terraform/mock && terraform init && terraform apply -auto-approve -var="testcase=../testcases/${{ matrix.testcase }}" $opts
+          on_retry_command: |
+            cd testing-framework/terraform/mock && terraform destroy -auto-approve && sleep $((RANDOM % 10))
         env:
           DOCKER_BUILDKIT: 1 # Required for TARGETARCH to be populated with Docker compose.


### PR DESCRIPTION
**Description:** Public ECR has an unauthenticated pull limit of 1 per second. We're having issues with multiple tests pulling the image at the same time. Trying to prevent that sort of collision with a delayed retry on failure.

Also fixed the build job so it actually uses the cache.

**Link to tracking Issue:** https://github.com/aws-observability/aws-otel-collector/issues/916
