### PR TITLE
Fix github context in pr body validate

### DIFF
--- a/.github/workflows/pr-body-validate.yml
+++ b/.github/workflows/pr-body-validate.yml
@@ -25,7 +25,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Validade license content
-          if: ${{ github.event.pull_request.user.login }} != 'dependabot' 
+          if: ${{ github.event.pull_request.user.login != 'dependabot[bot]'}}  
           run: | 
               if echo "${{ github.event.pull_request.body }}" | grep -q "${{ env.LICENSE_TEXT }}" ; then 
                 echo "License text found in PR body"


### PR DESCRIPTION
**Description:** Currently Dependabot PRs are blocked by the `pr-body-validate` workflow. This is due to a bad if check in the workflow syntax. I have updated the statement to check for what appears to be the proper bot username as found [here](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions). The context was also incorrect and has been adjusted after referencing these [steps](https://docs.github.com/en/actions/learn-github-actions/environment-variables).  See note in link. 

**Link to tracking Issue:** n/a

**Testing:** None done, this is a low impact change and replicating the payload would take as much time as merging this PR to see if dependabot PR builds pass. 

**Documentation:** n/a


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
