### PR TITLE
Fix roll back when releasing latest binaries to s3 and change condition when triggering delete-image-binaries in CD workflow

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -540,18 +540,18 @@ jobs:
       #but using the tools in workflows from the branch triggered with workflow_dispatch.
       - uses: actions/checkout@v2
 
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.17
-
       - name: Cache if success
         id: release-latest-image-s3
         uses: actions/cache@v2
         with:
-          path: |
-            VERSION
           key: release-latest-image-s3-${{ github.run_id }}
+          path: VERSION
+
+      - name: Set up Go 1.x
+        if: steps.release-latest-image-s3.outputs.cache-hit != 'true'
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
 
       - name: Restore cached packages
         if: steps.release-latest-image-s3.outputs.cache-hit != 'true'

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -145,7 +145,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Release to S3
-        run: s3_bucket_name=${{ env.RELEASE_S3_BUCKET }} upload_to_latest=1 bash tools/release/image-binary-release/s3-release.sh
+        run: s3_bucket_name=${{ env.RELEASE_S3_BUCKET }} upload_to_latest=0 bash tools/release/image-binary-release/s3-release.sh
 
       #Create ssm package and binaries/artifacts for validation test which is similar to SSM workflow release
       - name: Create SSM packages for validation test and set permission to public
@@ -507,7 +507,7 @@ jobs:
 
   delete-images-binaries-if-fail:
     runs-on: ubuntu-latest
-    if: failure()
+    if: $ {{ failure() || cancelled() }}
     needs: [s3-release-validation-1, s3-release-validation-2, s3-release-validation-3,release-validation-ecs, release-validation-eks, release-checking]
     steps:
       #Since the tools in workflow are always up-to-date with the github workflow, we don't need to use the tools in workflows from the commited sha
@@ -523,7 +523,7 @@ jobs:
 
       - name: Delete binaries from s3
         run: |
-          delete_to_latest=1 \
+          delete_to_latest=0 \
           s3_bucket_name=${{ env.RELEASE_S3_BUCKET }} \
           version=${{ needs.release-checking.outputs.version }} \
           bash tools/release/image-binary-release/delete-s3-release.sh
@@ -533,7 +533,7 @@ jobs:
           aws ecr-public batch-delete-image --repository-name $IMAGE_NAME --image-ids imageTag=${{ needs.release-checking.outputs.version }} --region us-east-1
 
 
-  release-latest-image:
+  release-latest-image-s3:
     runs-on: ubuntu-latest
     needs: [s3-release-validation-1, s3-release-validation-2, s3-release-validation-3,release-validation-ecs, release-validation-eks, release-checking]
     steps:
@@ -595,6 +595,10 @@ jobs:
           src: public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.release-checking.outputs.version }}
           dst: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.release-checking.outputs.version }}
 
+      - name: Release binaries to s3 with latest version
+        if: steps.release-latest-image.outputs.cache-hit != 'true'
+        run: s3_bucket_name=${{ env.RELEASE_S3_BUCKET }} upload_to_latest=1 bash tools/release/image-binary-release/s3-release.sh
+
       - name: Release adot operator
         if: ${{ steps.release-latest-image.outputs.cache-hit != 'true' && (steps.version.outputs.major-update == 'true' || steps.version.outputs.minor-update == 'true') }}
         run: cd tools/release/adot-operator-images-mirror && go run ./
@@ -615,6 +619,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Restore cached packages
+        id: cache_packages
         uses: actions/cache@v2
         with:
           key: "${{ env.PACKAGE_CACHE_KEY }}"

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -529,8 +529,7 @@ jobs:
           bash tools/release/image-binary-release/delete-s3-release.sh
 
       - name: Delete version image from ecr
-        run: |
-          aws ecr-public batch-delete-image --repository-name $IMAGE_NAME --image-ids imageTag=${{ needs.release-checking.outputs.version }} --region us-east-1
+        run: aws ecr-public batch-delete-image --repository-name $IMAGE_NAME --image-ids imageTag=${{ needs.release-checking.outputs.version }} --region us-east-1
 
 
   release-latest-image-s3:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -553,6 +553,13 @@ jobs:
             VERSION
           key: release-latest-image-${{ github.run_id }}
 
+      - name: Restore cached packages
+        if: steps.release-latest-image.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "${{ env.PACKAGE_CACHE_KEY }}"
+          path: "${{ env.PACKAGING_ROOT }}"
+
       - name: Compare version with Dockerhub latest
         id: version
         if: steps.release-latest-image.outputs.cache-hit != 'true'

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -220,7 +220,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 30
+          timeout_minutes: 8
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
           
@@ -283,7 +283,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 30
+          timeout_minutes: 8
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
           
@@ -346,7 +346,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 30
+          timeout_minutes: 8
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
           
@@ -438,7 +438,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 30
+          timeout_minutes: 8
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ecs && terraform destroy -auto-approve
                   
@@ -501,7 +501,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 30
+          timeout_minutes: 8
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/eks && terraform destroy -auto-approve
 
@@ -546,15 +546,15 @@ jobs:
           go-version: 1.17
 
       - name: Cache if success
-        id: release-latest-image
+        id: release-latest-image-s3
         uses: actions/cache@v2
         with:
           path: |
             VERSION
-          key: release-latest-image-${{ github.run_id }}
+          key: release-latest-image-s3-${{ github.run_id }}
 
       - name: Restore cached packages
-        if: steps.release-latest-image.outputs.cache-hit != 'true'
+        if: steps.release-latest-image-s3.outputs.cache-hit != 'true'
         uses: actions/cache@v2
         with:
           key: "${{ env.PACKAGE_CACHE_KEY }}"
@@ -562,21 +562,21 @@ jobs:
 
       - name: Compare version with Dockerhub latest
         id: version
-        if: steps.release-latest-image.outputs.cache-hit != 'true'
+        if: steps.release-latest-image-s3.outputs.cache-hit != 'true'
         run: |
           TAG="${{ needs.release-checking.outputs.version }}"
           TARGET_VERSION=$TAG bash tools/workflow/docker-version-compare.sh
 
       - name: Login Dockerhub
         uses: docker/login-action@v1
-        if: steps.release-latest-image.outputs.cache-hit != 'true'
+        if: steps.release-latest-image-s3.outputs.cache-hit != 'true'
         with:
           username: "${{ secrets.DOCKERHUB_RELEASE_USERNAME }}"
           password: "${{ secrets.DOCKERHUB_RELEASE_TOKEN }}"
 
       - name: Login to Public Release ECR
         id: login-ecr
-        if: ${{ steps.release-latest-image.outputs.cache-hit != 'true' && steps.version.outputs.any-update == 'true' }}
+        if: ${{ steps.release-latest-image-s3.outputs.cache-hit != 'true' && steps.version.outputs.any-update == 'true' }}
         uses: docker/login-action@v1
         with:
           registry: public.ecr.aws
@@ -586,7 +586,7 @@ jobs:
           AWS_REGION: us-east-1
 
       - name: Pull image from integration test ECR, tag as latest and push to public release ECR and DockerHub
-        if: ${{ steps.release-latest-image.outputs.cache-hit != 'true'  && steps.version.outputs.any-update == 'true' }}
+        if: ${{ steps.release-latest-image-s3.outputs.cache-hit != 'true'  && steps.version.outputs.any-update == 'true' }}
         uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.release-checking.outputs.version }}
@@ -596,17 +596,17 @@ jobs:
 
       - name: Pull image from integration test ECR, tag with input version and push to DockerHub
         uses: akhilerm/tag-push-action@v2.0.0
-        if: steps.release-latest-image.outputs.cache-hit != 'true'
+        if: steps.release-latest-image-s3.outputs.cache-hit != 'true'
         with:
           src: public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.release-checking.outputs.version }}
           dst: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.release-checking.outputs.version }}
 
       - name: Release binaries to s3 with latest version
-        if: steps.release-latest-image.outputs.cache-hit != 'true'
+        if: steps.release-latest-image-s3.outputs.cache-hit != 'true'
         run: s3_bucket_name=${{ env.RELEASE_S3_BUCKET }} upload_to_latest=1 bash tools/release/image-binary-release/s3-release.sh
 
       - name: Release adot operator
-        if: ${{ steps.release-latest-image.outputs.cache-hit != 'true' && (steps.version.outputs.major-update == 'true' || steps.version.outputs.minor-update == 'true') }}
+        if: ${{ steps.release-latest-image-s3.outputs.cache-hit != 'true' && (steps.version.outputs.major-update == 'true' || steps.version.outputs.minor-update == 'true') }}
         run: cd tools/release/adot-operator-images-mirror && go run ./
 
   clean-ssm-package:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -505,7 +505,7 @@ jobs:
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/eks && terraform destroy -auto-approve
 
-  delete-images-binaries-if-fail:
+  delete-images-binaries:
     runs-on: ubuntu-latest
     if: $ {{ failure() || cancelled() }}
     needs: [s3-release-validation-1, s3-release-validation-2, s3-release-validation-3,release-validation-ecs, release-validation-eks, release-checking]

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -507,7 +507,7 @@ jobs:
 
   delete-images-binaries:
     runs-on: ubuntu-latest
-    if: $ {{ failure() || cancelled() }}
+    if: ${{ failure() || cancelled() }}
     needs: [s3-release-validation-1, s3-release-validation-2, s3-release-validation-3,release-validation-ecs, release-validation-eks, release-checking]
     steps:
       #Since the tools in workflow are always up-to-date with the github workflow, we don't need to use the tools in workflows from the commited sha

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -529,8 +529,33 @@ jobs:
       - name: Delete version image from ecr
         run: aws ecr-public batch-delete-image --repository-name $IMAGE_NAME --image-ids imageTag=${{ needs.release-checking.outputs.version }} --region us-east-1
 
+  release-latest-s3:
+    runs-on: ubuntu-latest
+    needs: [ s3-release-validation-1, s3-release-validation-2, s3-release-validation-3,release-validation-ecs, release-validation-eks, release-checking ]
+    steps:
+      #Since the tools in workflow are always up-to-date with the github workflow, we don't need to use the tools in workflows from the committed sha
+      #but using the tools in workflows from the branch triggered with workflow_dispatch.
+      - uses: actions/checkout@v2
 
-  release-latest-image-s3:
+      - name: Cache if success
+        id: release-latest-s3
+        uses: actions/cache@v2
+        with:
+          key: release-latest-s3-${{ github.run_id }}
+          path: VERSION
+
+      - name: Restore cached packages
+        if: steps.release-latest-s3.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "${{ env.PACKAGE_CACHE_KEY }}"
+          path: "${{ env.PACKAGING_ROOT }}"
+
+      - name: Release binaries to s3 with latest version
+        if: steps.release-latest-s3.outputs.cache-hit != 'true'
+        run: s3_bucket_name=${{ env.RELEASE_S3_BUCKET }} upload_to_latest=1 bash tools/release/image-binary-release/s3-release.sh
+
+  release-latest-image:
     runs-on: ubuntu-latest
     needs: [s3-release-validation-1, s3-release-validation-2, s3-release-validation-3,release-validation-ecs, release-validation-eks, release-checking]
     steps:
@@ -539,42 +564,35 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Cache if success
-        id: release-latest-image-s3
+        id: release-latest-image
         uses: actions/cache@v2
         with:
-          key: release-latest-image-s3-${{ github.run_id }}
+          key: release-latest-image-${{ github.run_id }}
           path: VERSION
 
       - name: Set up Go 1.x
-        if: steps.release-latest-image-s3.outputs.cache-hit != 'true'
+        if: steps.release-latest-image.outputs.cache-hit != 'true'
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
 
-      - name: Restore cached packages
-        if: steps.release-latest-image-s3.outputs.cache-hit != 'true'
-        uses: actions/cache@v2
-        with:
-          key: "${{ env.PACKAGE_CACHE_KEY }}"
-          path: "${{ env.PACKAGING_ROOT }}"
-
       - name: Compare version with Dockerhub latest
         id: version
-        if: steps.release-latest-image-s3.outputs.cache-hit != 'true'
+        if: steps.release-latest-image.outputs.cache-hit != 'true'
         run: |
           TAG="${{ needs.release-checking.outputs.version }}"
           TARGET_VERSION=$TAG bash tools/workflow/docker-version-compare.sh
 
       - name: Login Dockerhub
         uses: docker/login-action@v1
-        if: steps.release-latest-image-s3.outputs.cache-hit != 'true'
+        if: steps.release-latest-image.outputs.cache-hit != 'true'
         with:
           username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
           password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
 
       - name: Login to Public Release ECR
         id: login-ecr
-        if: ${{ steps.release-latest-image-s3.outputs.cache-hit != 'true' && steps.version.outputs.any-update == 'true' }}
+        if: ${{ steps.release-latest-image.outputs.cache-hit != 'true' && steps.version.outputs.any-update == 'true' }}
         uses: docker/login-action@v1
         with:
           registry: public.ecr.aws
@@ -584,7 +602,7 @@ jobs:
           AWS_REGION: us-east-1
 
       - name: Pull image from integration test ECR, tag as latest and push to public release ECR and DockerHub
-        if: ${{ steps.release-latest-image-s3.outputs.cache-hit != 'true'  && steps.version.outputs.any-update == 'true' }}
+        if: ${{ steps.release-latest-image.outputs.cache-hit != 'true'  && steps.version.outputs.any-update == 'true' }}
         uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.release-checking.outputs.version }}
@@ -594,17 +612,13 @@ jobs:
 
       - name: Pull image from integration test ECR, tag with input version and push to DockerHub
         uses: akhilerm/tag-push-action@v2.0.0
-        if: steps.release-latest-image-s3.outputs.cache-hit != 'true'
+        if: steps.release-latest-image.outputs.cache-hit != 'true'
         with:
           src: public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.release-checking.outputs.version }}
           dst: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.release-checking.outputs.version }}
 
-      - name: Release binaries to s3 with latest version
-        if: steps.release-latest-image-s3.outputs.cache-hit != 'true'
-        run: s3_bucket_name=${{ env.RELEASE_S3_BUCKET }} upload_to_latest=1 bash tools/release/image-binary-release/s3-release.sh
-
       - name: Release adot operator
-        if: ${{ steps.release-latest-image-s3.outputs.cache-hit != 'true' && (steps.version.outputs.major-update == 'true' || steps.version.outputs.minor-update == 'true') || steps.version.outputs.same-version == 'true' }}
+        if: ${{ steps.release-latest-image.outputs.cache-hit != 'true' && (steps.version.outputs.major-update == 'true' || steps.version.outputs.minor-update == 'true') || steps.version.outputs.same-version == 'true' }}
         run: cd tools/release/adot-operator-images-mirror && go run ./
 
   clean-ssm-package:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -655,7 +655,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 30
+          timeout_minutes: 8
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
 
@@ -734,7 +734,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 30
+          timeout_minutes: 8
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
 
@@ -813,7 +813,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 30
+          timeout_minutes: 8
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
 
@@ -885,7 +885,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 30
+          timeout_minutes: 8
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ecs && terraform destroy -auto-approve
 
@@ -946,7 +946,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 30
+          timeout_minutes: 8
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/eks && terraform destroy -auto-approve
 
@@ -1007,7 +1007,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 30
+          timeout_minutes: 8
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/eks && terraform destroy -auto-approve -var="region=us-east-2" -var="eks_cluster_name=integ-test-arm64-cluster"
 
@@ -1080,7 +1080,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 30
+          timeout_minutes: 8
           retry_wait_seconds: 20
           command: |
             opts=""
@@ -1144,7 +1144,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 30
+          timeout_minutes: 8
           retry_wait_seconds: 20
           command: |
             opts=""


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Instead of release s3 to latest, we only need to release version s3 and release to latest if the validation test success. Moreover,  changing conditions when triggering delete-image-binaries

**Link to tracking Issue:** <Issue number if applicable>
N/A
**Testing:** <Describe what testing was performed and which tests were added.>
N/A
**Documentation:** <Describe the documentation added.>
N/A