### PR TITLE
Move ADOT Operator mirroring to own job in CD workflow

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -631,24 +631,32 @@ jobs:
 
   mirror_adot_operator:
     runs-on: ubuntu-latest
-    needs: release-latest-image
+    needs: release-checking
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cache if success
+        id: mirror_adot_operator
+        uses: actions/cache@v2
+        with:
+          key: mirror_adot_operator-${{ github.run_id }}
+          path: VERSION
+
       - name: Set up Go 1.x
+        if: steps.mirror_adot_operator.outputs.cache-hit != 'true'
         uses: actions/setup-go@v2
         with:
           go-version: ^1.17.7
 
       - name: Compare version with Dockerhub latest
         id: version
-        if: needs.release-latest-image.outputs.cache-hit != 'true'
+        if: steps.mirror_adot_operator.outputs.cache-hit != 'true'
         run: |
           TAG="${{ needs.release-checking.outputs.version }}"
           TARGET_VERSION=$TAG bash tools/workflow/docker-version-compare.sh
 
       - name: Configure AWS Credentials
-        if: needs.release-latest-image.outputs.cache-hit != 'true'
+        if: steps.mirror_adot_operator.outputs.cache-hit != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.RELEASE_KEY_ID }}
@@ -656,7 +664,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Mirror ADOT operator
-        if: ${{ github.event.inputs.skip-adot-operator-mirroring == 'false' && (needs.release-latest-image.outputs.cache-hit != 'true' && (steps.version.outputs.major-update == 'true' || steps.version.outputs.minor-update == 'true') || steps.version.outputs.same-version == 'true') }}
+        if: ${{ github.event.inputs.skip-adot-operator-mirroring == 'false' && (steps.mirror_adot_operator.outputs.cache-hit != 'true' && (steps.version.outputs.major-update == 'true' || steps.version.outputs.minor-update == 'true') || steps.version.outputs.same-version == 'true') }}
         run: cd tools/release/adot-operator-images-mirror && go run ./
         env:
           AWS_SDK_LOAD_CONFIG: true

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -629,34 +629,34 @@ jobs:
           src: public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.release-checking.outputs.version }}
           dst: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.release-checking.outputs.version }}
 
-  mirror_adot_operator:
+  mirror-adot-operator:
     runs-on: ubuntu-latest
     needs: release-checking
     steps:
       - uses: actions/checkout@v2
 
       - name: Cache if success
-        id: mirror_adot_operator
+        id: mirror-adot-operator
         uses: actions/cache@v2
         with:
-          key: mirror_adot_operator-${{ github.run_id }}
+          key: mirror-adot-operator-${{ github.run_id }}
           path: VERSION
 
       - name: Set up Go 1.x
-        if: steps.mirror_adot_operator.outputs.cache-hit != 'true'
+        if: steps.mirror-adot-operator.outputs.cache-hit != 'true'
         uses: actions/setup-go@v2
         with:
           go-version: ^1.17.7
 
       - name: Compare version with Dockerhub latest
         id: version
-        if: steps.mirror_adot_operator.outputs.cache-hit != 'true'
+        if: steps.mirror-adot-operator.outputs.cache-hit != 'true'
         run: |
           TAG="${{ needs.release-checking.outputs.version }}"
           TARGET_VERSION=$TAG bash tools/workflow/docker-version-compare.sh
 
       - name: Configure AWS Credentials
-        if: steps.mirror_adot_operator.outputs.cache-hit != 'true'
+        if: steps.mirror-adot-operator.outputs.cache-hit != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.RELEASE_KEY_ID }}
@@ -664,7 +664,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Mirror ADOT operator
-        if: ${{ github.event.inputs.skip-adot-operator-mirroring == 'false' && (steps.mirror_adot_operator.outputs.cache-hit != 'true' && (steps.version.outputs.major-update == 'true' || steps.version.outputs.minor-update == 'true') || steps.version.outputs.patch-update == 'true') }}
+        if: ${{ github.event.inputs.skip-adot-operator-mirroring == 'false' && (steps.mirror-adot-operator.outputs.cache-hit != 'true' && (steps.version.outputs.major-update == 'true' || steps.version.outputs.minor-update == 'true') || steps.version.outputs.patch-update == 'true') }}
         run: cd tools/release/adot-operator-images-mirror && go run ./
         env:
           AWS_SDK_LOAD_CONFIG: true

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -629,8 +629,26 @@ jobs:
           src: public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.release-checking.outputs.version }}
           dst: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.release-checking.outputs.version }}
 
+  mirror_adot_operator:
+    runs-on: ubuntu-latest
+    needs: release-latest-image
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.17.7
+
+      - name: Compare version with Dockerhub latest
+        id: version
+        if: needs.release-latest-image.outputs.cache-hit != 'true'
+        run: |
+          TAG="${{ needs.release-checking.outputs.version }}"
+          TARGET_VERSION=$TAG bash tools/workflow/docker-version-compare.sh
+
       - name: Configure AWS Credentials
-        if: steps.release-latest-image.outputs.cache-hit != 'true'
+        if: needs.release-latest-image.outputs.cache-hit != 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.RELEASE_KEY_ID }}
@@ -638,7 +656,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Mirror ADOT operator
-        if: ${{ github.event.inputs.skip-adot-operator-mirroring == 'false' && (steps.release-latest-image.outputs.cache-hit != 'true' && (steps.version.outputs.major-update == 'true' || steps.version.outputs.minor-update == 'true') || steps.version.outputs.same-version == 'true') }}
+        if: ${{ github.event.inputs.skip-adot-operator-mirroring == 'false' && (needs.release-latest-image.outputs.cache-hit != 'true' && (steps.version.outputs.major-update == 'true' || steps.version.outputs.minor-update == 'true') || steps.version.outputs.same-version == 'true') }}
         run: cd tools/release/adot-operator-images-mirror && go run ./
         env:
           AWS_SDK_LOAD_CONFIG: true

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -664,7 +664,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Mirror ADOT operator
-        if: ${{ github.event.inputs.skip-adot-operator-mirroring == 'false' && (steps.mirror_adot_operator.outputs.cache-hit != 'true' && (steps.version.outputs.major-update == 'true' || steps.version.outputs.minor-update == 'true') || steps.version.outputs.same-version == 'true') }}
+        if: ${{ github.event.inputs.skip-adot-operator-mirroring == 'false' && (steps.mirror_adot_operator.outputs.cache-hit != 'true' && (steps.version.outputs.major-update == 'true' || steps.version.outputs.minor-update == 'true') || steps.version.outputs.patch-update == 'true') }}
         run: cd tools/release/adot-operator-images-mirror && go run ./
         env:
           AWS_SDK_LOAD_CONFIG: true


### PR DESCRIPTION
**Description:**
This PR moves the ADOT Operator mirroring step out of the `release-latest-image` job into its own `mirror-adot-operator` job in the CD workflow

**Link to tracking Issue:** 
#1006 
