### PR TITLE
Better code redability in docker-version-compare.sh

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -628,7 +628,7 @@ jobs:
 
       - name: Login to Public Release ECR
         id: login-ecr
-        if: ${{ steps.release-latest-image.outputs.cache-hit != 'true' && steps.version.outputs.LATEST_OR_NEWER == 'true' }}
+        if: ${{ steps.release-latest-image.outputs.cache-hit != 'true' && steps.version.outputs.latest-or-newer == 'true' }}
         uses: docker/login-action@v1
         with:
           registry: public.ecr.aws

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -628,7 +628,7 @@ jobs:
 
       - name: Login to Public Release ECR
         id: login-ecr
-        if: ${{ steps.release-latest-image.outputs.cache-hit != 'true' && steps.version.outputs.any-update == 'true' }}
+        if: ${{ steps.release-latest-image.outputs.cache-hit != 'true' && steps.version.outputs.LATEST_OR_NEWER == 'true' }}
         uses: docker/login-action@v1
         with:
           registry: public.ecr.aws
@@ -638,7 +638,7 @@ jobs:
           AWS_REGION: us-east-1
 
       - name: Pull image from integration test ECR, tag as latest and push to public release ECR and DockerHub
-        if: ${{ steps.release-latest-image.outputs.cache-hit != 'true'  && steps.version.outputs.any-update == 'true' }}
+        if: ${{ steps.release-latest-image.outputs.cache-hit != 'true'  && steps.version.outputs.LATEST_OR_NEWER == 'true' }}
         uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.release-checking.outputs.version }}

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -638,7 +638,7 @@ jobs:
           AWS_REGION: us-east-1
 
       - name: Pull image from integration test ECR, tag as latest and push to public release ECR and DockerHub
-        if: ${{ steps.release-latest-image.outputs.cache-hit != 'true'  && steps.version.outputs.LATEST_OR_NEWER == 'true' }}
+        if: ${{ steps.release-latest-image.outputs.cache-hit != 'true'  && steps.version.outputs.latest-or-newer== 'true' }}
         uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.release-checking.outputs.version }}

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -638,7 +638,7 @@ jobs:
           AWS_REGION: us-east-1
 
       - name: Pull image from integration test ECR, tag as latest and push to public release ECR and DockerHub
-        if: ${{ steps.release-latest-image.outputs.cache-hit != 'true'  && steps.version.outputs.latest-or-newer== 'true' }}
+        if: ${{ steps.release-latest-image.outputs.cache-hit != 'true'  && steps.version.outputs.latest-or-newer == 'true' }}
         uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.release-checking.outputs.version }}

--- a/tools/workflow/docker-version-compare.sh
+++ b/tools/workflow/docker-version-compare.sh
@@ -91,7 +91,12 @@ elif [ "${TARGET_MAJOR}" -eq "${LATEST_MAJOR}" ]; then
     fi
 fi
 
-[ ${MAJOR_UPDATE} == "true" ] || [ ${MINOR_UPDATE} == "true" ] || [ ${PATCH_UPDATE} == "true" ] || [ ${SAME_VERSION} == "true" ] && ANY_UPDATE=true || ANY_UPDATE=false
+#if any of the versions are true, then ANY_UPDATE = true
+if [ ${MAJOR_UPDATE} == "true" ] || [ ${MINOR_UPDATE} == "true" ] || [ ${PATCH_UPDATE} == "true" ] || [ ${SAME_VERSION} == "true" ]; then 
+    ANY_UPDATE=true
+else
+    ANY_UPDATE=false
+fi
 
 echo "::set-output name=major-update::${MAJOR_UPDATE}"
 echo "::set-output name=minor-update::${MINOR_UPDATE}"

--- a/tools/workflow/docker-version-compare.sh
+++ b/tools/workflow/docker-version-compare.sh
@@ -92,7 +92,7 @@ elif [ "${TARGET_MAJOR}" -eq "${LATEST_MAJOR}" ]; then
 fi
 
 # If any of the updates are true, then LATEST_OR_NEWER = true
-# LATEST_OR_NEWER would be false if the target version is less than the current latest version or vice cersa
+# LATEST_OR_NEWER would be false if the target version is less than the current latest version
 if [ ${MAJOR_UPDATE} == "true" ] || [ ${MINOR_UPDATE} == "true" ] || [ ${PATCH_UPDATE} == "true" ] || [ ${SAME_VERSION} == "true" ]; then 
     LATEST_OR_NEWER=true
 else

--- a/tools/workflow/docker-version-compare.sh
+++ b/tools/workflow/docker-version-compare.sh
@@ -91,7 +91,7 @@ elif [ "${TARGET_MAJOR}" -eq "${LATEST_MAJOR}" ]; then
     fi
 fi
 
-#if any of the versions are true, then ANY_UPDATE = true
+#if any of the updates are true, then ANY_UPDATE = true
 if [ ${MAJOR_UPDATE} == "true" ] || [ ${MINOR_UPDATE} == "true" ] || [ ${PATCH_UPDATE} == "true" ] || [ ${SAME_VERSION} == "true" ]; then 
     ANY_UPDATE=true
 else

--- a/tools/workflow/docker-version-compare.sh
+++ b/tools/workflow/docker-version-compare.sh
@@ -26,7 +26,7 @@ set -e
 #
 # Step outputs
 # (All booleans: true/false)
-# 1. LATEST_OR_NEWER
+# 1. latest-or-newer
 # 2. major-update
 # 3. minor-update
 # 4. patch-update

--- a/tools/workflow/docker-version-compare.sh
+++ b/tools/workflow/docker-version-compare.sh
@@ -102,6 +102,6 @@ fi
 echo "::set-output name=major-update::${MAJOR_UPDATE}"
 echo "::set-output name=minor-update::${MINOR_UPDATE}"
 echo "::set-output name=patch-update::${PATCH_UPDATE}"
-echo "::set-output name=any-update::${LATEST_OR_NEWER}"
+echo "::set-output name=latest-or-newer::${LATEST_OR_NEWER}"
 echo "::set-output name=same-version::${SAME_VERSION}"
 

--- a/tools/workflow/docker-version-compare.sh
+++ b/tools/workflow/docker-version-compare.sh
@@ -26,7 +26,7 @@ set -e
 #
 # Step outputs
 # (All booleans: true/false)
-# 1. any-update
+# 1. LATEST_OR_NEWER
 # 2. major-update
 # 3. minor-update
 # 4. patch-update
@@ -91,15 +91,17 @@ elif [ "${TARGET_MAJOR}" -eq "${LATEST_MAJOR}" ]; then
     fi
 fi
 
-#if any of the updates are true, then ANY_UPDATE = true
+# If any of the updates are true, then LATEST_OR_NEWER = true
+# LATEST_OR_NEWER would be false if the target version is less than the current latest version or vice cersa
 if [ ${MAJOR_UPDATE} == "true" ] || [ ${MINOR_UPDATE} == "true" ] || [ ${PATCH_UPDATE} == "true" ] || [ ${SAME_VERSION} == "true" ]; then 
-    ANY_UPDATE=true
+    LATEST_OR_NEWER=true
 else
-    ANY_UPDATE=false
+    LATEST_OR_NEWER=false
 fi
 
 echo "::set-output name=major-update::${MAJOR_UPDATE}"
 echo "::set-output name=minor-update::${MINOR_UPDATE}"
 echo "::set-output name=patch-update::${PATCH_UPDATE}"
-echo "::set-output name=any-update::${ANY_UPDATE}"
+echo "::set-output name=any-update::${LATEST_OR_NEWER}"
 echo "::set-output name=same-version::${SAME_VERSION}"
+


### PR DESCRIPTION
**Description:** 

Changed the part of setting up the appropriate  `ANY_UPDATE ` boolean value in accordance to the target update for better code readability. 
The unlikely but possible problem with the old approach is if the ANY_UPDATE=true command were to fail, then ANY_UPDATE=false would be executed 

**Link to tracking Issue:** 
https://github.com/aws-observability/aws-otel-collector/issues/1008

**Testing:** 
Ran the bash scripts locally to verify the output.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
