### PR TITLE
Force CD release step to use Go 1.17

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -533,9 +533,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [s3-release-validation-1, s3-release-validation-2, s3-release-validation-3,release-validation-ecs, release-validation-eks, release-checking]
     steps:
-      #Since the tools in workflow are always up-to-date with the github workflow, we don't need to use the tools in workflows from the commited sha
+      #Since the tools in workflow are always up-to-date with the github workflow, we don't need to use the tools in workflows from the committed sha
       #but using the tools in workflows from the branch triggered with workflow_dispatch.
       - uses: actions/checkout@v2
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
 
       - name: Cache if success
         id: release-latest-image


### PR DESCRIPTION
**Description:** The CD ADOT Operator image mirror step is failing. 
https://github.com/aws-observability/aws-otel-collector/runs/4985859103?check_suite_focus=true
```
# github.com/aws-observability/aws-otel-collector/tools/release/adot-operator-images-mirror
./mirror.go:69:10: undefined: io.Discard
./mirror.go:85:10: undefined: io.Discard
note: module requires Go 1.17
```
It looks like the issue is that it's using Go 1.15 since `io.Discard` was introduced in Go 1.16. The default in ubuntu-latest seems to be 1.15.
