### PR TITLE
Update `timeout_minutes` for canary tests

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -131,7 +131,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3
-          timeout_minutes: 60
+          timeout_minutes: 120
           retry_on: error
           retry_wait_seconds: 5
           command: |


### PR DESCRIPTION
**Description:** 

This PR updates `timeout_minutes` for the canary tests. Current canary tests are failing due to timeout issues. Increasing the timeout minutes will give enough time to run the tests.