### PR TITLE
Change Dockerfile to be multi-stage with build args.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -517,7 +517,7 @@ jobs:
       #-Using the adot collector image to do the integration test
       #-Export it for delivery version image in CD
       #Documentation: https://github.com/docker/build-push-action
-      - name: Build adot collector image
+      - name: Build ADOT collector image
         uses: docker/build-push-action@v2
         if: steps.e2etest-release.outputs.cache-hit != 'true'
         with:
@@ -527,6 +527,7 @@ jobs:
           tags: |
             public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.e2etest-preparation.outputs.version }}
             public.ecr.aws/${{ env.ECR_REPO }}:latest
+          build_args: BUILDMODE=copy
           cache-from: type=registry
           cache-to: type=inline
           platforms : linux/amd64, linux/arm64

--- a/Makefile
+++ b/Makefile
@@ -115,11 +115,11 @@ package-deb: build
 
 .PHONY: docker-build
 docker-build: amd64-build
-	docker buildx build --platform linux/amd64 -t $(DOCKER_NAMESPACE)/$(COMPONENT):$(VERSION) -f ./cmd/$(COMPONENT)/Dockerfile .
+	docker buildx build --platform linux/amd64 --build-arg BUILDMODE=copy --load -t $(DOCKER_NAMESPACE)/$(COMPONENT):$(VERSION) -f ./cmd/$(COMPONENT)/Dockerfile .
 
 .PHONY: docker-build-arm
 docker-build-arm: arm64-build
-	docker buildx build --platform linux/arm64 -t $(DOCKER_NAMESPACE)/$(COMPONENT):$(VERSION) -f ./cmd/$(COMPONENT)/Dockerfile .
+	docker buildx build --platform linux/arm64 --build-arg BUILDMODE=copy --load -t $(DOCKER_NAMESPACE)/$(COMPONENT):$(VERSION) -f ./cmd/$(COMPONENT)/Dockerfile .
 
 .PHONY: docker-push
 docker-push:

--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -1,11 +1,48 @@
+# The build mode (options: build, copy) passed in as a --build-arg. If build is specified, then the copy
+# stage will be skipped and vice versa. The build mode builds the binary from the source files, while
+# the copy mode copies in a pre-built binary.
+ARG BUILDMODE=build
+
 ################################
-#	Building Stage         #	
+#	Certificate Stage      #
+#			       #
+################################
+FROM alpine:latest AS certs
+
+RUN apk --update add ca-certificates
+
+################################
+#	Build Stage            #
+#			       #
+################################
+FROM golang:1.17 AS prep-build
+
+ARG TARGETARCH
+
+# pass in the GOPROXY as a --build-arg (e.g. --build-arg GOPROXY=direct)
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
+# download go modules ahead to speed up the building
+WORKDIR /workspace
+COPY go.mod .
+COPY go.sum .
+RUN go mod download -x
+
+# copy source
+COPY . .
+
+# build
+RUN make ${TARGETARCH}-build
+
+# move
+RUN mv /workspace/build/linux/$TARGETARCH/aoc /workspace/awscollector
+
+################################
+#	Copy Stage             #
 #			       #	
 ################################
-FROM alpine:latest as build 
-
-# update cert
-RUN apk --update add ca-certificates
+FROM scratch AS prep-copy
 
 WORKDIR /workspace
 
@@ -14,6 +51,13 @@ ARG TARGETARCH
 # copy artifacts
 # always assume binary is created
 COPY build/linux/$TARGETARCH/aoc /workspace/awscollector
+
+################################
+#	Packing Stage          #
+#			       #
+################################
+FROM prep-${BUILDMODE} AS package
+
 COPY config.yaml /workspace/config/otel-config.yaml
 COPY config/ /workspace/config/
 
@@ -23,9 +67,9 @@ COPY config/ /workspace/config/
 ################################
 FROM scratch
 
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=build /workspace/awscollector /awscollector
-COPY --from=build /workspace/config/ /etc/
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=package /workspace/awscollector /awscollector
+COPY --from=package /workspace/config/ /etc/
 
 ENV RUN_IN_CONTAINER="True"
 # aws-sdk-go needs $HOME to look up shared credentials
@@ -33,4 +77,3 @@ ENV HOME=/root
 ENTRYPOINT ["/awscollector"]
 CMD ["--config=/etc/otel-config.yaml"]
 EXPOSE 4317 55681 2000
-


### PR DESCRIPTION
**Description:** Mostly based on https://github.com/docker/cli/issues/1134#issuecomment-406449342. The idea is basically to have a build stage and a copy stage. Only one of them will run based on the `BUILDMODE` build arg. By default, the steps will build the binary (takes forever to download the go mod) and skip the copy stage. For our CI and Makefile, we will pass in `BUILDMODE=copy`, which will skip the build stage.

**Link to tracking Issue:** Resolves https://github.com/aws-observability/aws-otel-collector/issues/878

**Testing:** Ran `make docker-build` and `docker buildx build --platform linux/amd64 --build-arg BUILDMODE=build --load -t awscollector:test -f ./cmd/awscollector/Dockerfile .`
