### PR TITLE
Change AWS OTel references to ADOT in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,22 @@
 
 ### Overview
 
-AWS Distro for OpenTelemetry Collector (AWS OTel Collector) is an AWS supported version of the upstream OpenTelemetry Collector and is distributed by Amazon. It supports the selected components from the OpenTelemetry community. It is fully compatible with AWS computing platforms including EC2, ECS, and EKS. It enables users to send telemetry data to AWS CloudWatch Metrics, Traces, and Logs backends as well as the other supported backends.
+AWS Distro for OpenTelemetry Collector (ADOT Collector) is an AWS supported version of the upstream OpenTelemetry Collector and is distributed by Amazon. It supports the selected components from the OpenTelemetry community. It is fully compatible with AWS computing platforms including EC2, ECS, and EKS. It enables users to send telemetry data to AWS CloudWatch Metrics, Traces, and Logs backends as well as the other supported backends.
 
 See the [AWS Distro for OpenTelemetry documentation](https://aws-otel.github.io/docs/getting-started/collector) for more information.
 
 ### Getting Help
 
-Use the community resources below for getting help with AWS OTel Collector.
+Use the community resources below for getting help with the ADOT Collector.
 * Use [GitHub issues](https://github.com/aws-observability/aws-otel-collector/issues) to report bugs and request features.
 * Join our GitHub [Community](https://github.com/aws-observability/aws-otel-community) for AWS Distro for OpenTelemetry to ask your questions, file issues, or request enhancements.
 * Open a support ticket with [AWS Support](http://docs.aws.amazon.com/awssupport/latest/user/getting-started.html).
 * If you think you may have found a bug, open a [bug report](https://github.com/aws-observability/aws-otel-collector/issues/new?template=bug_report.md).
 * For contributing guidelines, refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 
-#### AWS OTel Collector Built-in Components
+#### ADOT Collector Built-in Components
 
-This table represents the supported components of AWS OTel Collector. The highlighted components below are developed by AWS in-house. The rest of the components in the table are the essential default components that AWS OTel Collector will support.
+This table represents the supported components of the ADOT Collector. The highlighted components below are developed by AWS in-house. The rest of the components in the table are the essential default components that the ADOT Collector will support.
 
 | Receiver                        | Processor                     | Exporter                           | Extensions             |
 |---------------------------------|-------------------------------|------------------------------------|------------------------|
@@ -39,7 +39,7 @@ This table represents the supported components of AWS OTel Collector. The highli
 |                                 |                               | logzioexporter                     |                        |
 
 
-#### AWS OTel Collector AWS Components
+#### ADOT Collector AWS Components
 
 * [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector/)
 * [Trace X-Ray Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awsxrayexporter)
@@ -52,18 +52,18 @@ This table represents the supported components of AWS OTel Collector. The highli
 
 #### Prerequisites
 
-To build AWS OTel Collector locally, you will need to have Golang installed. You can download and install Golang [here](https://golang.org/doc/install).
+To build the ADOT Collector locally, you will need to have Golang installed. You can download and install Golang [here](https://golang.org/doc/install).
 
-#### AWS OTel Collector Configuration
+#### ADOT Collector Configuration
 
 We built in a [default configuration](https://github.com/aws-observability/aws-otel-collector/blob/main/config.yaml) to our docker image and other format of release.
-So, you can run the AWS OTel Collector out of the box with the default settings.
-Also, AWS OTel Collector configuration uses the same configuration syntax/design from [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector)
-so you can customize or port your OpenTelemetry Collector configuration files when running AWS OTel Collector. Please refer to the `Try out AWS OTel Collector` section on configuring AWS OTel Collector.
+So, you can run the ADOT Collector out of the box with the default settings.
+Also, the ADOT Collector configuration uses the same configuration syntax/design from [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector)
+so you can customize or port your OpenTelemetry Collector configuration files when running ADOT Collector. Please refer to the `Try out ADOT Collector` section on configuring ADOT Collector.
 
-#### Try out AWS OTel Collector
+#### Try out the ADOT Collector
 
-AWS OTel Collector supports all AWS computing platforms and Docker/Kubernetes. Here are some examples on how to run AWS OTel Collector to send telemetry data:
+The ADOT Collector supports all AWS computing platforms and Docker/Kubernetes. Here are some examples on how to run the ADOT Collector to send telemetry data:
 
 * [Run it with Docker](docs/developers/docker-demo.md)
 * [Run it with ECS](docs/developers/ecs-demo.md)
@@ -74,7 +74,7 @@ AWS OTel Collector supports all AWS computing platforms and Docker/Kubernetes. H
 
 #### Build Your Own Artifacts
 
-Use the following instructions to build your own AWS OTel Collector artifacts:
+Use the following instructions to build your own ADOT Collector artifacts:
 
 * [Build Docker Image](docs/developers/build-docker.md)
 * [Build RPM/Deb/MSI](docs/developers/build-aoc.md)
@@ -97,4 +97,4 @@ This image is used for the integration tests. You can pull any of the images fro
 
 ### License
 
-AWS OTel Collector is licensed under an Apache 2.0 license.
+ADOT Collector is licensed under an Apache 2.0 license.

--- a/docs/developers/docker-demo.md
+++ b/docs/developers/docker-demo.md
@@ -2,7 +2,7 @@
 
 This example will introduce how to run AWSOTelCollector Beta in the Docker container. This example uses a AWS data emitter container image that will generate Open Telemetry Protocol (OTLP) format based metrics and traces data to AWS CloudWatch and X-Ray consoles.  
 
-Please follow the steps below to try AWS OTel Collector Beta.
+Please follow the steps below to try ADOT Collector Beta.
 
 #### Prerequisite
 

--- a/docs/developers/ecs-demo.md
+++ b/docs/developers/ecs-demo.md
@@ -1,6 +1,6 @@
 ### Using AWS-OTel-Collector on Amazon ECS
 
-This example will introduce how to use AWS-OTel-Collector to send application traces and metrics on AWS ECS. This instruction provided the data emitter image that will generate OTLP format of metrics and traces data to AWS CloudWatch and X-Ray consoles.  Please follow the steps below to try AWS OTel Collector Beta.
+This example will introduce how to use AWS-OTel-Collector to send application traces and metrics on AWS ECS. This instruction provided the data emitter image that will generate OTLP format of metrics and traces data to AWS CloudWatch and X-Ray consoles.  Please follow the steps below to try the ADOT Collector Beta.
 
 * Install AWS-OTel-Collector via Task Definition Template
 * Install AWS-OTel-Collector via CloudFormation Template
@@ -81,7 +81,7 @@ Replace the <PATH_TO_CloudFormation_TEMPLATE> with the path where your template 
 
 * Cluster_Name - ECS Cluster name setup in Prerequisite step
 * AWS_Region - Region the data will be sent
-* command - Assign value to the command variable to select the config file path; The AWS collector comes with two configs baked in for ECS customers:
+* command - Assign value to the command variable to select the config file path; The ADOT Collector comes with two configs baked in for ECS customers:
   * To consume application metrics, traces (using OTLP and Xray) and container resource utilization metrics (using awsecscontainermetrics receiver):  `--config=/etc/ecs/container-insights/otel-task-metrics-config.yaml`
   * To consume OTLP metrics/traces and X-Ray SDK traces (custom application metrics/traces):  `--config=/etc/ecs/ecs-default-config.yaml`
 ```

--- a/docs/developers/eks-demo.md
+++ b/docs/developers/eks-demo.md
@@ -1,6 +1,6 @@
 ### Using AWS-OTel-Collector on Amazon EKS
 
-This example will introduce how to use AWS-OTel-Collector to send application traces and metrics on AWS EKS. This instruction provided the data emitter image that will generate OTLP format of metrics and traces data to AWS CloudWatch and X-Ray consoles.  Please follow the steps below to try AWS OTel Collector Beta.
+This example will introduce how to use AWS-OTel-Collector to send application traces and metrics on AWS EKS. This instruction provided the data emitter image that will generate OTLP format of metrics and traces data to AWS CloudWatch and X-Ray consoles.  Please follow the steps below to try ADOT Collector Beta.
 
 ### Create EKS-AWSOTel IAM Policy 
 1. Open the IAM console at https://console.aws.amazon.com/iam/.

--- a/examples/docker/docker-compose.yaml
+++ b/examples/docker/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "2"
 services:
 
-  # AWS OTel Collector
+  # ADOT Collector
   aws-ot-collector:
     image: public.ecr.aws/aws-observability/aws-otel-collector:latest
     # very slow when you build it first time locally!!!

--- a/tools/release/header.md.template
+++ b/tools/release/header.md.template
@@ -1,4 +1,4 @@
-# 🎉 AWS OpenTelemetry Collector __VERSION__ Change Log 🎉
+# 🎉 ADOT Collector __VERSION__ Change Log 🎉
 
 The AWS Distro for OpenTelemetry (ADOT) Collector is a downstream distribution of the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector). Check out the [Getting Started](https://aws-otel.github.io/docs/introduction) documentation.
 


### PR DESCRIPTION
**Description:** This PR is the first stage in addressing #971. `AWS OTel` and `AWS collector` references were changed to `ADOT Collector`. There are still references to `aws-collector` in the codebase but most of them are referencing docker and ECR repositories. Future work will include addressing the need to update those repository names and update existing references to those repositories. Those references should remain as is for now until the subsequent changes to the repository names are made. 

**Link to tracking Issue:** #971 

**Testing:** None, documentation update

