### PR TITLE
Add OTEL_METRICS_EXPORTER environment variable to example config.

### DIFF
--- a/deployment-template/eks/otel-cloudwatch-sidecar.yaml
+++ b/deployment-template/eks/otel-cloudwatch-sidecar.yaml
@@ -36,6 +36,8 @@ spec:
               value: "service.namespace=AWSObservability,service.name=CloudWatchEKSService"
             - name: S3_REGION
               value: {{region}}
+            - name: OTEL_METRICS_EXPORTER
+              value: "otlp"
           imagePullPolicy: Always
         - name: aws-otel-collector
           image: amazon/aws-otel-collector:latest

--- a/examples/ec2/aws-cloudwatch/ecs-ec2-sidecar.json
+++ b/examples/ec2/aws-cloudwatch/ecs-ec2-sidecar.json
@@ -22,6 +22,10 @@
         {
           "name": "S3_REGION",
           "value": "{{region}}"
+        },
+        {
+          "name": "OTEL_METRICS_EXPORTER",
+          "value": "otlp"
         }
       ],
       "dependsOn": [],

--- a/examples/eks/aws-cloudwatch/otel-sidecar.yaml
+++ b/examples/eks/aws-cloudwatch/otel-sidecar.yaml
@@ -34,6 +34,8 @@ spec:
             value: "service.namespace=AWSObservability,service.name=CloudWatchEKSService"
           - name: S3_REGION
             value: "us-west-2"
+          - name: OTEL_METRICS_EXPORTER
+            value: "otlp"
           imagePullPolicy: Always
         - name: aws-otel-collector
           image: amazon/aws-otel-collector:latest


### PR DESCRIPTION
**Description:** When we switched to using the aws-otel-java-instrumentation spark sample app, we didn't account for the configuration changes. This fixes our examples that use the new spark sample app by adding the `OTEL_METRICS_EXPORTER` environment variable.

**Link to tracking Issue:** Fixes https://github.com/aws-observability/aws-otel-collector/issues/933
