### PR TITLE
CI Workflow for ADOT Operator releases

### DIFF
--- a/.github/workflows/CI-adot-operator.yml
+++ b/.github/workflows/CI-adot-operator.yml
@@ -15,22 +15,13 @@ name: C/I ADOT Operator
 on:
   push:
     branches:
-      - main
-      - release/v*
-      - dev
-      - test/*
+
     paths-ignore:
       - '.github/**'
       - '!.github/workflows/CI-adot-operator.yml'
       - '**.md'
 
-  # from collector and contrib repo
-  repository_dispatch:
-    types: [dependency-build, workflow-run]
-
 env:
-  IMAGE_NAME: aws-otel-collector
-  ECR_REPO: aws-otel-test/adot-collector-integration-test
   TF_VAR_aws_access_key_id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
   TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
 
@@ -47,125 +38,13 @@ jobs:
         with:
           repository: 'aws-observability/aws-otel-test-framework'
           path: testing-framework
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.17
-      - name: Install Go tools
-        run: cd /tmp && go get -u golang.org/x/tools/cmd/goimports
-      - name: Build aotutil
-        run: cd testing-framework/cmd/aotutil && make build
-
-  build:
-    needs:
-      - build-aotutil
-    runs-on: ubuntu-latest
-
-    steps:
-    # Set up building environment, patch the dev repo code on dispatch events.
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
-
-    - uses: actions/checkout@v2
-
-    - name: Checkout dev opentelemetry-collector-contrib
-      if: github.event_name == 'repository_dispatch' && github.event.action == 'dependency-build'
-      uses: actions/checkout@v2
-      with:
-        repository: ${{ github.repository_owner }}/opentelemetry-collector-contrib
-        ref: main
-        path: pkg/opentelemetry-collector-contrib
-
-    - name: Checkout dev opentelemetry-collector
-      if: github.event_name == 'repository_dispatch' && github.event.action == 'dependency-build'
-      uses: actions/checkout@v2
-      with:
-        repository: ${{ github.repository_owner }}/opentelemetry-collector
-        ref: main
-        path: pkg/opentelemetry-collector
-
-    - name: append replace statement to go.mod to build with dev repo
-      if: github.event_name == 'repository_dispatch' && github.event.action == 'dependency-build'
-      run: |
-        echo "replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter => ./pkg/opentelemetry-collector-contrib/exporter/awsxrayexporter" >> go.mod
-        echo "replace go.opentelemetry.io/collector => ./pkg/opentelemetry-collector" >> go.mod
-        cat go.mod
-        ls pkg
-
-    #Cache go build and dependencies before making unit testing and build
-    #Samples codes for different OS: https://github.com/actions/cache/blob/main/examples.md#go---modules
-    #Since we are using Linux, the go packages are in /go/pkg/mod and build are in /.cache/go-build
-    #Also speed up unit testing since go test uses the go build cache and also speed up the go build.
-    - name: Cache binaries
-      id: cached_binaries
-      uses: actions/cache@v2
-      with:
-        key: "cached_binaries_${{ github.run_id }}"
-        path: build
-
-    # Unit Test and attach test coverage badge
-    - name: Unit Test
-      if: steps.cached_binaries.outputs.cache-hit != 'true'
-      run: make test
-
-    - name: Upload Coverage report to CodeCov
-      if: steps.cached_binaries.outputs.cache-hit != 'true'
-      uses: codecov/codecov-action@v2
-      with:
-        file: ./coverage.txt
-
-    # Build and archive binaries into cache.
-    - name: Build Binaries
-      if: steps.cached_binaries.outputs.cache-hit != 'true'
-      run: make build
-
-    # upload the binaries to artifact as well because cache@v2 hasn't support windows
-    - name: Upload
-      uses: actions/upload-artifact@v2
-      with:
-        name: binary_artifacts
-        path: build
-
-  e2etest-preparation:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.versioning.outputs.version }}
-    steps:
-      # Build a version with github short sha for the following reasons:
-      # - Distingush each build for Integration test
-      # - Increase more visibility to the customer and also for the developer since we publish the image for integration test.
-      # - Avoid having similar layers image and only have a final result image.
-      - name: Versioning for testing
-        id: versioning
-        run: |
-          version="$(cat VERSION)-$(git rev-parse --short HEAD)"
-          echo "::set-output name=version::$version"
 
   e2etest-release:
     runs-on: ubuntu-latest
-    needs: e2etest-preparation
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache if success
-        id: e2etest-release
-        uses: actions/cache@v2
-        with:
-          path: |
-            VERSION
-          key: e2etest-release-${{ github.run_id }}
-
-      - name: Restore cached binaries
-        if: steps.e2etest-release.outputs.cache-hit != 'true'
-        uses: actions/cache@v2
-        with:
-          key: "cached_binaries_${{ github.run_id }}"
-          path: build
-
       - name: Login to Public Integration Test ECR
-        if: steps.e2etest-release.outputs.cache-hit != 'true'
         uses: docker/login-action@v1
         with:
           registry: public.ecr.aws
@@ -180,39 +59,6 @@ jobs:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
           aws-region: us-west-2
-
-      - name: Set up Docker Buildx
-        if: steps.e2etest-release.outputs.cache-hit != 'true'
-        uses: docker/setup-buildx-action@v1
-
-      - name: Set up QEMU
-        if: steps.e2etest-release.outputs.cache-hit != 'true'
-        uses: docker/setup-qemu-action@v1
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: public.ecr.aws/${{ env.ECR_REPO }}
-
-      #Build the adot collector image for two primary reasons:
-      #-Using the adot collector image to do the integration test
-      #-Export it for delivery version image in CD
-      #Documentation: https://github.com/docker/build-push-action
-      - name: Build ADOT collector image
-        uses: docker/build-push-action@v2
-        if: steps.e2etest-release.outputs.cache-hit != 'true'
-        with:
-          file: cmd/awscollector/Dockerfile
-          context: .
-          push: true
-          tags: |
-            public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.e2etest-preparation.outputs.version }}
-          build-args: BUILDMODE=copy
-          cache-from: type=registry
-          cache-to: type=inline
-          platforms : linux/amd64, linux/arm64
-          labels: ${{ steps.meta.outputs.labels }}
 
   get-testing-suites:
     runs-on: ubuntu-latest
@@ -236,7 +82,7 @@ jobs:
 
   e2etest-eks-adot-operator:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release ]
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -245,16 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache if success
-        id: e2etest-eks-adot-operator
-        uses: actions/cache@v2
-        with:
-          path: |
-            VERSION
-          key: e2etest-eks-adot-operator-${{ github.run_id }}-${{ matrix.testcase }}
-
       - name: Configure AWS Credentials
-        if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
@@ -262,32 +99,28 @@ jobs:
           aws-region: us-west-2
 
       - name: Set up JDK 11
-        if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
           java-version: '11'
 
       - name: Set up terraform
-        if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
         uses: hashicorp/setup-terraform@v1
 
       - name: Check out testing framework
-        if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
           repository: 'aws-observability/aws-otel-collector-test-framework'
           path: testing-framework
 
+        #The ADOT collector version that needs to tested against the operator need to be specified in -var="aoc_version=<ADOT-collector-version>", for eg -var="aoc_version=v0.16.0" will test for ADOT collector image on v0.16.0
       - name: Run ADOT Operator testing suite on eks
-        if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
         run: |
           opts=""
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
-          cd testing-framework/terraform/eks && terraform init && terraform apply -auto-approve $opts -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}"
+          cd testing-framework/terraform/eks && terraform init && terraform apply -auto-approve $opts -var="aoc_version=latest" -var="aoc_image_repo=public.ecr.aws/aws-observability/aws-otel-collector:" -var="testcase=../testcases/${{ matrix.testcase }}"
 
       - name: Destroy resources
-        if: ${{ always() && steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true' }}
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3

--- a/.github/workflows/CI-adot-operator.yml
+++ b/.github/workflows/CI-adot-operator.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-name: C/I
+name: C/I ADOT Operator
 on:
   push:
     branches:
@@ -30,20 +30,10 @@ on:
 
 env:
   IMAGE_NAME: aws-otel-collector
-  PACKAGING_ROOT: build/packages
   ECR_REPO: aws-otel-test/adot-collector-integration-test
   TF_VAR_aws_access_key_id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
   TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
-  TF_VAR_aoc_vpc_name: aoc-vpc-large
-  TF_VAR_aoc_vpc_security_group: aoc-vpc-security-group-large
-  # TF_VAR_patch: 'true'
-  PKG_SIGN_PRIVATE_KEY_NAME: aoc-linux-pkg-signing-gpg-key
-  WIN_UNSIGNED_PKG_BUCKET: aoc-aws-signer-unsigned-artifact-src
-  WIN_SIGNED_PKG_BUCKET: aoc-aws-signer-signed-artifact-dest
-  WIN_UNSIGNED_PKG_FOLDER: OTelCollectorAuthenticode/AuthenticodeSigner-SHA256-RSA
-  WIN_SIGNED_PKG_FOLDER: OTelCollectorAuthenticode/AuthenticodeSigner-SHA256-RSA
-  SSM_PACKAGE_NAME: "testAWSDistroOTel-Collector"
-  US_EAST_2_AMP_ENDPOINT: "https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-1de68e95-0680-42bb-8e55-67e7fd5d0861"
+
 concurrency:
   group: ci-${{ github.ref_name }}
   cancel-in-progress: true
@@ -65,11 +55,6 @@ jobs:
         run: cd /tmp && go get -u golang.org/x/tools/cmd/goimports
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
-      - name: Cache aotutil
-        uses: actions/cache@v2
-        with:
-          key: "aotutil_${{ github.run_id }}"
-          path: testing-framework/cmd/aotutil/aotutil
 
   build:
     needs:
@@ -113,17 +98,6 @@ jobs:
     #Samples codes for different OS: https://github.com/actions/cache/blob/main/examples.md#go---modules
     #Since we are using Linux, the go packages are in /go/pkg/mod and build are in /.cache/go-build
     #Also speed up unit testing since go test uses the go build cache and also speed up the go build.
-    - name: Cache go
-      id: cached_go
-      uses: actions/cache@v2
-      env:
-        cache-name: cached_go_modules
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: v1-go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-
     - name: Cache binaries
       id: cached_binaries
       uses: actions/cache@v2
@@ -154,296 +128,24 @@ jobs:
         name: binary_artifacts
         path: build
 
-  packaging-msi:
-    needs: build
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Download built artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: binary_artifacts
-          path: build
-
-      - name: Display structure of downloaded files
-        run: ls -R
-
-      - name: Create msi file using candle and light
-        run: .\tools\packaging\windows\create_msi.ps1
-
-      - name: Install AWS Cli v2
-        run: |
-          Invoke-WebRequest -Uri "https://awscli.amazonaws.com/AWSCLIV2.msi" -OutFile "AWSCLIV2.msi"
-          msiexec.exe /i AWSCLIV2.msi /passive
-          [System.Environment]::SetEnvironmentVariable('Path',$Env:Path + ";C:\\Program Files\\Amazon\\AWSCLIV2",'User')
-
-      - name: Sign windows artifacts
-        run: |
-          $pkgfile = "build\packages\windows\amd64\aws-otel-collector.msi"
-          $hashobj = Get-FileHash -Algorithm sha256 $pkgfile
-          $hash = $hashobj.Hash
-          $create_date = Get-Date -format s
-          aws s3api put-object "--body" $pkgfile "--bucket" ${{ env.WIN_UNSIGNED_PKG_BUCKET }} "--key" ${{ env.WIN_UNSIGNED_PKG_FOLDER }}/aws-otel-collector-$hash.msi
-          $objkey = ""
-          for ($num = 1 ; $num -le 60 ; $num++) { # 60 * 10 = 600s = 10min timeout
-             Start-Sleep -s 10
-             Write-Output "Poll number $num"
-             $objkey = aws s3api list-objects "--bucket" ${{ env.WIN_SIGNED_PKG_BUCKET }} "--prefix" ${{ env.WIN_SIGNED_PKG_FOLDER }}/aws-otel-collector-$hash.msi "--output" text "--query" "Contents[?LastModified>'$create_date'].Key|[0]"
-             if ($objkey -ne "None") {
-               Write-Output "Found: $objkey"
-               break
-             } else {
-               Write-Output "$objkey returned, obj not available yet, try again later"
-             }
-          }
-          if ($objkey -eq "None") {
-            Throw "Could not find the signed artifact"
-          }
-          aws s3api get-object "--bucket" ${{ env.WIN_SIGNED_PKG_BUCKET }} "--key" $objkey $pkgfile
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.SIGN_PKG_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.SIGN_PKG_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-west-2
-
-      - name: Verify package signature
-        run: |
-          $pkgfile = "build\packages\windows\amd64\aws-otel-collector.msi"
-          $sig = Get-AuthenticodeSignature $pkgfile
-          $status = $sig.Status
-          if ($status -ne "Valid") {
-            Throw "Invalid signature found: $status"
-          }
-          Write-Output "Valid signature found from the package"
-
-      - name: Upload the msi
-        uses: actions/upload-artifact@v2
-        with:
-          name: msi_artifacts
-          path: "${{ env.PACKAGING_ROOT }}"
-
-  packaging-rpm:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      # Build and archive rpms into cache.
-      - uses: actions/checkout@v2
-
-      - name: Cache rpms
-        id: cached_rpms
-        uses: actions/cache@v2
-        with:
-          key: "cached_rpms_${{ github.run_id }}"
-          path: "${{ env.PACKAGING_ROOT }}"
-
-      - name: restore cached binaries
-        if: steps.cached_rpms.outputs.cache-hit != 'true'
-        uses: actions/cache@v2
-        with:
-          key: "cached_binaries_${{ github.run_id }}"
-          path: build
-
-      - name: Display structure of downloaded files
-        run: ls -R
-
-      - name: Build RPM
-        if: steps.cached_rpms.outputs.cache-hit != 'true'
-        run: |
-          ARCH=x86_64 SOURCE_ARCH=amd64 DEST=$PACKAGING_ROOT/linux/amd64 tools/packaging/linux/create_rpm.sh
-          ARCH=aarch64 SOURCE_ARCH=arm64 DEST=$PACKAGING_ROOT/linux/arm64 tools/packaging/linux/create_rpm.sh
-
-      - name: Download Package Signing GPG key
-        if: steps.cached_rpms.outputs.cache-hit != 'true'
-        run: |
-          aws secretsmanager get-secret-value --region us-west-2 --secret-id "$PKG_SIGN_PRIVATE_KEY_NAME" | jq -r ".SecretString" > pkg_sign_private.key
-          md5sum pkg_sign_private.key
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.SIGN_PKG_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.SIGN_PKG_AWS_SECRET_ACCESS_KEY }}
-
-      - name: Import Package Signing GPG Key
-        if: steps.cached_rpms.outputs.cache-hit != 'true'
-        run: |
-          gpg --import pkg_sign_private.key
-          gpg --list-keys
-          gpg --armor --export -a "aws-otel-collector@amazon.com" > pkg_sign_public.key
-          rpm --import pkg_sign_public.key
-          echo "%_gpg_name aws-otel-collector@amazon.com" > ~/.rpmmacros
-          md5sum pkg_sign_public.key
-          shred -fuvz pkg_sign_private.key
-
-      - name: Sign RPM Pakcage
-        if: steps.cached_rpms.outputs.cache-hit != 'true'
-        run: |
-          rpmsign --addsign $PACKAGING_ROOT/linux/*/*.rpm
-
-      - name: Remove Package Signing GPG Key from local GPG Key Ring
-        if: steps.cached_rpms.outputs.cache-hit != 'true'
-        run: |
-          gpg --fingerprint --with-colons aws-otel-collector@amazon.com grep "^fpr" | sed -n 's/^fpr:::::::::\([[:alnum:]]\+\):/\1/p' | xargs gpg --batch --yes --delete-secret-keys
-          gpg --list-secret-keys
-
-  packaging-deb:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      # Build and archive debs into cache.
-      - uses: actions/checkout@v2
-
-      - name: Cache Debs
-        id: cached_debs
-        uses: actions/cache@v2
-        with:
-          key: "cached_debs_${{ github.run_id }}"
-          path: ${{ env.PACKAGING_ROOT }}
-
-      - name: restore cached binaries
-        if: steps.cached_debs.outputs.cache-hit != 'true'
-        uses: actions/cache@v2
-        with:
-          key: "cached_binaries_${{ github.run_id }}"
-          path: build
-
-      - name: Build Debs
-        if: steps.cached_debs.outputs.cache-hit != 'true'
-        run: |
-          ARCH=amd64 DEST=$PACKAGING_ROOT/debian/amd64 tools/packaging/debian/create_deb.sh
-          ARCH=arm64 DEST=$PACKAGING_ROOT/debian/arm64 tools/packaging/debian/create_deb.sh
-
-      - name: Download Package Signing GPG key
-        if: steps.cached_debs.outputs.cache-hit != 'true'
-        run: |
-          aws secretsmanager get-secret-value --region us-west-2 --secret-id "$PKG_SIGN_PRIVATE_KEY_NAME" | jq -r ".SecretString" > pkg_sign_private.key
-          md5sum pkg_sign_private.key
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.SIGN_PKG_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.SIGN_PKG_AWS_SECRET_ACCESS_KEY }}
-
-      - name: Import Package Signing GPG Key
-        if: steps.cached_debs.outputs.cache-hit != 'true'
-        run: |
-          gpg --import pkg_sign_private.key
-          gpg --list-secret-keys
-          shred -fuvz pkg_sign_private.key
-
-      - name: Sign DEB Pakcage
-        if: steps.cached_debs.outputs.cache-hit != 'true'
-        run: |
-          sudo apt install -y dpkg-sig
-          dpkg-sig --sign origin -k "aws-otel-collector@amazon.com" $PACKAGING_ROOT/debian/*/*.deb
-
-      - name: Remove Package Signing GPG Key from local GPG Key Ring
-        if: steps.cached_debs.outputs.cache-hit != 'true'
-        run: |
-          gpg --fingerprint --with-colons aws-otel-collector@amazon.com grep "^fpr" | sed -n 's/^fpr:::::::::\([[:alnum:]]\+\):/\1/p' | xargs gpg --batch --yes --delete-secret-keys
-          gpg --list-secret-keys
-
-  packaging-ssm:
-    runs-on: ubuntu-latest
-    needs: [packaging-rpm, packaging-deb, packaging-msi]
-    steps:
-      # Build and archive SSM package into cache.
-      - uses: actions/checkout@v2
-
-      - name: Cache SSM files
-        id: cached_ssm
-        uses: actions/cache@v2
-        with:
-          key: "cached_ssm_${{ github.run_id }}"
-          path: "${{ env.PACKAGING_ROOT }}/ssm"
-
-      - name: Restore cached rpms
-        if: steps.cached_ssm.outputs.cache-hit != 'true'
-        uses: actions/cache@v2
-        with:
-          key: "cached_rpms_${{ github.run_id }}"
-          path: "${{ env.PACKAGING_ROOT }}"
-
-      - name: Restore cached debs
-        if: steps.cached_ssm.outputs.cache-hit != 'true'
-        uses: actions/cache@v2
-        with:
-          key: "cached_debs_${{ github.run_id }}"
-          path: "${{ env.PACKAGING_ROOT }}"
-
-      - name: Download built artifacts
-        if: steps.cached_ssm.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v2
-        with:
-          name: msi_artifacts
-          path: "${{ env.PACKAGING_ROOT }}"
-
-      - run: ls -R
-
-        # Build the ssm package and manifest by using a version with github short sha as same as e2etest-preparation.
-      - name: Create zip file and manifest for SSM package
-        if: steps.cached_ssm.outputs.cache-hit != 'true'
-        run: |
-          ssm_pkg_version="$(cat VERSION)-$(git rev-parse --short HEAD)"
-          rm -rf $PACKAGING_ROOT/ssm
-          python3 tools/ssm/ssm_manifest.py ${ssm_pkg_version}
-
   e2etest-preparation:
     runs-on: ubuntu-latest
-    needs: [packaging-rpm, packaging-deb, packaging-msi, packaging-ssm]
     outputs:
       version: ${{ steps.versioning.outputs.version }}
     steps:
-      # Archive all the packages into one, and build a unique version number for e2etesting
-      - uses: actions/checkout@v2
-
-      - name: Cache the packages
-        id: cached_packages
-        uses: actions/cache@v2
-        with:
-          key: "cached_packages_${{ github.run_id }}"
-          path: "${{ env.PACKAGING_ROOT }}"
-
-      - name: Restore cached rpms
-        if: steps.cached_packages.outputs.cache-hit != 'true'
-        uses: actions/cache@v2
-        with:
-          key: "cached_rpms_${{ github.run_id }}"
-          path: "${{ env.PACKAGING_ROOT }}"
-
-      - name: Restore cached debs
-        if: steps.cached_packages.outputs.cache-hit != 'true'
-        uses: actions/cache@v2
-        with:
-          key: "cached_debs_${{ github.run_id }}"
-          path: "${{ env.PACKAGING_ROOT }}"
-
-      - name: Download built artifacts
-        if: steps.cached_packages.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v2
-        with:
-          name: msi_artifacts
-          path: "${{ env.PACKAGING_ROOT }}"
-
-      - name: Restore cached ssm
-        if: steps.cached_packages.outputs.cache-hit != 'true'
-        uses: actions/cache@v2
-        with:
-          key: "cached_ssm_${{ github.run_id }}"
-          path: "${{ env.PACKAGING_ROOT }}/ssm"
-
-      - run: ls -R
-
       # Build a version with github short sha for the following reasons:
       # - Distingush each build for Integration test
-      # - Increase more visibility to the customer and also for the dev since we publish the image for integration test.
+      # - Increase more visibility to the customer and also for the developer since we publish the image for integration test.
       # - Avoid having similar layers image and only have a final result image.
       - name: Versioning for testing
         id: versioning
         run: |
           version="$(cat VERSION)-$(git rev-parse --short HEAD)"
-          echo $version > $PACKAGING_ROOT/VERSION
-          cat $PACKAGING_ROOT/VERSION
           echo "::set-output name=version::$version"
 
   e2etest-release:
     runs-on: ubuntu-latest
-    needs: [e2etest-preparation]
+    needs: e2etest-preparation
     steps:
       - uses: actions/checkout@v2
 
@@ -454,12 +156,6 @@ jobs:
           path: |
             VERSION
           key: e2etest-release-${{ github.run_id }}
-
-      - name: restore cached rpms
-        uses: actions/cache@v2
-        with:
-          key: "cached_packages_${{ github.run_id }}"
-          path: "${{ env.PACKAGING_ROOT }}"
 
       - name: Restore cached binaries
         if: steps.e2etest-release.outputs.cache-hit != 'true'
@@ -484,20 +180,6 @@ jobs:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
           aws-region: us-west-2
-
-      - name: Create SSM package
-        run: |
-          ssm_pkg_version=`cat build/packages/VERSION`
-          (aws ssm describe-document --name ${SSM_PACKAGE_NAME} --version-name ${ssm_pkg_version} >/dev/null 2>&1) || {
-            pip3 install boto3
-            python3 tools/ssm/ssm_manifest.py ${ssm_pkg_version}
-            aws s3 cp build/packages/ssm s3://aws-otel-collector-test/ssm/${ssm_pkg_version} --recursive
-            python3 tools/ssm/ssm_create.py --no-default ${SSM_PACKAGE_NAME} ${ssm_pkg_version} aws-otel-collector-test/ssm/${ssm_pkg_version} us-west-2
-          }
-
-      - name: Upload to S3 in the testing stack
-        if: steps.e2etest-release.outputs.cache-hit != 'true'
-        run: s3_bucket_name=aws-otel-collector-test upload_to_latest=0 bash tools/release/image-binary-release/s3-release.sh
 
       - name: Set up Docker Buildx
         if: steps.e2etest-release.outputs.cache-hit != 'true'
@@ -526,7 +208,6 @@ jobs:
           push: true
           tags: |
             public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.e2etest-preparation.outputs.version }}
-            public.ecr.aws/${{ env.ECR_REPO }}:latest
           build-args: BUILDMODE=copy
           cache-from: type=registry
           cache-to: type=inline
@@ -544,7 +225,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2.3.2
 
-      - name: Get all the testing suites
+      - name: testing suite for ADOT operator
         id: set-matrix
         run: |
           eks_adot_operator_matrix=$(python e2etest/get-testcases.py eks_adot_operator_matrix)
@@ -616,69 +297,4 @@ jobs:
             opts=""
             if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
             cd testing-framework/terraform/eks && terraform destroy -auto-approve $opts
-
-
-  release-candidate:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && !contains(github.ref_name,'test/') # only create the artifact when there's a push, not for dispatch.
-    needs: [e2etest-eks-adot-operator]
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
-          aws-region: us-west-2
-
-      - name: restore cached packages
-        uses: actions/cache@v2
-        with:
-          path: "${{ env.PACKAGING_ROOT }}"
-          key: "cached_packages_${{ github.run_id }}"
-
-      - name: prepare production version
-        run: |
-          TESTING_VERSION=`cat $PACKAGING_ROOT/VERSION`
-          VERSION=`echo $TESTING_VERSION | awk -F "-" '{print $1}'`
-          echo $VERSION > $PACKAGING_ROOT/VERSION
-          echo $GITHUB_SHA > $PACKAGING_ROOT/GITHUB_SHA
-          echo $TESTING_VERSION > $PACKAGING_ROOT/TESTING_VERSION
-
-      - name: upload packages as release candidate on s3
-        run: |
-          tar czvf $GITHUB_SHA.tar.gz build
-          aws s3 cp $GITHUB_SHA.tar.gz s3://aws-otel-collector-release-candidate/$GITHUB_SHA.tar.gz
-
-      - name: Trigger performance test
-        uses: peter-evans/repository-dispatch@v1.1.3
-        with:
-          token: "${{ secrets.REPO_WRITE_ACCESS_TOKEN }}"
-          event-type: trigger-perf
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
-
-  clean-ssm-package:
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: [e2etest-eks-adot-operator]
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
-          aws-region: us-west-2
-
-      - name: restore cached packages
-        id: cache_packages
-        uses: actions/cache@v2
-        with:
-          path: "${{ env.PACKAGING_ROOT }}"
-          key: "cached_packages_${{ github.run_id }}"
-
-      - name: clean up SSM test package
-        if: steps.cache_packages.outputs.cache-hit == 'true'
-        run: |
-          ssm_pkg_version=`cat build/packages/VERSION`
-          aws ssm describe-document --name ${SSM_PACKAGE_NAME} --version-name ${ssm_pkg_version} >/dev/null 2>&1 && \
-            aws ssm delete-document --name ${SSM_PACKAGE_NAME} --version-name ${ssm_pkg_version}
 

--- a/.github/workflows/CI-adot-operator.yml
+++ b/.github/workflows/CI-adot-operator.yml
@@ -1,0 +1,684 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+name: C/I
+on:
+  push:
+    branches:
+      - main
+      - release/v*
+      - dev
+      - test/*
+    paths-ignore:
+      - '.github/**'
+      - '!.github/workflows/CI-adot-operator.yml'
+      - '**.md'
+
+  # from collector and contrib repo
+  repository_dispatch:
+    types: [dependency-build, workflow-run]
+
+env:
+  IMAGE_NAME: aws-otel-collector
+  PACKAGING_ROOT: build/packages
+  ECR_REPO: aws-otel-test/adot-collector-integration-test
+  TF_VAR_aws_access_key_id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+  TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+  TF_VAR_aoc_vpc_name: aoc-vpc-large
+  TF_VAR_aoc_vpc_security_group: aoc-vpc-security-group-large
+  # TF_VAR_patch: 'true'
+  PKG_SIGN_PRIVATE_KEY_NAME: aoc-linux-pkg-signing-gpg-key
+  WIN_UNSIGNED_PKG_BUCKET: aoc-aws-signer-unsigned-artifact-src
+  WIN_SIGNED_PKG_BUCKET: aoc-aws-signer-signed-artifact-dest
+  WIN_UNSIGNED_PKG_FOLDER: OTelCollectorAuthenticode/AuthenticodeSigner-SHA256-RSA
+  WIN_SIGNED_PKG_FOLDER: OTelCollectorAuthenticode/AuthenticodeSigner-SHA256-RSA
+  SSM_PACKAGE_NAME: "testAWSDistroOTel-Collector"
+  US_EAST_2_AMP_ENDPOINT: "https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-1de68e95-0680-42bb-8e55-67e7fd5d0861"
+concurrency:
+  group: ci-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build-aotutil:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out testing framework
+        uses: actions/checkout@v2
+        with:
+          repository: 'aws-observability/aws-otel-test-framework'
+          path: testing-framework
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Install Go tools
+        run: cd /tmp && go get -u golang.org/x/tools/cmd/goimports
+      - name: Build aotutil
+        run: cd testing-framework/cmd/aotutil && make build
+      - name: Cache aotutil
+        uses: actions/cache@v2
+        with:
+          key: "aotutil_${{ github.run_id }}"
+          path: testing-framework/cmd/aotutil/aotutil
+
+  build:
+    needs:
+      - build-aotutil
+    runs-on: ubuntu-latest
+
+    steps:
+    # Set up building environment, patch the dev repo code on dispatch events.
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - uses: actions/checkout@v2
+
+    - name: Checkout dev opentelemetry-collector-contrib
+      if: github.event_name == 'repository_dispatch' && github.event.action == 'dependency-build'
+      uses: actions/checkout@v2
+      with:
+        repository: ${{ github.repository_owner }}/opentelemetry-collector-contrib
+        ref: main
+        path: pkg/opentelemetry-collector-contrib
+
+    - name: Checkout dev opentelemetry-collector
+      if: github.event_name == 'repository_dispatch' && github.event.action == 'dependency-build'
+      uses: actions/checkout@v2
+      with:
+        repository: ${{ github.repository_owner }}/opentelemetry-collector
+        ref: main
+        path: pkg/opentelemetry-collector
+
+    - name: append replace statement to go.mod to build with dev repo
+      if: github.event_name == 'repository_dispatch' && github.event.action == 'dependency-build'
+      run: |
+        echo "replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter => ./pkg/opentelemetry-collector-contrib/exporter/awsxrayexporter" >> go.mod
+        echo "replace go.opentelemetry.io/collector => ./pkg/opentelemetry-collector" >> go.mod
+        cat go.mod
+        ls pkg
+
+    #Cache go build and dependencies before making unit testing and build
+    #Samples codes for different OS: https://github.com/actions/cache/blob/main/examples.md#go---modules
+    #Since we are using Linux, the go packages are in /go/pkg/mod and build are in /.cache/go-build
+    #Also speed up unit testing since go test uses the go build cache and also speed up the go build.
+    - name: Cache go
+      id: cached_go
+      uses: actions/cache@v2
+      env:
+        cache-name: cached_go_modules
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: v1-go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+
+    - name: Cache binaries
+      id: cached_binaries
+      uses: actions/cache@v2
+      with:
+        key: "cached_binaries_${{ github.run_id }}"
+        path: build
+
+    # Unit Test and attach test coverage badge
+    - name: Unit Test
+      if: steps.cached_binaries.outputs.cache-hit != 'true'
+      run: make test
+
+    - name: Upload Coverage report to CodeCov
+      if: steps.cached_binaries.outputs.cache-hit != 'true'
+      uses: codecov/codecov-action@v2
+      with:
+        file: ./coverage.txt
+
+    # Build and archive binaries into cache.
+    - name: Build Binaries
+      if: steps.cached_binaries.outputs.cache-hit != 'true'
+      run: make build
+
+    # upload the binaries to artifact as well because cache@v2 hasn't support windows
+    - name: Upload
+      uses: actions/upload-artifact@v2
+      with:
+        name: binary_artifacts
+        path: build
+
+  packaging-msi:
+    needs: build
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download built artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: binary_artifacts
+          path: build
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
+      - name: Create msi file using candle and light
+        run: .\tools\packaging\windows\create_msi.ps1
+
+      - name: Install AWS Cli v2
+        run: |
+          Invoke-WebRequest -Uri "https://awscli.amazonaws.com/AWSCLIV2.msi" -OutFile "AWSCLIV2.msi"
+          msiexec.exe /i AWSCLIV2.msi /passive
+          [System.Environment]::SetEnvironmentVariable('Path',$Env:Path + ";C:\\Program Files\\Amazon\\AWSCLIV2",'User')
+
+      - name: Sign windows artifacts
+        run: |
+          $pkgfile = "build\packages\windows\amd64\aws-otel-collector.msi"
+          $hashobj = Get-FileHash -Algorithm sha256 $pkgfile
+          $hash = $hashobj.Hash
+          $create_date = Get-Date -format s
+          aws s3api put-object "--body" $pkgfile "--bucket" ${{ env.WIN_UNSIGNED_PKG_BUCKET }} "--key" ${{ env.WIN_UNSIGNED_PKG_FOLDER }}/aws-otel-collector-$hash.msi
+          $objkey = ""
+          for ($num = 1 ; $num -le 60 ; $num++) { # 60 * 10 = 600s = 10min timeout
+             Start-Sleep -s 10
+             Write-Output "Poll number $num"
+             $objkey = aws s3api list-objects "--bucket" ${{ env.WIN_SIGNED_PKG_BUCKET }} "--prefix" ${{ env.WIN_SIGNED_PKG_FOLDER }}/aws-otel-collector-$hash.msi "--output" text "--query" "Contents[?LastModified>'$create_date'].Key|[0]"
+             if ($objkey -ne "None") {
+               Write-Output "Found: $objkey"
+               break
+             } else {
+               Write-Output "$objkey returned, obj not available yet, try again later"
+             }
+          }
+          if ($objkey -eq "None") {
+            Throw "Could not find the signed artifact"
+          }
+          aws s3api get-object "--bucket" ${{ env.WIN_SIGNED_PKG_BUCKET }} "--key" $objkey $pkgfile
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.SIGN_PKG_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SIGN_PKG_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-west-2
+
+      - name: Verify package signature
+        run: |
+          $pkgfile = "build\packages\windows\amd64\aws-otel-collector.msi"
+          $sig = Get-AuthenticodeSignature $pkgfile
+          $status = $sig.Status
+          if ($status -ne "Valid") {
+            Throw "Invalid signature found: $status"
+          }
+          Write-Output "Valid signature found from the package"
+
+      - name: Upload the msi
+        uses: actions/upload-artifact@v2
+        with:
+          name: msi_artifacts
+          path: "${{ env.PACKAGING_ROOT }}"
+
+  packaging-rpm:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      # Build and archive rpms into cache.
+      - uses: actions/checkout@v2
+
+      - name: Cache rpms
+        id: cached_rpms
+        uses: actions/cache@v2
+        with:
+          key: "cached_rpms_${{ github.run_id }}"
+          path: "${{ env.PACKAGING_ROOT }}"
+
+      - name: restore cached binaries
+        if: steps.cached_rpms.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "cached_binaries_${{ github.run_id }}"
+          path: build
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
+      - name: Build RPM
+        if: steps.cached_rpms.outputs.cache-hit != 'true'
+        run: |
+          ARCH=x86_64 SOURCE_ARCH=amd64 DEST=$PACKAGING_ROOT/linux/amd64 tools/packaging/linux/create_rpm.sh
+          ARCH=aarch64 SOURCE_ARCH=arm64 DEST=$PACKAGING_ROOT/linux/arm64 tools/packaging/linux/create_rpm.sh
+
+      - name: Download Package Signing GPG key
+        if: steps.cached_rpms.outputs.cache-hit != 'true'
+        run: |
+          aws secretsmanager get-secret-value --region us-west-2 --secret-id "$PKG_SIGN_PRIVATE_KEY_NAME" | jq -r ".SecretString" > pkg_sign_private.key
+          md5sum pkg_sign_private.key
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.SIGN_PKG_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SIGN_PKG_AWS_SECRET_ACCESS_KEY }}
+
+      - name: Import Package Signing GPG Key
+        if: steps.cached_rpms.outputs.cache-hit != 'true'
+        run: |
+          gpg --import pkg_sign_private.key
+          gpg --list-keys
+          gpg --armor --export -a "aws-otel-collector@amazon.com" > pkg_sign_public.key
+          rpm --import pkg_sign_public.key
+          echo "%_gpg_name aws-otel-collector@amazon.com" > ~/.rpmmacros
+          md5sum pkg_sign_public.key
+          shred -fuvz pkg_sign_private.key
+
+      - name: Sign RPM Pakcage
+        if: steps.cached_rpms.outputs.cache-hit != 'true'
+        run: |
+          rpmsign --addsign $PACKAGING_ROOT/linux/*/*.rpm
+
+      - name: Remove Package Signing GPG Key from local GPG Key Ring
+        if: steps.cached_rpms.outputs.cache-hit != 'true'
+        run: |
+          gpg --fingerprint --with-colons aws-otel-collector@amazon.com grep "^fpr" | sed -n 's/^fpr:::::::::\([[:alnum:]]\+\):/\1/p' | xargs gpg --batch --yes --delete-secret-keys
+          gpg --list-secret-keys
+
+  packaging-deb:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      # Build and archive debs into cache.
+      - uses: actions/checkout@v2
+
+      - name: Cache Debs
+        id: cached_debs
+        uses: actions/cache@v2
+        with:
+          key: "cached_debs_${{ github.run_id }}"
+          path: ${{ env.PACKAGING_ROOT }}
+
+      - name: restore cached binaries
+        if: steps.cached_debs.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "cached_binaries_${{ github.run_id }}"
+          path: build
+
+      - name: Build Debs
+        if: steps.cached_debs.outputs.cache-hit != 'true'
+        run: |
+          ARCH=amd64 DEST=$PACKAGING_ROOT/debian/amd64 tools/packaging/debian/create_deb.sh
+          ARCH=arm64 DEST=$PACKAGING_ROOT/debian/arm64 tools/packaging/debian/create_deb.sh
+
+      - name: Download Package Signing GPG key
+        if: steps.cached_debs.outputs.cache-hit != 'true'
+        run: |
+          aws secretsmanager get-secret-value --region us-west-2 --secret-id "$PKG_SIGN_PRIVATE_KEY_NAME" | jq -r ".SecretString" > pkg_sign_private.key
+          md5sum pkg_sign_private.key
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.SIGN_PKG_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SIGN_PKG_AWS_SECRET_ACCESS_KEY }}
+
+      - name: Import Package Signing GPG Key
+        if: steps.cached_debs.outputs.cache-hit != 'true'
+        run: |
+          gpg --import pkg_sign_private.key
+          gpg --list-secret-keys
+          shred -fuvz pkg_sign_private.key
+
+      - name: Sign DEB Pakcage
+        if: steps.cached_debs.outputs.cache-hit != 'true'
+        run: |
+          sudo apt install -y dpkg-sig
+          dpkg-sig --sign origin -k "aws-otel-collector@amazon.com" $PACKAGING_ROOT/debian/*/*.deb
+
+      - name: Remove Package Signing GPG Key from local GPG Key Ring
+        if: steps.cached_debs.outputs.cache-hit != 'true'
+        run: |
+          gpg --fingerprint --with-colons aws-otel-collector@amazon.com grep "^fpr" | sed -n 's/^fpr:::::::::\([[:alnum:]]\+\):/\1/p' | xargs gpg --batch --yes --delete-secret-keys
+          gpg --list-secret-keys
+
+  packaging-ssm:
+    runs-on: ubuntu-latest
+    needs: [packaging-rpm, packaging-deb, packaging-msi]
+    steps:
+      # Build and archive SSM package into cache.
+      - uses: actions/checkout@v2
+
+      - name: Cache SSM files
+        id: cached_ssm
+        uses: actions/cache@v2
+        with:
+          key: "cached_ssm_${{ github.run_id }}"
+          path: "${{ env.PACKAGING_ROOT }}/ssm"
+
+      - name: Restore cached rpms
+        if: steps.cached_ssm.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "cached_rpms_${{ github.run_id }}"
+          path: "${{ env.PACKAGING_ROOT }}"
+
+      - name: Restore cached debs
+        if: steps.cached_ssm.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "cached_debs_${{ github.run_id }}"
+          path: "${{ env.PACKAGING_ROOT }}"
+
+      - name: Download built artifacts
+        if: steps.cached_ssm.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@v2
+        with:
+          name: msi_artifacts
+          path: "${{ env.PACKAGING_ROOT }}"
+
+      - run: ls -R
+
+        # Build the ssm package and manifest by using a version with github short sha as same as e2etest-preparation.
+      - name: Create zip file and manifest for SSM package
+        if: steps.cached_ssm.outputs.cache-hit != 'true'
+        run: |
+          ssm_pkg_version="$(cat VERSION)-$(git rev-parse --short HEAD)"
+          rm -rf $PACKAGING_ROOT/ssm
+          python3 tools/ssm/ssm_manifest.py ${ssm_pkg_version}
+
+  e2etest-preparation:
+    runs-on: ubuntu-latest
+    needs: [packaging-rpm, packaging-deb, packaging-msi, packaging-ssm]
+    outputs:
+      version: ${{ steps.versioning.outputs.version }}
+    steps:
+      # Archive all the packages into one, and build a unique version number for e2etesting
+      - uses: actions/checkout@v2
+
+      - name: Cache the packages
+        id: cached_packages
+        uses: actions/cache@v2
+        with:
+          key: "cached_packages_${{ github.run_id }}"
+          path: "${{ env.PACKAGING_ROOT }}"
+
+      - name: Restore cached rpms
+        if: steps.cached_packages.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "cached_rpms_${{ github.run_id }}"
+          path: "${{ env.PACKAGING_ROOT }}"
+
+      - name: Restore cached debs
+        if: steps.cached_packages.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "cached_debs_${{ github.run_id }}"
+          path: "${{ env.PACKAGING_ROOT }}"
+
+      - name: Download built artifacts
+        if: steps.cached_packages.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@v2
+        with:
+          name: msi_artifacts
+          path: "${{ env.PACKAGING_ROOT }}"
+
+      - name: Restore cached ssm
+        if: steps.cached_packages.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "cached_ssm_${{ github.run_id }}"
+          path: "${{ env.PACKAGING_ROOT }}/ssm"
+
+      - run: ls -R
+
+      # Build a version with github short sha for the following reasons:
+      # - Distingush each build for Integration test
+      # - Increase more visibility to the customer and also for the dev since we publish the image for integration test.
+      # - Avoid having similar layers image and only have a final result image.
+      - name: Versioning for testing
+        id: versioning
+        run: |
+          version="$(cat VERSION)-$(git rev-parse --short HEAD)"
+          echo $version > $PACKAGING_ROOT/VERSION
+          cat $PACKAGING_ROOT/VERSION
+          echo "::set-output name=version::$version"
+
+  e2etest-release:
+    runs-on: ubuntu-latest
+    needs: [e2etest-preparation]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache if success
+        id: e2etest-release
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: e2etest-release-${{ github.run_id }}
+
+      - name: restore cached rpms
+        uses: actions/cache@v2
+        with:
+          key: "cached_packages_${{ github.run_id }}"
+          path: "${{ env.PACKAGING_ROOT }}"
+
+      - name: Restore cached binaries
+        if: steps.e2etest-release.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "cached_binaries_${{ github.run_id }}"
+          path: build
+
+      - name: Login to Public Integration Test ECR
+        if: steps.e2etest-release.outputs.cache-hit != 'true'
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          password: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+        env:
+          AWS_REGION: us-east-1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Create SSM package
+        run: |
+          ssm_pkg_version=`cat build/packages/VERSION`
+          (aws ssm describe-document --name ${SSM_PACKAGE_NAME} --version-name ${ssm_pkg_version} >/dev/null 2>&1) || {
+            pip3 install boto3
+            python3 tools/ssm/ssm_manifest.py ${ssm_pkg_version}
+            aws s3 cp build/packages/ssm s3://aws-otel-collector-test/ssm/${ssm_pkg_version} --recursive
+            python3 tools/ssm/ssm_create.py --no-default ${SSM_PACKAGE_NAME} ${ssm_pkg_version} aws-otel-collector-test/ssm/${ssm_pkg_version} us-west-2
+          }
+
+      - name: Upload to S3 in the testing stack
+        if: steps.e2etest-release.outputs.cache-hit != 'true'
+        run: s3_bucket_name=aws-otel-collector-test upload_to_latest=0 bash tools/release/image-binary-release/s3-release.sh
+
+      - name: Set up Docker Buildx
+        if: steps.e2etest-release.outputs.cache-hit != 'true'
+        uses: docker/setup-buildx-action@v1
+
+      - name: Set up QEMU
+        if: steps.e2etest-release.outputs.cache-hit != 'true'
+        uses: docker/setup-qemu-action@v1
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: public.ecr.aws/${{ env.ECR_REPO }}
+
+      #Build the adot collector image for two primary reasons:
+      #-Using the adot collector image to do the integration test
+      #-Export it for delivery version image in CD
+      #Documentation: https://github.com/docker/build-push-action
+      - name: Build ADOT collector image
+        uses: docker/build-push-action@v2
+        if: steps.e2etest-release.outputs.cache-hit != 'true'
+        with:
+          file: cmd/awscollector/Dockerfile
+          context: .
+          push: true
+          tags: |
+            public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.e2etest-preparation.outputs.version }}
+            public.ecr.aws/${{ env.ECR_REPO }}:latest
+          build-args: BUILDMODE=copy
+          cache-from: type=registry
+          cache-to: type=inline
+          platforms : linux/amd64, linux/arm64
+          labels: ${{ steps.meta.outputs.labels }}
+
+  get-testing-suites:
+    runs-on: ubuntu-latest
+    outputs:
+      eks-adot-operator-matrix: ${{ steps.set-matrix.outputs.eks-adot-operator-matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2.3.2
+
+      - name: Get all the testing suites
+        id: set-matrix
+        run: |
+          eks_adot_operator_matrix=$(python e2etest/get-testcases.py eks_adot_operator_matrix)
+          echo "::set-output name=eks-adot-operator-matrix::$eks_adot_operator_matrix"
+      - name: List testing suites
+        run: |
+          echo ${{ steps.set-matrix.outputs.eks-adot-operator-matrix }}
+
+  e2etest-eks-adot-operator:
+    runs-on: ubuntu-latest
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.eks-adot-operator-matrix) }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache if success
+        id: e2etest-eks-adot-operator
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: e2etest-eks-adot-operator-${{ github.run_id }}-${{ matrix.testcase }}
+
+      - name: Configure AWS Credentials
+        if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Set up JDK 11
+        if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Set up terraform
+        if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v1
+
+      - name: Check out testing framework
+        if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
+        uses: actions/checkout@v2
+        with:
+          repository: 'aws-observability/aws-otel-collector-test-framework'
+          path: testing-framework
+
+      - name: Run ADOT Operator testing suite on eks
+        if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
+        run: |
+          opts=""
+          if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
+          cd testing-framework/terraform/eks && terraform init && terraform apply -auto-approve $opts -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}"
+
+      - name: Destroy resources
+        if: ${{ always() && steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true' }}
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 20
+          command: |
+            opts=""
+            if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
+            cd testing-framework/terraform/eks && terraform destroy -auto-approve $opts
+
+
+  release-candidate:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && !contains(github.ref_name,'test/') # only create the artifact when there's a push, not for dispatch.
+    needs: [e2etest-eks-adot-operator]
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: restore cached packages
+        uses: actions/cache@v2
+        with:
+          path: "${{ env.PACKAGING_ROOT }}"
+          key: "cached_packages_${{ github.run_id }}"
+
+      - name: prepare production version
+        run: |
+          TESTING_VERSION=`cat $PACKAGING_ROOT/VERSION`
+          VERSION=`echo $TESTING_VERSION | awk -F "-" '{print $1}'`
+          echo $VERSION > $PACKAGING_ROOT/VERSION
+          echo $GITHUB_SHA > $PACKAGING_ROOT/GITHUB_SHA
+          echo $TESTING_VERSION > $PACKAGING_ROOT/TESTING_VERSION
+
+      - name: upload packages as release candidate on s3
+        run: |
+          tar czvf $GITHUB_SHA.tar.gz build
+          aws s3 cp $GITHUB_SHA.tar.gz s3://aws-otel-collector-release-candidate/$GITHUB_SHA.tar.gz
+
+      - name: Trigger performance test
+        uses: peter-evans/repository-dispatch@v1.1.3
+        with:
+          token: "${{ secrets.REPO_WRITE_ACCESS_TOKEN }}"
+          event-type: trigger-perf
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+
+  clean-ssm-package:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [e2etest-eks-adot-operator]
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: restore cached packages
+        id: cache_packages
+        uses: actions/cache@v2
+        with:
+          path: "${{ env.PACKAGING_ROOT }}"
+          key: "cached_packages_${{ github.run_id }}"
+
+      - name: clean up SSM test package
+        if: steps.cache_packages.outputs.cache-hit == 'true'
+        run: |
+          ssm_pkg_version=`cat build/packages/VERSION`
+          aws ssm describe-document --name ${SSM_PACKAGE_NAME} --version-name ${ssm_pkg_version} >/dev/null 2>&1 && \
+            aws ssm delete-document --name ${SSM_PACKAGE_NAME} --version-name ${ssm_pkg_version}
+


### PR DESCRIPTION
**Description:** 

This PR creates a seperate CI Workflow for ADOT operator releases. It included e2e tests for `adot-operator` 

Second Step : The next step is to eliminate the adot-operator tests from the[ CI workflow](https://github.com/aws-observability/aws-otel-collector/blob/main/.github/workflows/CI.yml#L1091)

**Testing:** <Describe what testing was performed and which tests were added.>

*In-Progress*

**Documentation:** <Describe the documentation added.>
 *In-Progress*