### PR TITLE
Added missed dash in sourceRepo registry in `config.yaml`

### DIFF
--- a/tools/release/adot-operator-images-mirror/config.yaml
+++ b/tools/release/adot-operator-images-mirror/config.yaml
@@ -1,6 +1,6 @@
 ## The source repositories and target repositories are one-to-one correspondence.
 sourceRepos:
-  - registry: opentelemetry/opentelemetry-operator
+  - registry: open-telemetry/opentelemetry-operator
     name: opentelemetry-operator
     host: ghcr.io
   - registry: kubebuilder


### PR DESCRIPTION
**Description:** 
Second PR to fix ADOT Operator mirroring tool, incorrect registry name for sourceRepo
