### PR TITLE
Fix docker/build-push-action build-args input.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -527,7 +527,7 @@ jobs:
           tags: |
             public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.e2etest-preparation.outputs.version }}
             public.ecr.aws/${{ env.ECR_REPO }}:latest
-          build_args: BUILDMODE=copy
+          build-args: BUILDMODE=copy
           cache-from: type=registry
           cache-to: type=inline
           platforms : linux/amd64, linux/arm64


### PR DESCRIPTION
**Description:** Misspelled the `build-args` input as `build_args`. https://github.com/docker/build-push-action#inputs

https://github.com/aws-observability/aws-otel-collector/runs/5043900853?check_suite_focus=true
