### PR TITLE
Change `sourceRepo` host and registry 

### DIFF
--- a/tools/release/adot-operator-images-mirror/config.yaml
+++ b/tools/release/adot-operator-images-mirror/config.yaml
@@ -1,8 +1,8 @@
 ## The source repositories and target repositories are one-to-one correspondence.
 sourceRepos:
-  - registry: opentelemetry
+  - registry: opentelemetry/opentelemetry-operator
     name: opentelemetry-operator
-    host: quay.io
+    host: ghcr.io
   - registry: kubebuilder
     name: kube-rbac-proxy
     host: gcr.io


### PR DESCRIPTION
**Description:** 
This PR fixes the mirroring tool to use the correct sourceRepo host and registry.

