### PR TITLE
Add cache packages for delete SSM on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1231,17 +1231,27 @@ jobs:
           aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
           aws-region: us-west-2
 
+      - name: restore cached packages
+        id: cache_packages
+        uses: actions/cache@v2
+        with:
+          path: "${{ env.PACKAGING_ROOT }}"
+          key: "cached_packages_${{ github.run_id }}"
+
       - name: Get SSM package version
         id: versioning
+        if: steps.cache_packages.outputs.cache-hit == 'true'
         run: |
           ssm_pkg_version=$(cat $PACKAGING_ROOT/VERSION)
           echo "::set-output name=ssm_pkg_version::$ssm_pkg_version"
 
       - name: Rollback SSM default version
+        if: steps.cache_packages.outputs.cache-hit == 'true'
         run: |
           ssm_package_name=${{ env.SSM_PACKAGE_NAME }} version=${{ steps.versioning.outputs.ssm_pkg_version }}  tools/ssm/ssm_rollback_default_version.sh
 
       - name: clean up SSM test package
+        if: steps.cache_packages.outputs.cache-hit == 'true'
         run: |
           aws ssm describe-document --name ${{ env.SSM_PACKAGE_NAME }} --version-name ${{ steps.versioning.outputs.ssm_pkg_version }} >/dev/null 2>&1 && \
             aws ssm delete-document --name ${{ env.SSM_PACKAGE_NAME }} --version-name ${{ steps.versioning.outputs.ssm_pkg_version }}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
After the fixed for [deleting SSM default version](https://github.com/aws-observability/aws-otel-collector/pull/952), the CI was not able to delete because it was not able to take the input from version file. Therefore, adding back the `cache packages` for  CI to take the required input.
**Link to tracking Issue:** <Issue number if applicable>
N/A
**Testing:** <Describe what testing was performed and which tests were added.>
N/A
**Documentation:** <Describe the documentation added.>
N/A

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
