### PR TITLE
Fix typo in ci-e2etest-eks-arm64

### DIFF
--- a/.github/workflows/CI-e2etest-eks-arm64.yml
+++ b/.github/workflows/CI-e2etest-eks-arm64.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       max-parallel: 5
-      matrix: ${{ fromJson(needs.get-testing-suites.outputs.eks-arm64-matrix) }}
+      matrix: ${{ fromJson(needs.get-testing-suite.outputs.eks-arm64-matrix) }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
**Description:** `get-testing-suites` -> `get-testing-suite`


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
