### PR TITLE
Split e2etest-ec2 matrices

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -519,6 +519,70 @@ jobs:
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
   
+  s3-release-validation-6:
+    runs-on: ubuntu-latest
+    needs: [get-testing-suites, release-to-s3, release-checking, create-test-ref]
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-6) }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache if success
+        id: s3-release-validation-6
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: s3-release-validation-6-${{ needs.release-checking.outputs.testing_version }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
+
+      - name: Configure AWS Credentials
+        if: steps.s3-release-validation-6.outputs.cache-hit != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Set up JDK 11
+        if: steps.s3-release-validation-6.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v2
+        with:
+          distribution: zulu
+          java-version: 11
+
+      - name: Set up terraform
+        if: steps.s3-release-validation-6.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.10
+
+      - name: Check out testing framework
+        if: steps.s3-release-validation-6.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
+          path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef}}
+
+      - name: Run testing suite on ec2
+        if: steps.s3-release-validation-6.outputs.cache-hit != 'true'
+        run: |
+          opts=""
+          if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
+          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=${{ env.RELEASE_S3_BUCKET }}" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }}"
+          
+      - name: Destroy resources
+        if: ${{ always() && steps.s3-release-validation-6.outputs.cache-hit != 'true' }}
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 20
+          command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
+  
   release-version-image:
     runs-on: ubuntu-latest
     needs: [release-checking]

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -110,6 +110,12 @@ jobs:
       ec2-matrix-1: ${{ steps.set-matrix.outputs.ec2-matrix-1 }}
       ec2-matrix-2: ${{ steps.set-matrix.outputs.ec2-matrix-2 }}
       ec2-matrix-3: ${{ steps.set-matrix.outputs.ec2-matrix-3 }}
+      ec2-matrix-4: ${{ steps.set-matrix.outputs.ec2-matrix-4 }}
+      ec2-matrix-5: ${{ steps.set-matrix.outputs.ec2-matrix-5 }}
+      ec2-matrix-6: ${{ steps.set-matrix.outputs.ec2-matrix-6 }}
+      ec2-matrix-7: ${{ steps.set-matrix.outputs.ec2-matrix-7 }}
+      ec2-matrix-8: ${{ steps.set-matrix.outputs.ec2-matrix-8 }}
+      ec2-matrix-9: ${{ steps.set-matrix.outputs.ec2-matrix-9 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -125,6 +131,12 @@ jobs:
           ec2_matrix_1=$(python e2etest/get-testcases.py ec2_matrix_1)
           ec2_matrix_2=$(python e2etest/get-testcases.py ec2_matrix_2)
           ec2_matrix_3=$(python e2etest/get-testcases.py ec2_matrix_3)
+          ec2_matrix_4=$(python e2etest/get-testcases.py ec2_matrix_4)
+          ec2_matrix_5=$(python e2etest/get-testcases.py ec2_matrix_5)
+          ec2_matrix_6=$(python e2etest/get-testcases.py ec2_matrix_6)
+          ec2_matrix_7=$(python e2etest/get-testcases.py ec2_matrix_7)
+          ec2_matrix_8=$(python e2etest/get-testcases.py ec2_matrix_8)
+          ec2_matrix_9=$(python e2etest/get-testcases.py ec2_matrix_9)
           ecs_matrix=$(python e2etest/get-testcases.py ecs_matrix)
           eks_matrix=$(python e2etest/get-testcases.py eks_matrix)
           echo "::set-output name=eks-matrix::$eks_matrix"
@@ -132,6 +144,12 @@ jobs:
           echo "::set-output name=ec2-matrix-1::$ec2_matrix_1"
           echo "::set-output name=ec2-matrix-2::$ec2_matrix_2"
           echo "::set-output name=ec2-matrix-3::$ec2_matrix_3"
+          echo "::set-output name=ec2-matrix-3::$ec2_matrix_4"
+          echo "::set-output name=ec2-matrix-3::$ec2_matrix_5"
+          echo "::set-output name=ec2-matrix-3::$ec2_matrix_6"
+          echo "::set-output name=ec2-matrix-3::$ec2_matrix_7"
+          echo "::set-output name=ec2-matrix-3::$ec2_matrix_8"
+          echo "::set-output name=ec2-matrix-3::$ec2_matrix_9"
       - name: List testing suites
         run: |
           echo ${{ steps.set-matrix.outputs.eks-matrix }}    
@@ -139,6 +157,12 @@ jobs:
           echo ${{ steps.set-matrix.outputs.ec2-matrix-1 }}
           echo ${{ steps.set-matrix.outputs.ec2-matrix-2 }}
           echo ${{ steps.set-matrix.outputs.ec2-matrix-3 }}
+          echo ${{ steps.set-matrix.outputs.ec2-matrix-4 }}
+          echo ${{ steps.set-matrix.outputs.ec2-matrix-5 }}
+          echo ${{ steps.set-matrix.outputs.ec2-matrix-6 }}
+          echo ${{ steps.set-matrix.outputs.ec2-matrix-7 }}
+          echo ${{ steps.set-matrix.outputs.ec2-matrix-8 }}
+          echo ${{ steps.set-matrix.outputs.ec2-matrix-9 }}
           
   release-to-s3:
     runs-on: ubuntu-latest
@@ -367,6 +391,70 @@ jobs:
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
           
+  s3-release-validation-4:
+    runs-on: ubuntu-latest
+    needs: [get-testing-suites, release-to-s3, release-checking, create-test-ref]
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-4) }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache if success
+        id: s3-release-validation-4
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: s3-release-validation-4-${{ needs.release-checking.outputs.testing_version }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
+
+      - name: Configure AWS Credentials
+        if: steps.s3-release-validation-4.outputs.cache-hit != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Set up JDK 11
+        if: steps.s3-release-validation-4.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v2
+        with:
+          distribution: zulu
+          java-version: 11
+
+      - name: Set up terraform
+        if: steps.s3-release-validation-4.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.10
+
+      - name: Check out testing framework
+        if: steps.s3-release-validation-4.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
+          path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef}}
+
+      - name: Run testing suite on ec2
+        if: steps.s3-release-validation-4.outputs.cache-hit != 'true'
+        run: |
+          opts=""
+          if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
+          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=${{ env.RELEASE_S3_BUCKET }}" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }}"
+          
+      - name: Destroy resources
+        if: ${{ always() && steps.s3-release-validation-4.outputs.cache-hit != 'true' }}
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 20
+          command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
+  
   release-version-image:
     runs-on: ubuntu-latest
     needs: [release-checking]

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -455,6 +455,70 @@ jobs:
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
   
+  s3-release-validation-5:
+    runs-on: ubuntu-latest
+    needs: [get-testing-suites, release-to-s3, release-checking, create-test-ref]
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-5) }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache if success
+        id: s3-release-validation-5
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: s3-release-validation-5-${{ needs.release-checking.outputs.testing_version }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
+
+      - name: Configure AWS Credentials
+        if: steps.s3-release-validation-5.outputs.cache-hit != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Set up JDK 11
+        if: steps.s3-release-validation-5.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v2
+        with:
+          distribution: zulu
+          java-version: 11
+
+      - name: Set up terraform
+        if: steps.s3-release-validation-5.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.10
+
+      - name: Check out testing framework
+        if: steps.s3-release-validation-5.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
+          path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef}}
+
+      - name: Run testing suite on ec2
+        if: steps.s3-release-validation-5.outputs.cache-hit != 'true'
+        run: |
+          opts=""
+          if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
+          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=${{ env.RELEASE_S3_BUCKET }}" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }}"
+          
+      - name: Destroy resources
+        if: ${{ always() && steps.s3-release-validation-5.outputs.cache-hit != 'true' }}
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 20
+          command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
+  
   release-version-image:
     runs-on: ubuntu-latest
     needs: [release-checking]

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -711,6 +711,70 @@ jobs:
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
   
+  s3-release-validation-9:
+    runs-on: ubuntu-latest
+    needs: [get-testing-suites, release-to-s3, release-checking, create-test-ref]
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-9 }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache if success
+        id: s3-release-validation-9
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: s3-release-validation-9-${{ needs.release-checking.outputs.testing_version }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
+
+      - name: Configure AWS Credentials
+        if: steps.s3-release-validation-9.outputs.cache-hit != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Set up JDK 11
+        if: steps.s3-release-validation-9.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v2
+        with:
+          distribution: zulu
+          java-version: 11
+
+      - name: Set up terraform
+        if: steps.s3-release-validation-9.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.10
+
+      - name: Check out testing framework
+        if: steps.s3-release-validation-9.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
+          path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef}}
+
+      - name: Run testing suite on ec2
+        if: steps.s3-release-validation-9.outputs.cache-hit != 'true'
+        run: |
+          opts=""
+          if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
+          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=${{ env.RELEASE_S3_BUCKET }}" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }}"
+          
+      - name: Destroy resources
+        if: ${{ always() && steps.s3-release-validation-9.outputs.cache-hit != 'true' }}
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 20
+          command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
+  
   release-version-image:
     runs-on: ubuntu-latest
     needs: [release-checking]

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -959,7 +959,7 @@ jobs:
 
   validation-tests-checked:
     runs-on: ubuntu-latest
-    needs: [ s3-release-validation-1, s3-release-validation-2, s3-release-validation-3,release-validation-ecs, release-validation-eks, release-checking ]
+    needs: [ s3-release-validation-1, s3-release-validation-2, s3-release-validation-3, s3-release-validation-4, s3-release-validation-5, s3-release-validation-6, s3-release-validation-7, s3-release-validation-8, s3-release-validation-9,release-validation-ecs, release-validation-eks, release-checking ]
     steps:
       - run: echo "All validation tests passed."
 

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -583,6 +583,70 @@ jobs:
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
   
+  s3-release-validation-7:
+    runs-on: ubuntu-latest
+    needs: [get-testing-suites, release-to-s3, release-checking, create-test-ref]
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-7) }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache if success
+        id: s3-release-validation-7
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: s3-release-validation-7-${{ needs.release-checking.outputs.testing_version }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
+
+      - name: Configure AWS Credentials
+        if: steps.s3-release-validation-7.outputs.cache-hit != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Set up JDK 11
+        if: steps.s3-release-validation-7.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v2
+        with:
+          distribution: zulu
+          java-version: 11
+
+      - name: Set up terraform
+        if: steps.s3-release-validation-7.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.10
+
+      - name: Check out testing framework
+        if: steps.s3-release-validation-7.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
+          path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef}}
+
+      - name: Run testing suite on ec2
+        if: steps.s3-release-validation-7.outputs.cache-hit != 'true'
+        run: |
+          opts=""
+          if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
+          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=${{ env.RELEASE_S3_BUCKET }}" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }}"
+          
+      - name: Destroy resources
+        if: ${{ always() && steps.s3-release-validation-7.outputs.cache-hit != 'true' }}
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 20
+          command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
+  
   release-version-image:
     runs-on: ubuntu-latest
     needs: [release-checking]

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -647,6 +647,70 @@ jobs:
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
   
+  s3-release-validation-8:
+    runs-on: ubuntu-latest
+    needs: [get-testing-suites, release-to-s3, release-checking, create-test-ref]
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-8 }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache if success
+        id: s3-release-validation-8
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: s3-release-validation-8-${{ needs.release-checking.outputs.testing_version }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
+
+      - name: Configure AWS Credentials
+        if: steps.s3-release-validation-8.outputs.cache-hit != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Set up JDK 11
+        if: steps.s3-release-validation-8.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v2
+        with:
+          distribution: zulu
+          java-version: 11
+
+      - name: Set up terraform
+        if: steps.s3-release-validation-8.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.10
+
+      - name: Check out testing framework
+        if: steps.s3-release-validation-8.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
+          path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef}}
+
+      - name: Run testing suite on ec2
+        if: steps.s3-release-validation-8.outputs.cache-hit != 'true'
+        run: |
+          opts=""
+          if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
+          cd testing-framework/terraform/ec2 && terraform init && terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.release-checking.outputs.version }}" -var="package_s3_bucket=${{ env.RELEASE_S3_BUCKET }}" -var="testcase=../testcases/${{ matrix.testcase }}" -var="ssm_package_name=${{ env.SSM_RELEASE_PACKAGE_NAME }}"
+          
+      - name: Destroy resources
+        if: ${{ always() && steps.s3-release-validation-8.outputs.cache-hit != 'true' }}
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 20
+          command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
+  
   release-version-image:
     runs-on: ubuntu-latest
     needs: [release-checking]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1105,6 +1105,86 @@ jobs:
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
   
+  e2etest-ec2-7:
+    runs-on: ubuntu-latest
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-7) }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache if success
+        id: e2etest-ec2-7
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: e2etest-ec2-7-${{ github.run_id }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
+
+      - name: Configure AWS Credentials
+        if: steps.e2etest-ec2-7.outputs.cache-hit != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Set up JDK 11
+        if: steps.e2etest-ec2-7.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Set up terraform
+        if: steps.e2etest-ec2-7.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v1
+
+      - name: Check out testing framework
+        if: steps.e2etest-ec2-7.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
+          path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
+
+      - name: Restore aoutil
+        if: steps.e2etest-ec2-7.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "aotutil_${{ github.run_id }}"
+          path: testing-framework/cmd/aotutil/aotutil
+
+      - name: Run testing suite on ec2
+        if: steps.e2etest-ec2-7.outputs.cache-hit != 'true'
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 60
+          command: |
+            opts=""
+            if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
+            cd testing-framework/terraform/ec2
+            terraform init
+            if terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}" ; then
+              terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+
+      #This is here just in case workflow cancel
+      - name: Destroy resources
+        if: ${{ cancelled() && steps.e2etest-ec2-7.outputs.cache-hit != 'true' }}
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 20
+          command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
+
   e2etest-ecs:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1688,7 +1688,7 @@ jobs:
   release-candidate:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && !contains(github.ref_name,'test/') # only create the artifact when there's a push, not for dispatch.
-    needs: [e2etest-eks, e2etest-eks-arm64, e2etest-eks-adot-operator, e2etest-eks-fargate, e2etest-ecs, e2etest-ec2-1, e2etest-ec2-2, e2etest-ec2-3]
+    needs: [e2etest-eks, e2etest-eks-arm64, e2etest-eks-adot-operator, e2etest-eks-fargate, e2etest-ecs, e2etest-ec2-1, e2etest-ec2-2, e2etest-ec2-3, e2etest-ec2-4, e2etest-ec2-5, e2etest-ec2-6, e2etest-ec2-7, e2etest-ec2-8, e2etest-ec2-9]
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -1726,7 +1726,7 @@ jobs:
   clean-ssm-package:
     runs-on: ubuntu-latest
     if: ${{ always() && needs.e2etest-preparation.result == 'success' }}
-    needs: [e2etest-preparation, e2etest-eks, e2etest-eks-adot-operator, e2etest-eks-fargate, e2etest-ecs, e2etest-ec2-1, e2etest-ec2-2, e2etest-ec2-3]
+    needs: [e2etest-preparation, e2etest-eks, e2etest-eks-adot-operator, e2etest-eks-fargate, e2etest-ecs, e2etest-ec2-1, e2etest-ec2-2, e2etest-ec2-3, e2etest-ec2-4, e2etest-ec2-5, e2etest-ec2-6, e2etest-ec2-7, e2etest-ec2-8, e2etest-ec2-9]
     steps:
       - uses: actions/checkout@v3
       - name: Configure AWS Credentials

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1265,6 +1265,86 @@ jobs:
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
   
+  e2etest-ec2-9:
+    runs-on: ubuntu-latest
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-9) }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache if success
+        id: e2etest-ec2-9
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: e2etest-ec2-9-${{ github.run_id }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
+
+      - name: Configure AWS Credentials
+        if: steps.e2etest-ec2-9.outputs.cache-hit != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Set up JDK 11
+        if: steps.e2etest-ec2-9.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Set up terraform
+        if: steps.e2etest-ec2-9.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v1
+
+      - name: Check out testing framework
+        if: steps.e2etest-ec2-9.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
+          path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
+
+      - name: Restore aoutil
+        if: steps.e2etest-ec2-9.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "aotutil_${{ github.run_id }}"
+          path: testing-framework/cmd/aotutil/aotutil
+
+      - name: Run testing suite on ec2
+        if: steps.e2etest-ec2-9.outputs.cache-hit != 'true'
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 60
+          command: |
+            opts=""
+            if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
+            cd testing-framework/terraform/ec2
+            terraform init
+            if terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}" ; then
+              terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+
+      #This is here just in case workflow cancel
+      - name: Destroy resources
+        if: ${{ cancelled() && steps.e2etest-ec2-9.outputs.cache-hit != 'true' }}
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 20
+          command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
+  
   e2etest-ecs:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -871,7 +871,7 @@ jobs:
     strategy:
       fail-fast: false
       max-parallel: 10
-      matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-3) }}
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-4) }}
 
     steps:
       - uses: actions/checkout@v3
@@ -882,7 +882,7 @@ jobs:
         with:
           path: |
             VERSION
-          key: e2etest-ec2-3-${{ github.run_id }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
+          key: e2etest-ec2-4-${{ github.run_id }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
 
       - name: Configure AWS Credentials
         if: steps.e2etest-ec2-4.outputs.cache-hit != 'true'
@@ -945,6 +945,166 @@ jobs:
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
 
+  e2etest-ec2-5:
+    runs-on: ubuntu-latest
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-5) }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache if success
+        id: e2etest-ec2-5
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: e2etest-ec2-5-${{ github.run_id }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
+
+      - name: Configure AWS Credentials
+        if: steps.e2etest-ec2-5.outputs.cache-hit != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Set up JDK 11
+        if: steps.e2etest-ec2-5.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Set up terraform
+        if: steps.e2etest-ec2-5.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v1
+
+      - name: Check out testing framework
+        if: steps.e2etest-ec2-5.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
+          path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
+
+      - name: Restore aoutil
+        if: steps.e2etest-ec2-5.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "aotutil_${{ github.run_id }}"
+          path: testing-framework/cmd/aotutil/aotutil
+
+      - name: Run testing suite on ec2
+        if: steps.e2etest-ec2-5.outputs.cache-hit != 'true'
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 60
+          command: |
+            opts=""
+            if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
+            cd testing-framework/terraform/ec2
+            terraform init
+            if terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}" ; then
+              terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+
+      #This is here just in case workflow cancel
+      - name: Destroy resources
+        if: ${{ cancelled() && steps.e2etest-ec2-5.outputs.cache-hit != 'true' }}
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 20
+          command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
+  
+  e2etest-ec2-6:
+    runs-on: ubuntu-latest
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-6) }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache if success
+        id: e2etest-ec2-6
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: e2etest-ec2-6-${{ github.run_id }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
+
+      - name: Configure AWS Credentials
+        if: steps.e2etest-ec2-6.outputs.cache-hit != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Set up JDK 11
+        if: steps.e2etest-ec2-6.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Set up terraform
+        if: steps.e2etest-ec2-6.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v1
+
+      - name: Check out testing framework
+        if: steps.e2etest-ec2-6.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
+          path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
+
+      - name: Restore aoutil
+        if: steps.e2etest-ec2-6.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "aotutil_${{ github.run_id }}"
+          path: testing-framework/cmd/aotutil/aotutil
+
+      - name: Run testing suite on ec2
+        if: steps.e2etest-ec2-6.outputs.cache-hit != 'true'
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 60
+          command: |
+            opts=""
+            if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
+            cd testing-framework/terraform/ec2
+            terraform init
+            if terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}" ; then
+              terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+
+      #This is here just in case workflow cancel
+      - name: Destroy resources
+        if: ${{ cancelled() && steps.e2etest-ec2-6.outputs.cache-hit != 'true' }}
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 20
+          command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
+  
   e2etest-ecs:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -564,6 +564,12 @@ jobs:
       ec2-matrix-1: ${{ steps.set-matrix.outputs.ec2-matrix-1 }}
       ec2-matrix-2: ${{ steps.set-matrix.outputs.ec2-matrix-2 }}
       ec2-matrix-3: ${{ steps.set-matrix.outputs.ec2-matrix-3 }}
+      ec2-matrix-4: ${{ steps.set-matrix.outputs.ec2-matrix-4 }}
+      ec2-matrix-5: ${{ steps.set-matrix.outputs.ec2-matrix-5 }}
+      ec2-matrix-6: ${{ steps.set-matrix.outputs.ec2-matrix-6 }}
+      ec2-matrix-7: ${{ steps.set-matrix.outputs.ec2-matrix-7 }}
+      ec2-matrix-8: ${{ steps.set-matrix.outputs.ec2-matrix-8 }}
+      ec2-matrix-9: ${{ steps.set-matrix.outputs.ec2-matrix-9 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -577,6 +583,12 @@ jobs:
           ec2_matrix_1=$(python e2etest/get-testcases.py ec2_matrix_1)
           ec2_matrix_2=$(python e2etest/get-testcases.py ec2_matrix_2)
           ec2_matrix_3=$(python e2etest/get-testcases.py ec2_matrix_3)
+          ec2_matrix_4=$(python e2etest/get-testcases.py ec2_matrix_4)
+          ec2_matrix_5=$(python e2etest/get-testcases.py ec2_matrix_5)
+          ec2_matrix_6=$(python e2etest/get-testcases.py ec2_matrix_6)
+          ec2_matrix_7=$(python e2etest/get-testcases.py ec2_matrix_7)
+          ec2_matrix_8=$(python e2etest/get-testcases.py ec2_matrix_8)
+          ec2_matrix_9=$(python e2etest/get-testcases.py ec2_matrix_9)
           ecs_matrix=$(python e2etest/get-testcases.py ecs_matrix)
           eks_matrix=$(python e2etest/get-testcases.py eks_matrix)
           eks_arm64_matrix=$(python e2etest/get-testcases.py eks_arm64_matrix)
@@ -590,6 +602,12 @@ jobs:
           echo "::set-output name=ec2-matrix-1::$ec2_matrix_1"
           echo "::set-output name=ec2-matrix-2::$ec2_matrix_2"
           echo "::set-output name=ec2-matrix-3::$ec2_matrix_3"
+          echo "::set-output name=ec2-matrix-3::$ec2_matrix_4"
+          echo "::set-output name=ec2-matrix-3::$ec2_matrix_5"
+          echo "::set-output name=ec2-matrix-3::$ec2_matrix_6"
+          echo "::set-output name=ec2-matrix-3::$ec2_matrix_7"
+          echo "::set-output name=ec2-matrix-3::$ec2_matrix_8"
+          echo "::set-output name=ec2-matrix-3::$ec2_matrix_9"
       - name: List testing suites
         run: |
           echo ${{ steps.set-matrix.outputs.eks-matrix }}
@@ -600,6 +618,12 @@ jobs:
           echo ${{ steps.set-matrix.outputs.ec2-matrix-1 }}
           echo ${{ steps.set-matrix.outputs.ec2-matrix-2 }}
           echo ${{ steps.set-matrix.outputs.ec2-matrix-3 }}
+          echo ${{ steps.set-matrix.outputs.ec2-matrix-4 }}
+          echo ${{ steps.set-matrix.outputs.ec2-matrix-5 }}
+          echo ${{ steps.set-matrix.outputs.ec2-matrix-6 }}
+          echo ${{ steps.set-matrix.outputs.ec2-matrix-7 }}
+          echo ${{ steps.set-matrix.outputs.ec2-matrix-8 }}
+          echo ${{ steps.set-matrix.outputs.ec2-matrix-9 }}
 
   e2etest-ec2-1:
     runs-on: ubuntu-latest
@@ -834,6 +858,86 @@ jobs:
       #This is here just in case workflow cancel
       - name: Destroy resources
         if: ${{ cancelled() && steps.e2etest-ec2-3.outputs.cache-hit != 'true' }}
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 20
+          command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
+    
+  e2etest-ec2-4:
+    runs-on: ubuntu-latest
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-3) }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache if success
+        id: e2etest-ec2-4
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: e2etest-ec2-3-${{ github.run_id }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
+
+      - name: Configure AWS Credentials
+        if: steps.e2etest-ec2-4.outputs.cache-hit != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Set up JDK 11
+        if: steps.e2etest-ec2-4.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Set up terraform
+        if: steps.e2etest-ec2-4.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v1
+
+      - name: Check out testing framework
+        if: steps.e2etest-ec2-4.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
+          path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
+
+      - name: Restore aoutil
+        if: steps.e2etest-ec2-4.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "aotutil_${{ github.run_id }}"
+          path: testing-framework/cmd/aotutil/aotutil
+
+      - name: Run testing suite on ec2
+        if: steps.e2etest-ec2-4.outputs.cache-hit != 'true'
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 60
+          command: |
+            opts=""
+            if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
+            cd testing-framework/terraform/ec2
+            terraform init
+            if terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}" ; then
+              terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+
+      #This is here just in case workflow cancel
+      - name: Destroy resources
+        if: ${{ cancelled() && steps.e2etest-ec2-4.outputs.cache-hit != 'true' }}
         uses: nick-invision/retry@v2
         with:
           max_attempts: 3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1185,6 +1185,86 @@ jobs:
           retry_wait_seconds: 20
           command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
 
+  e2etest-ec2-8:
+    runs-on: ubuntu-latest
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.ec2-matrix-8) }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache if success
+        id: e2etest-ec2-8
+        uses: actions/cache@v2
+        with:
+          path: |
+            VERSION
+          key: e2etest-ec2-8-${{ github.run_id }}-${{ matrix.testcase }}-${{ matrix.testing_ami }}
+
+      - name: Configure AWS Credentials
+        if: steps.e2etest-ec2-8.outputs.cache-hit != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: Set up JDK 11
+        if: steps.e2etest-ec2-8.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Set up terraform
+        if: steps.e2etest-ec2-8.outputs.cache-hit != 'true'
+        uses: hashicorp/setup-terraform@v1
+
+      - name: Check out testing framework
+        if: steps.e2etest-ec2-8.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
+          path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
+
+      - name: Restore aoutil
+        if: steps.e2etest-ec2-8.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          key: "aotutil_${{ github.run_id }}"
+          path: testing-framework/cmd/aotutil/aotutil
+
+      - name: Run testing suite on ec2
+        if: steps.e2etest-ec2-8.outputs.cache-hit != 'true'
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 60
+          command: |
+            opts=""
+            if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
+            cd testing-framework/terraform/ec2
+            terraform init
+            if terraform apply -auto-approve -lock=false $opts -var="testing_ami=${{ matrix.testing_ami }}" -var="aoc_version=${{ needs.e2etest-preparation.outputs.version }}" -var="testcase=../testcases/${{ matrix.testcase }}" ; then
+              terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+
+      #This is here just in case workflow cancel
+      - name: Destroy resources
+        if: ${{ cancelled() && steps.e2etest-ec2-8.outputs.cache-hit != 'true' }}
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 20
+          command: cd testing-framework/terraform/ec2 && terraform destroy -auto-approve
+  
   e2etest-ecs:
     runs-on: ubuntu-latest
     needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]

--- a/e2etest/get-testcases.py
+++ b/e2etest/get-testcases.py
@@ -9,28 +9,53 @@ if __name__ == "__main__":
 
     ec2_matrix_1 = {"testcase": [], "testing_ami": [
         "amazonlinux2", 
-        "amazonlinux", 
+        "amazonlinux",  
+    ]}
+
+    ec2_matrix_2 = {"testcase":[],"testing_ami":[
         "ubuntu18", 
         "ubuntu16", 
+    ]}
+
+    ec2_matrix_3 = {"testcase":[],"testing_ami":[
         "debian10", 
         "debian9", 
-        "suse15"
     ]}
-    ec2_matrix_2 = {"testcase": [], "testing_ami": [
-        "suse12", 
+
+    ec2_matrix_4 = {"testcase":[],"testing_ami":[
+        "suse15" 
+        "suse12",
+    ]}
+
+    ec2_matrix_5 = {"testcase":[],"testing_ami":[
         "redhat8", 
         "redhat7", 
+    ]}
+
+    ec2_matrix_6 = {"testcase": [], "testing_ami": [
         "centos7", 
         "windows2019"
     ]}
-    ec2_matrix_3 = {"testcase": [], "testing_ami": [
-        "arm_amazonlinux2",
-        "arm_suse15",
+
+    ec2_matrix_7 = {"testcase": [], "testing_ami": [
         "arm_redhat8",
         "arm_redhat7",
+        
+    ]}
+
+    ec2_matrix_8 = {"testcase": [], "testing_ami": [
+        "arm_amazonlinux2",
+        "arm_suse15",
+    ]}
+
+    ec2_matrix_9 = {"testcase": [], "testing_ami": [
         "arm_ubuntu18",
         "arm_ubuntu16"
     ]}
+
+
+
+
     ecs_matrix = {"testcase": [], "launch_type": ["EC2", "FARGATE"]}
     eks_matrix = {"testcase": []}
     eks_arm64_matrix = {"testcase": []}
@@ -44,6 +69,12 @@ if __name__ == "__main__":
             "ec2_matrix_1": ec2_matrix_1, 
             "ec2_matrix_2": ec2_matrix_2,
             "ec2_matrix_3": ec2_matrix_3,
+            "ec2_matrix_4": ec2_matrix_4,
+            "ec2_matrix_5": ec2_matrix_5,
+            "ec2_matrix_6": ec2_matrix_6,
+            "ec2_matrix_7": ec2_matrix_7,
+            "ec2_matrix_8": ec2_matrix_8,
+            "ec2_matrix_9": ec2_matrix_9,
             "ecs_matrix": ecs_matrix,
             "eks_matrix": eks_matrix,
             "eks_arm64_matrix": eks_arm64_matrix,
@@ -61,6 +92,12 @@ if __name__ == "__main__":
                 ec2_matrix_1["testcase"].append(testcase["case_name"])
                 ec2_matrix_2["testcase"].append(testcase["case_name"])
                 ec2_matrix_3["testcase"].append(testcase["case_name"])
+                ec2_matrix_4["testcase"].append(testcase["case_name"])
+                ec2_matrix_5["testcase"].append(testcase["case_name"])
+                ec2_matrix_6["testcase"].append(testcase["case_name"])
+                ec2_matrix_7["testcase"].append(testcase["case_name"])
+                ec2_matrix_8["testcase"].append(testcase["case_name"])
+                ec2_matrix_9["testcase"].append(testcase["case_name"])
             if 'ECS' in testcase["platforms"]:
                 ecs_matrix["testcase"].append(testcase["case_name"])
             if 'EKS' in testcase["platforms"]:


### PR DESCRIPTION
**Description:** This PR reduces the amount of jobs created by the `e2etest-ec2` matrices by splitting them out further. This adds `e2etest-eks-4` through `e2etest-eks-9`. The CD and CI workflows were also updated so that there is no loss in test coverage for existing workflows. The result is that the CI and CD workflows will have 5 more jobs but each job will have less steps overall. 



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
