### PR TITLE
Update CI/CD badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![CI](https://github.com/aws-observability/aws-otel-collector/workflows/CI/badge.svg)
-![CD](https://github.com/aws-observability/aws-otel-collector/workflows/CD/badge.svg)
+![CI](https://github.com/aws-observability/aws-otel-collector/actions/workflows/CI.yml/badge.svg)
+![CD](https://github.com/aws-observability/aws-otel-collector/actions/workflows/CD.yml/badge.svg)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/aws-observability/aws-otel-collector)
 
 ### Overview


### PR DESCRIPTION
**Description:** Updated links to CI/CD badges because they were showing successful when in failed status.


**Testing:** go to badge URL

**Documentation:** [GH Doc Link](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge)


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
