### PR TITLE
Update actor check in pr-validate

### DIFF
--- a/.github/workflows/pr-body-validate.yml
+++ b/.github/workflows/pr-body-validate.yml
@@ -25,7 +25,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Validade license content
-          if: ${{ github.event.pull_request.user.login }} != 'dependabot' 
+          if: ${{ github.event.pull_request.user.login != 'dependabot[bot]'}}  
           run: | 
               if echo "${{ github.event.pull_request.body }}" | grep -q "${{ env.LICENSE_TEXT }}" ; then 
                 echo "License text found in PR body"

--- a/.github/workflows/pr-body-validate.yml
+++ b/.github/workflows/pr-body-validate.yml
@@ -25,7 +25,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Validade license content
-          if: ${{ github.event.pull_request.user.login != 'dependabot[bot]'}}  
+          if: ${{ github.actor != 'dependabot[bot]' }} 
           run: | 
               if echo "${{ github.event.pull_request.body }}" | grep -q "${{ env.LICENSE_TEXT }}" ; then 
                 echo "License text found in PR body"


### PR DESCRIPTION
**Description:** This is the second attempt to correctly skip PRs from dependabot. This fix uses the examples provided in [this](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#fetch-metadata-about-a-pull-request) example. The reason this was not used on the last PR because of caution surrounding the `github.actor` env variable. It is still unclear who the actor would resolve if the job is manually re ran in case of failure. This should likely never happen as this is quite a simple workflow. 

**Link to tracking Issue:** n/a

**Testing:** None, low impact change that can be tested immediately against current PRs. 

**Documentation:** b/a


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
