### PR TITLE
Add bash cmd to clean-ssm-package

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -687,7 +687,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Rollback SSM default version
-        run: ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }} version=${{ needs.release-checking.outputs.version }}  tools/ssm/ssm_rollback_default_version.sh
+        run: ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }} version=${{ needs.release-checking.outputs.version }} bash tools/ssm/ssm_rollback_default_version.sh
 
       - name: Clean up SSM release package created for validation testing
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1249,7 +1249,7 @@ jobs:
       - name: Rollback SSM default version
         if: steps.cache_packages.outputs.cache-hit == 'true'
         run: |
-          ssm_package_name=${{ env.SSM_PACKAGE_NAME }} version=${{ steps.versioning.outputs.ssm_pkg_version }}  tools/ssm/ssm_rollback_default_version.sh
+          ssm_package_name=${{ env.SSM_PACKAGE_NAME }} version=${{ steps.versioning.outputs.ssm_pkg_version }} bash tools/ssm/ssm_rollback_default_version.sh
 
       - name: clean up SSM test package
         if: steps.cache_packages.outputs.cache-hit == 'true'


### PR DESCRIPTION
**Description:** Adds bash command to properly execute rollback script

**Testing:** n/a

**Documentation:** Isolated error by referencing other examples of executing shell scrips in workflows. Noticed bash command was missing. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
