### PR TITLE
Add EBS cleaner

### DIFF
--- a/.github/workflows/weekly-resources-clean.yml
+++ b/.github/workflows/weekly-resources-clean.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        resource: [autoscaling, ec2, ecs, efs, iam, launchconfig, loadbalancer]
+        resource: [autoscaling, ec2, ecs, efs, iam, launchconfig, loadbalancer, ebs]
     steps:
       - uses: actions/checkout@v2
 

--- a/tools/workflow/cleaner/ebs/clean.go
+++ b/tools/workflow/cleaner/ebs/clean.go
@@ -1,0 +1,47 @@
+package ebs
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+const Type = "ebs"
+
+var logger = log.New(os.Stdout, fmt.Sprintf("[%s] ", Type), log.LstdFlags)
+
+// delete ebs volumes that are not actively attached to an instance and are older than the expiration date.
+func Clean(sess *session.Session, expirationDate time.Time) error {
+	ec2client := ec2.New(sess)
+
+	var nextToken *string
+	for {
+		describeVolumesInput := ec2.DescribeVolumesInput{MaxResults: aws.Int64(100), NextToken: nextToken}
+		describeVolumesOutput, err := ec2client.DescribeVolumes(&describeVolumesInput)
+
+		if err != nil {
+			return err
+		}
+
+		for _, volume := range describeVolumesOutput.Volumes {
+			if expirationDate.After(*volume.CreateTime) && len(volume.Attachments) == 0 {
+				logger.Printf("Try to delete volume %s launch-date %v", *volume.VolumeId, volume.CreateTime)
+				deleteVolumeInput := ec2.DeleteVolumeInput{VolumeId: volume.VolumeId}
+				if _, err := ec2client.DeleteVolume(&deleteVolumeInput); err != nil {
+					return err
+				}
+			}
+		}
+		if describeVolumesOutput.NextToken == nil {
+			break
+		}
+		nextToken = describeVolumesOutput.NextToken
+	}
+
+	return nil
+}

--- a/tools/workflow/cleaner/main.go
+++ b/tools/workflow/cleaner/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 
 	"github.com/aws-observability/aws-otel-collector/tools/workflow/cleaner/autoscaling"
+	"github.com/aws-observability/aws-otel-collector/tools/workflow/cleaner/ebs"
 	"github.com/aws-observability/aws-otel-collector/tools/workflow/cleaner/ec2"
 	"github.com/aws-observability/aws-otel-collector/tools/workflow/cleaner/ecs"
 	"github.com/aws-observability/aws-otel-collector/tools/workflow/cleaner/efs"
@@ -44,7 +45,7 @@ var (
 	daysToKeep    int
 	cleanersToRun string
 
-	cleanerTypes   = []string{autoscaling.Type, ec2.Type, ecs.Type, efs.Type, iam.Type, launchconfig.Type, loadbalancer.Type}
+	cleanerTypes   = []string{autoscaling.Type, ec2.Type, ecs.Type, efs.Type, iam.Type, launchconfig.Type, loadbalancer.Type, ebs.Type}
 	cleanerOptions = strings.Join(cleanerTypes, delimiter)
 )
 
@@ -102,6 +103,10 @@ func main() {
 			}
 		case loadbalancer.Type:
 			if err = loadbalancer.Clean(sess, expirationDate); err != nil {
+				log.Printf("%v", err)
+			}
+		case ebs.Type:
+			if err = ebs.Clean(sess, expirationDate); err != nil {
 				log.Printf("%v", err)
 			}
 		default:


### PR DESCRIPTION
**Description:** This PR adds a cleaner to remove EBS volumes that do not have any attached instances and are older than a supplied expiration date. 

**Link to tracking Issue:** n/a

**Testing:** Tested locally and cleaner successfully removed volumes in `integ-test` account. 

**Documentation:** n/a
