### PR TITLE
Enable gosec for goalngci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ lint-static-check: | $(LINT) $(STATIC_CHECK)
 
 .PHONY: lint
 lint: lint-static-check
-	$(LINT) run --timeout 5m
+	$(LINT) run --timeout 5m --enable gosec
 
 .PHONY: multimod-verify
 multimod-verify: | $(MULTIMOD)


### PR DESCRIPTION
**Description:** Enables go sec during lint

**Link to tracking Issue:** closes #970 

**Testing:** `make lint`

**Documentation:** n/a


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
