### PR TITLE
Update flags.go to be in sync with upstream

### DIFF
--- a/pkg/config/config_factory.go
+++ b/pkg/config/config_factory.go
@@ -32,8 +32,8 @@ func GetConfigProvider() service.ConfigProvider {
 	loc := getConfigFlag()
 	if configContent, ok := os.LookupEnv(envKey); ok {
 		log.Printf("Reading AOT config from environment: %v\n", configContent)
-		loc = "env:" + envKey
+		loc = append(loc, "env:"+envKey)
 	}
 
-	return service.NewDefaultConfigProvider([]string{loc}, getSetFlag())
+	return service.NewDefaultConfigProvider(loc, getSetFlag())
 }

--- a/pkg/config/config_factory.go
+++ b/pkg/config/config_factory.go
@@ -32,7 +32,7 @@ func GetConfigProvider() service.ConfigProvider {
 	loc := getConfigFlag()
 	if configContent, ok := os.LookupEnv(envKey); ok {
 		log.Printf("Reading AOT config from environment: %v\n", configContent)
-		loc = append(loc, "env:"+envKey)
+		loc = []string{"env:"+envKey}
 	}
 
 	return service.NewDefaultConfigProvider(loc, getSetFlag())

--- a/pkg/config/config_factory_test.go
+++ b/pkg/config/config_factory_test.go
@@ -37,7 +37,7 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 
 	resetFlag := func() {
 		configFlag = new(stringArrayValue)
-		setFlag    = new(stringArrayValue)
+		setFlag = new(stringArrayValue)
 	}
 
 	t.Run("test_invalid_path", func(t *testing.T) {
@@ -50,11 +50,11 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 		err := cmd.ParseFlags([]string{
 			"--config=invalid-path/otelcol-config.yaml",
 		})
+		t.Cleanup(resetFlag)
 		require.NoError(t, err)
 		provider := GetConfigProvider()
 		_, err = provider.Get(context.Background(), factories)
 		require.Error(t, err)
-		resetFlag()
 	})
 
 	t.Run("test_config_with_env_var_set", func(t *testing.T) {
@@ -71,6 +71,7 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 		err := cmd.ParseFlags([]string{
 			"--config=testdata/config.yaml",
 		})
+		t.Cleanup(resetFlag)
 		require.NoError(t, err)
 		provider := GetConfigProvider()
 		cfg, err := provider.Get(context.Background(), factories)
@@ -79,7 +80,6 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 		receiver := cfg.Receivers[config.NewComponentID("awsxray")].(*awsxrayreceiver.Config)
 		require.NotNil(t, receiver)
 		require.Equal(t, expectedEndpoint, receiver.Endpoint)
-		resetFlag()
 	})
 
 	t.Run("test_config_without_env_var_set", func(t *testing.T) {
@@ -93,6 +93,7 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 		err := cmd.ParseFlags([]string{
 			"--config=testdata/config.yaml",
 		})
+		t.Cleanup(resetFlag)
 		require.NoError(t, err)
 		provider := GetConfigProvider()
 		cfg, err := provider.Get(context.Background(), factories)
@@ -101,7 +102,6 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 		receiver := cfg.Receivers[config.NewComponentID("awsxray")].(*awsxrayreceiver.Config)
 		require.NotNil(t, receiver)
 		require.Empty(t, receiver.Endpoint)
-		resetFlag()
 	})
 }
 

--- a/pkg/config/config_factory_test.go
+++ b/pkg/config/config_factory_test.go
@@ -37,6 +37,7 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 
 	resetFlag := func() {
 		configFlag = new(stringArrayValue)
+		setFlag    = new(stringArrayValue)
 	}
 
 	t.Run("test_invalid_path", func(t *testing.T) {

--- a/pkg/config/config_factory_test.go
+++ b/pkg/config/config_factory_test.go
@@ -59,7 +59,7 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 
 	t.Run("test_config_with_env_var_set", func(t *testing.T) {
 		const expectedEndpoint = "0.0.0.0:2000"
-		os.Setenv("XRAY_ENDPOINT", expectedEndpoint)
+		t.Setenv("XRAY_ENDPOINT", expectedEndpoint)
 		defer os.Unsetenv("XRAY_ENDPOINT")
 		cmd := &cobra.Command{
 			Use:          params.BuildInfo.Command,
@@ -107,11 +107,9 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 
 func TestGetMapProviderContainer(t *testing.T) {
 	const expectedEndpoint = "0.0.0.0:1777"
-	os.Setenv("PPROF_ENDPOINT", expectedEndpoint)
-	defer os.Unsetenv("PPROF_ENDPOINT")
+	t.Setenv("PPROF_ENDPOINT", expectedEndpoint)
 
-	os.Setenv(envKey, "extensions:\n  health_check:\n  pprof:\n    endpoint: '${PPROF_ENDPOINT}'\nreceivers:\n  otlp:\n    protocols:\n      grpc:\n        endpoint: 0.0.0.0:4317\nprocessors:\n  batch:\nexporters:\n  logging:\n    loglevel: debug\n  awsxray:\n    local_mode: true\n    region: 'us-west-2'\n  awsemf:\n    region: 'us-west-2'\nservice:\n  pipelines:\n    traces:\n      receivers: [otlp]\n      exporters: [logging,awsxray]\n    metrics:\n      receivers: [otlp]\n      exporters: [awsemf]\n  extensions: [pprof]")
-	defer os.Unsetenv(envKey)
+	t.Setenv(envKey, "extensions:\n  health_check:\n  pprof:\n    endpoint: '${PPROF_ENDPOINT}'\nreceivers:\n  otlp:\n    protocols:\n      grpc:\n        endpoint: 0.0.0.0:4317\nprocessors:\n  batch:\nexporters:\n  logging:\n    loglevel: debug\n  awsxray:\n    local_mode: true\n    region: 'us-west-2'\n  awsemf:\n    region: 'us-west-2'\nservice:\n  pipelines:\n    traces:\n      receivers: [otlp]\n      exporters: [logging,awsxray]\n    metrics:\n      receivers: [otlp]\n      exporters: [awsemf]\n  extensions: [pprof]")
 
 	factories, _ := defaultcomponents.Components()
 	provider := GetConfigProvider()

--- a/pkg/config/config_factory_test.go
+++ b/pkg/config/config_factory_test.go
@@ -35,6 +35,10 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 		Factories: factories,
 	}
 
+	resetFlag := func() {
+		configFlag = new(stringArrayValue)
+	}
+
 	t.Run("test_invalid_path", func(t *testing.T) {
 		cmd := &cobra.Command{
 			Use:          params.BuildInfo.Command,
@@ -49,6 +53,7 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 		provider := GetConfigProvider()
 		_, err = provider.Get(context.Background(), factories)
 		require.Error(t, err)
+		resetFlag()
 	})
 
 	t.Run("test_config_with_env_var_set", func(t *testing.T) {
@@ -60,6 +65,7 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 			Version:      params.BuildInfo.Version,
 			SilenceUsage: true,
 		}
+
 		cmd.Flags().AddGoFlagSet(Flags())
 		err := cmd.ParseFlags([]string{
 			"--config=testdata/config.yaml",
@@ -72,6 +78,7 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 		receiver := cfg.Receivers[config.NewComponentID("awsxray")].(*awsxrayreceiver.Config)
 		require.NotNil(t, receiver)
 		require.Equal(t, expectedEndpoint, receiver.Endpoint)
+		resetFlag()
 	})
 
 	t.Run("test_config_without_env_var_set", func(t *testing.T) {
@@ -80,6 +87,7 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 			Version:      params.BuildInfo.Version,
 			SilenceUsage: true,
 		}
+
 		cmd.Flags().AddGoFlagSet(Flags())
 		err := cmd.ParseFlags([]string{
 			"--config=testdata/config.yaml",
@@ -92,6 +100,7 @@ func TestGetCfgFactoryConfig(t *testing.T) {
 		receiver := cfg.Receivers[config.NewComponentID("awsxray")].(*awsxrayreceiver.Config)
 		require.NotNil(t, receiver)
 		require.Empty(t, receiver.Endpoint)
+		resetFlag()
 	})
 }
 

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -22,10 +22,8 @@ import (
 )
 
 var (
-	defaultConfig = ""
-
 	// Command-line flag that control the configuration file.
-	configFlag = &defaultConfig
+	configFlag = new(stringArrayValue)
 	setFlag    = new(stringArrayValue)
 )
 
@@ -39,14 +37,14 @@ func (s *stringArrayValue) Set(val string) error {
 }
 
 func (s *stringArrayValue) String() string {
-	return "[" + strings.Join(s.values, ",") + "]"
+	return "[" + strings.Join(s.values, ", ") + "]"
 }
-
 func Flags() *flag.FlagSet {
 	flagSet := new(flag.FlagSet)
 	featuregate.Flags(flagSet)
 
-	configFlag = flagSet.String("config", defaultConfig, "Path to the config file")
+	flagSet.Var(configFlag, "config", "Locations to the config file(s), note that only a"+
+		" single location can be set per flag entry e.g. `-config=file:/path/to/first --config=file:path/to/second`.")
 
 	flagSet.Var(setFlag, "set",
 		"Set arbitrary component config property. The component has to be defined in the config file and the flag"+
@@ -56,8 +54,8 @@ func Flags() *flag.FlagSet {
 	return flagSet
 }
 
-func getConfigFlag() string {
-	return *configFlag
+func getConfigFlag() []string {
+	return configFlag.values
 }
 
 func getSetFlag() []string {


### PR DESCRIPTION
**Description:** During the v0.16.0 an updated to the unexported `flags.go` file was not recognized and updated. This PR updates `flags.go` to match upstream. The unit tests had to be slightly modified. The `configflag` was reset after each test case so that no flag was left in memory between test runs. 

**Link to tracking Issue:** closes #951 

**Testing:** `go test ./...` `make test` `make build`

**Documentation:** n/a
