### PR TITLE
remove codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![codecov](https://codecov.io/gh/aws-observability/aws-otel-collector/branch/main/graph/badge.svg)](https://codecov.io/gh/aws-observability/aws-otel-collector)
 ![CI](https://github.com/aws-observability/aws-otel-collector/workflows/CI/badge.svg)
 ![CD](https://github.com/aws-observability/aws-otel-collector/workflows/CD/badge.svg)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/aws-observability/aws-otel-collector)


### PR DESCRIPTION
Removes codecov badge which is currently displaying incorrect statistics. Will investigate and add back when correct info is displayed. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
