### PR TITLE
Change canary tests to run every 4 hours

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -14,7 +14,7 @@
 name: 'Canary Test'
 on:
   schedule:
-    - cron: '0 * * * *' # triggers the workflow every hour
+    - cron: '0 */4 * * *' # triggers the workflow every hour
 
   # we can manually trigger this workflow by using dispatch for debuging
   repository_dispatch:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -25,6 +25,9 @@ env:
   TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
   TF_VAR_patch: 'true'
 
+concurrency:
+  group: canary-${{ github.ref_name }}
+
 jobs:
   build-aotutil:
     runs-on: ubuntu-latest

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -14,7 +14,7 @@
 name: 'Canary Test'
 on:
   schedule:
-    - cron: '0 */4 * * *' # triggers the workflow every hour
+    - cron: '0 */4 * * *' # triggers the workflow every four hours
 
   # we can manually trigger this workflow by using dispatch for debuging
   repository_dispatch:


### PR DESCRIPTION
**Description:** Canary tests are taking longer than an hour but being queued on the hour. Change to run once every 4 hours. 

