### PR TITLE
Fix update-gh-pages-docs workflow

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -20,7 +20,6 @@ on:
       - 'docs/**'
       - 'README.md'
       - 'CONTRIBUTING.md'
-      - 'RELEASING.md'
 
 env:
   GH_PAGES_BRANCH: gh-pages

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Commit docs to gh-pages branch
         run: |
           git switch ${{ env.GH_PAGES_BRANCH }}
-          git restore --source=main -- README.md CONTRIBUTING.md RELEASING.md docs
-          git add README.md CONTRIBUTING.md RELEASING.md docs
+          git restore --source=main -- README.md CONTRIBUTING.md docs
+          git add README.md CONTRIBUTING.md docs
           git -c user.name="${{ env.COMMIT_USER }}" -c user.email="${{ env.COMMIT_EMAIL }}" commit -m "Update documentation"
           git push origin ${{ env.GH_PAGES_BRANCH }}:${{ env.GH_PAGES_BRANCH }}

--- a/README.md
+++ b/README.md
@@ -83,10 +83,6 @@ Use the following instructions to build your own AWS OTel Collector artifacts:
 
 See [docs/developers](docs/developers/README.md)
 
-### Release Process
-
-See [RELEASING.md](RELEASING.md) for release steps.
-
 ### Benchmark
 
 The latest performance report is [here](https://aws-observability.github.io/aws-otel-collector/benchmark/report), while the trends by testcase can be found [here](https://aws-observability.github.io/aws-otel-collector/benchmark/trend).


### PR DESCRIPTION
**Description:** Fix `update-gh-pages-docs` workflow after `RELEASING.md` was removed. Also removed leftover reference to `RELEASING.md` in `README.md`
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** n/a

**Testing:** No testing, clerical fixes. 

**Documentation:** Update readme
