### PR TITLE
Automatically target release branches in aws-otel-test-framework

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -46,18 +46,18 @@ env:
 
 jobs:
   create-test-ref:
-  runs-on: ubuntu-latest
-  outputs:
-    testRef: ${{ steps.setRef.outputs.ref }}
-  steps:
-    - name: Set testRef output
-      id: setRef
-      run: |
-        if [[ ${{ github.ref_name }} == release/v* ]]; then 
-          echo "::set-output name=ref::${{github.ref_name}}"
-        else
-          echo "::set-output name=ref::terraform"
-        fi
+    runs-on: ubuntu-latest
+    outputs:
+      testRef: ${{ steps.setRef.outputs.ref }}
+    steps:
+      - name: Set testRef output
+        id: setRef
+        run: |
+          if [[ ${{ github.ref_name }} == release/v* ]]; then 
+            echo "::set-output name=ref::${{github.ref_name}}"
+          else
+            echo "::set-output name=ref::terraform"
+          fi
 
 
   release-checking: 

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -39,12 +39,27 @@ env:
   TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
   TF_VAR_aoc_vpc_name: aoc-vpc-large
   TF_VAR_aoc_vpc_security_group: aoc-vpc-security-group-large
-  TESTING_FRAMEWORK_REPO: "aws-observability/aws-otel-collector-test-framework"
+  TESTING_FRAMEWORK_REPO: "aws-observability/aws-otel-test-framework"
   SSM_RELEASE_S3_BUCKET: "aws-otel-collector-ssm"
   SSM_RELEASE_PACKAGE_NAME: "AWSDistroOTel-Collector"
   RELEASE_S3_BUCKET: "aws-otel-collector"
 
 jobs:
+  create-test-ref:
+  runs-on: ubuntu-latest
+  outputs:
+    testRef: ${{ steps.setRef.outputs.ref }}
+  steps:
+    - name: Set testRef output
+      id: setRef
+      run: |
+        if [[ ${{ github.ref_name }} == release/v* ]]; then 
+          echo "::set-output name=ref::${{github.ref_name}}"
+        else
+          echo "::set-output name=ref::terraform"
+        fi
+
+
   release-checking: 
     runs-on: ubuntu-latest
     outputs:
@@ -167,7 +182,7 @@ jobs:
 
   s3-release-validation-1:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, release-to-s3, release-checking]
+    needs: [get-testing-suites, release-to-s3, release-checking, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -210,6 +225,7 @@ jobs:
         with:
           repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Run testing suite on ec2
         if: steps.s3-release-validation-1.outputs.cache-hit != 'true'
@@ -229,7 +245,7 @@ jobs:
           
   s3-release-validation-2:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, release-to-s3, release-checking]
+    needs: [get-testing-suites, release-to-s3, release-checking, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -273,6 +289,7 @@ jobs:
         with:
           repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Run testing suite on ec2
         if: steps.s3-release-validation-2.outputs.cache-hit != 'true'
@@ -292,7 +309,7 @@ jobs:
           
   s3-release-validation-3:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, release-to-s3, release-checking]
+    needs: [get-testing-suites, release-to-s3, release-checking, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -336,6 +353,7 @@ jobs:
         with:
           repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef}}
 
       - name: Run testing suite on ec2
         if: steps.s3-release-validation-3.outputs.cache-hit != 'true'
@@ -383,7 +401,7 @@ jobs:
 
   release-validation-ecs:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, release-version-image, release-checking]
+    needs: [get-testing-suites, release-version-image, release-checking, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -427,6 +445,7 @@ jobs:
         with:
           repository: "${{ env.TESTING_FRAMEWORK_REPO }}"
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
           
       - name: Run testing suite on ecs
         if: steps.release-validation-ecs.outputs.cache-hit != 'true'
@@ -446,7 +465,7 @@ jobs:
                   
   release-validation-eks:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, release-version-image, release-checking]
+    needs: [get-testing-suites, release-version-image, release-checking, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -490,6 +509,7 @@ jobs:
         with:
           repository: "${{ env.TESTING_FRAMEWORK_REPO }}"
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef}}
       
       - name: Run testing suite on eks
         if: steps.release-validation-eks.outputs.cache-hit != 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,16 +53,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  create-test-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      testRef: ${{ steps.setRef.outputs.ref }}
+    steps:
+      - name: Set testRef output
+        id: setRef
+        run: |
+          if [[ ${{ github.ref_name }} == release/v* ]]; then 
+            echo "::set-output name=ref::${{github.ref_name}}"
+          else
+            echo "::set-output name=ref::terraform"
+          fi
 
   build-aotutil:
     runs-on: ubuntu-latest
+    needs: create-test-ref
     steps:
       - name: Check out testing framework
         uses: actions/checkout@v2
         with:
           repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
-          ref: terraform
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
@@ -589,7 +603,7 @@ jobs:
 
   e2etest-ec2-1:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -631,6 +645,7 @@ jobs:
         with:
           repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Restore aoutil
         if: steps.e2etest-ec2-1.outputs.cache-hit != 'true'
@@ -668,7 +683,7 @@ jobs:
 
   e2etest-ec2-2:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -710,6 +725,7 @@ jobs:
         with:
           repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Restore aoutil
         if: steps.e2etest-ec2-2.outputs.cache-hit != 'true'
@@ -747,7 +763,7 @@ jobs:
 
   e2etest-ec2-3:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -789,6 +805,7 @@ jobs:
         with:
           repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Restore aoutil
         if: steps.e2etest-ec2-3.outputs.cache-hit != 'true'
@@ -826,7 +843,7 @@ jobs:
 
   e2etest-ecs:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -868,6 +885,7 @@ jobs:
         with:
           repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Run testing suite on ecs
         if: steps.e2etest-ecs.outputs.cache-hit != 'true'
@@ -898,7 +916,7 @@ jobs:
 
   e2etest-eks:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -940,6 +958,7 @@ jobs:
         with:
           repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Run testing suite on eks
         if: steps.e2etest-eks.outputs.cache-hit != 'true'
@@ -959,7 +978,7 @@ jobs:
 
   e2etest-eks-arm64:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -1001,6 +1020,7 @@ jobs:
         with:
           repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Run testing suite on eks
         if: steps.e2etest-eks-arm64.outputs.cache-hit != 'true'
@@ -1021,7 +1041,7 @@ jobs:
 
   e2etest-eks-fargate:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -1063,6 +1083,7 @@ jobs:
         with:
           repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Run testing suite on eks
         if: steps.e2etest-eks-fargate.outputs.cache-hit != 'true'
@@ -1096,7 +1117,7 @@ jobs:
 
   e2etest-eks-adot-operator:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -1138,6 +1159,7 @@ jobs:
         with:
           repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Run ADOT Operator testing suite on eks
         if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,19 +44,25 @@ env:
   WIN_SIGNED_PKG_FOLDER: OTelCollectorAuthenticode/AuthenticodeSigner-SHA256-RSA
   SSM_PACKAGE_NAME: "testAWSDistroOTel-Collector"
   US_EAST_2_AMP_ENDPOINT: "https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-1de68e95-0680-42bb-8e55-67e7fd5d0861"
+  TEST_FRAMEWORK_REPO: 'aws-observability/aws-otel-test-framework'
+
+
+
 concurrency:
   group: ci-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
+
   build-aotutil:
     runs-on: ubuntu-latest
     steps:
       - name: Check out testing framework
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-test-framework'
+          repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: terraform
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
@@ -623,7 +629,7 @@ jobs:
         if: steps.e2etest-ec2-1.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
 
       - name: Restore aoutil
@@ -702,7 +708,7 @@ jobs:
         if: steps.e2etest-ec2-2.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
 
       - name: Restore aoutil
@@ -781,7 +787,7 @@ jobs:
         if: steps.e2etest-ec2-3.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
 
       - name: Restore aoutil
@@ -860,7 +866,7 @@ jobs:
         if: steps.e2etest-ecs.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
 
       - name: Run testing suite on ecs
@@ -932,7 +938,7 @@ jobs:
         if: steps.e2etest-eks.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
 
       - name: Run testing suite on eks
@@ -993,7 +999,7 @@ jobs:
         if: steps.e2etest-eks-arm64.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
 
       - name: Run testing suite on eks
@@ -1055,7 +1061,7 @@ jobs:
         if: steps.e2etest-eks-fargate.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
 
       - name: Run testing suite on eks
@@ -1130,7 +1136,7 @@ jobs:
         if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TEST_FRAMEWORK_REPO }}
           path: testing-framework
 
       - name: Run ADOT Operator testing suite on eks

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ env:
   WIN_SIGNED_PKG_FOLDER: OTelCollectorAuthenticode/AuthenticodeSigner-SHA256-RSA
   SSM_PACKAGE_NAME: "testAWSDistroOTel-Collector"
   US_EAST_2_AMP_ENDPOINT: "https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-1de68e95-0680-42bb-8e55-67e7fd5d0861"
-  TESTING_FRAMEWORK_REPO: 'aws-observability/aws-otel-test-framework'
+  TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
 
 
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ env:
   WIN_SIGNED_PKG_FOLDER: OTelCollectorAuthenticode/AuthenticodeSigner-SHA256-RSA
   SSM_PACKAGE_NAME: "testAWSDistroOTel-Collector"
   US_EAST_2_AMP_ENDPOINT: "https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-1de68e95-0680-42bb-8e55-67e7fd5d0861"
-  TEST_FRAMEWORK_REPO: 'aws-observability/aws-otel-test-framework'
+  TESTING_FRAMEWORK_REPO: 'aws-observability/aws-otel-test-framework'
 
 
 
@@ -74,7 +74,7 @@ jobs:
       - name: Check out testing framework
         uses: actions/checkout@v2
         with:
-          repository: ${{ env.TEST_FRAMEWORK_REPO }}
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
           ref: ${{ needs.create-test-ref.outputs.testRef }}
       - name: Set up Go 1.x
@@ -643,7 +643,7 @@ jobs:
         if: steps.e2etest-ec2-1.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: ${{ env.TEST_FRAMEWORK_REPO }}
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
           ref: ${{ needs.create-test-ref.outputs.testRef }}
 
@@ -723,7 +723,7 @@ jobs:
         if: steps.e2etest-ec2-2.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: ${{ env.TEST_FRAMEWORK_REPO }}
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
           ref: ${{ needs.create-test-ref.outputs.testRef }}
 
@@ -803,7 +803,7 @@ jobs:
         if: steps.e2etest-ec2-3.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: ${{ env.TEST_FRAMEWORK_REPO }}
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
           ref: ${{ needs.create-test-ref.outputs.testRef }}
 
@@ -883,7 +883,7 @@ jobs:
         if: steps.e2etest-ecs.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: ${{ env.TEST_FRAMEWORK_REPO }}
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
           ref: ${{ needs.create-test-ref.outputs.testRef }}
 
@@ -956,7 +956,7 @@ jobs:
         if: steps.e2etest-eks.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: ${{ env.TEST_FRAMEWORK_REPO }}
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
           ref: ${{ needs.create-test-ref.outputs.testRef }}
 
@@ -1018,7 +1018,7 @@ jobs:
         if: steps.e2etest-eks-arm64.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: ${{ env.TEST_FRAMEWORK_REPO }}
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
           ref: ${{ needs.create-test-ref.outputs.testRef }}
 
@@ -1081,7 +1081,7 @@ jobs:
         if: steps.e2etest-eks-fargate.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: ${{ env.TEST_FRAMEWORK_REPO }}
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
           ref: ${{ needs.create-test-ref.outputs.testRef }}
 
@@ -1157,7 +1157,7 @@ jobs:
         if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: ${{ env.TEST_FRAMEWORK_REPO }}
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
           ref: ${{ needs.create-test-ref.outputs.testRef }}
 

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -24,7 +24,7 @@ on:
 env:
   IMAGE_NAME: aws-otel-collector
   PACKAGING_ROOT: build/packages 
-  TESTING_FRAMEWORK_REPO: 'aws-observability/aws-otel-test-framework'
+  TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
 
 concurrency:
   group: pr-build-${{ github.event.pull_request.number }}

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -24,12 +24,27 @@ on:
 env:
   IMAGE_NAME: aws-otel-collector
   PACKAGING_ROOT: build/packages 
+  TESTING_FRAMEWORK_REPO: 'aws-observability/aws-otel-test-framework'
 
 concurrency:
   group: pr-build-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
+  create-test-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      testRef: ${{ steps.setRef.outputs.ref }}
+    steps:
+      - name: Set testRef output
+        id: setRef
+        run: |
+          if [[ ${{ github.ref_name }} == release/v* ]]; then 
+            echo "::set-output name=ref::${{github.ref_name}}"
+          else
+            echo "::set-output name=ref::terraform"
+          fi
+
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -202,7 +217,7 @@ jobs:
           
   run-test-case:
     runs-on: ubuntu-latest
-    needs: [changes, get-test-cases, build]
+    needs: [changes, get-test-cases, build, create-test-ref]
     strategy:
       matrix: ${{ fromJson(needs.get-test-cases.outputs.matrix) }}
     steps:
@@ -210,8 +225,9 @@ jobs:
         if: ${{ needs.changes.outputs.changed == 'true' }}
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Check out Collector
         if: ${{ needs.changes.outputs.changed == 'true' }}

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -24,19 +24,37 @@ env:
   TF_VAR_aws_access_key_id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
   TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
   TF_VAR_patch: 'true'
+  TESTING_FRAMEWORK_REPO: 'aws-observability/aws-otel-test-framework'
 
 concurrency:
   group: canary-${{ github.ref_name }}
 
 jobs:
+  create-test-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      testRef: ${{ steps.setRef.outputs.ref }}
+    steps:
+      - name: Set testRef output
+        id: setRef
+        run: |
+          if [[ ${{ github.ref_name }} == release/v* ]]; then 
+            echo "::set-output name=ref::${{github.ref_name}}"
+          else
+            echo "::set-output name=ref::terraform"
+          fi
+
   build-aotutil:
     runs-on: ubuntu-latest
+    needs: create-test-ref
     steps:
       - name: Check out testing framework
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
+
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
@@ -71,7 +89,7 @@ jobs:
 
   run-canary-test:
     runs-on: ubuntu-latest
-    needs: [get-canary-test-cases]
+    needs: [get-canary-test-cases, create-test-ref]
     strategy:
       matrix: ${{ fromJson(needs.get-canary-test-cases.outputs.canary_matrix) }}
       fail-fast: false
@@ -99,8 +117,10 @@ jobs:
       - name: Check out testing framework
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
+          
       - name: Restore aoutil
         uses: actions/cache@v2
         with:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -24,7 +24,7 @@ env:
   TF_VAR_aws_access_key_id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
   TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
   TF_VAR_patch: 'true'
-  TESTING_FRAMEWORK_REPO: 'aws-observability/aws-otel-test-framework'
+  TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
 
 concurrency:
   group: canary-${{ github.ref_name }}
@@ -120,7 +120,7 @@ jobs:
           repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
           ref: ${{ needs.create-test-ref.outputs.testRef }}
-          
+
       - name: Restore aoutil
         uses: actions/cache@v2
         with:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -28,8 +28,23 @@ env:
   MAX_BENCHMARKS_TO_KEEP: 100
   COMMIT_USER: Github Actions
   COMMIT_EMAIL: actions@github.com
+  TESTING_FRAMEWORK_REPO: 'aws-observability/aws-otel-test-framework'
   
 jobs:
+  create-test-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      testRef: ${{ steps.setRef.outputs.ref }}
+    steps:
+      - name: Set testRef output
+        id: setRef
+        run: |
+          if [[ ${{ github.ref_name }} == release/v* ]]; then 
+            echo "::set-output name=ref::${{github.ref_name}}"
+          else
+            echo "::set-output name=ref::terraform"
+          fi
+
   get-testing-version:
     runs-on: ubuntu-latest
     outputs:
@@ -98,7 +113,7 @@ jobs:
           
   run-perf-test:
     runs-on: ubuntu-latest
-    needs: [get-perf-test-cases, get-testing-version]
+    needs: [get-perf-test-cases, get-testing-version, create-test-ref]
     strategy:
       matrix: ${{ fromJson(needs.get-perf-test-cases.outputs.perf_matrix) }}
       max-parallel: 10
@@ -124,8 +139,9 @@ jobs:
       - name: Check out testing framework
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO}}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
           
       - name: Run Performance test
         run: |

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -28,7 +28,7 @@ env:
   MAX_BENCHMARKS_TO_KEEP: 100
   COMMIT_USER: Github Actions
   COMMIT_EMAIL: actions@github.com
-  TESTING_FRAMEWORK_REPO: 'aws-observability/aws-otel-test-framework'
+  TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   
 jobs:
   create-test-ref:


### PR DESCRIPTION
**Description:** This PR accomplishes two main items. 
1. Removes old references to `aws-otel-collector-test-framework` and updates to `aws-otel-test-framework`. This step also included standardizing the creation of a `TESTING_FRAMEWORK_REPO` environment variable to be referenced in the steps where the testing framework repository was checked out.  
2. Adds the `create-test-ref` job to any workflow which checks out the `aws-otel-test-framework` repository. This job creates an output which subsequent jobs will use to target a specific branch in `aws-otel-test-framework`. Specifically, events dispached from `release/v*` branches will target their respective `release/v*.**.x` branches moving forward. This automates an improvement that the ADOT team sought to improve our release/patching process. This removed the neccessity for a developer to manually change the target for each release. 

**Testing:** Forked repo actions: 
[On release/v* branch](https://github.com/bryan-aguilar/aws-otel-collector/actions/runs/1954070131)
[On non release branch](https://github.com/bryan-aguilar/aws-otel-collector/actions/runs/1954059792)
These tests validated the `create-test-ref` logic. 


**Documentation:** Internal release documentation has been updated to standardize the creation of the release branches on `aws-otel-test-framework`. It is a hard requirement that these branches follow the naming schema `release/vX.XX.x`. For example for `v0.17.0` release branches MUST be named `release/v0.17.x`.
