### PR TITLE
Add checkout in clean-ssm-package for both CI and CD stage

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -672,6 +672,10 @@ jobs:
     if: ${{ always() && needs.release-to-s3.result == 'success' }}
     needs: [ validation-tests-checked, release-checking, release-to-s3 ]
     steps:
+      #Since the tools in workflow are always up-to-date with the github workflow, we don't need to use the tools in workflows from the committed sha
+      #but using the tools in workflows from the branch triggered with workflow_dispatch.
+      - uses: actions/checkout@v3
+
       #Delete ssm package and binaries/artifacts which is created on s3 bucket for validation test regardless of these two scenarios:
       #-if the validation test failed, then we will delete the SSM package since we don't want to roll out the unstable version
       #-if the validation successes, then we will trigger the release SSM package workflow to replace all of this with the appropriate region

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1224,6 +1224,7 @@ jobs:
     if: ${{ always() && needs.e2etest-preparation.result == 'success' }}
     needs: [e2etest-preparation, e2etest-eks, e2etest-eks-adot-operator, e2etest-eks-fargate, e2etest-ecs, e2etest-ec2-1, e2etest-ec2-2, e2etest-ec2-3]
     steps:
+      - uses: actions/checkout@v3
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
Description:
After the fixed for roll_back SSM default version in the PR https://github.com/aws-observability/aws-otel-collector/pull/952, the CI needs to use the sh file in tools folder to serve the purpose. Therefore, adding a checkout for both CI and CD in the `clean-ssm-package` job.

Link to tracking Issue:
N/A
Testing:
N/A
Documentation:
N/A