### PR TITLE
Add simple job to end of e2etest-eks-arm64 workflow

### DIFF
--- a/.github/workflows/CI-e2etest-eks-arm64.yml
+++ b/.github/workflows/CI-e2etest-eks-arm64.yml
@@ -109,10 +109,6 @@ jobs:
     if: ${{ always() }}
     needs: [e2etest-eks-arm64]
     steps:
-      - name: Output payload
-        run: |
-          echo 'Triggering ci-cleanup with payload of:'
-          echo '${{ toJSON(github.event.client_payload) }}'
       - name: Trigger CI-cleaup
         uses: peter-evans/repository-dispatch@v2
         with:

--- a/.github/workflows/CI-e2etest-eks-arm64.yml
+++ b/.github/workflows/CI-e2etest-eks-arm64.yml
@@ -109,6 +109,10 @@ jobs:
     if: ${{ always() }}
     needs: [e2etest-eks-arm64]
     steps:
+      - name: Output payload
+        run: |
+          echo 'Triggering ci-cleanup with payload of:'
+          echo '${{ toJSON(github.event.client_payload) }}'
       - name: Trigger CI-cleaup
         uses: peter-evans/repository-dispatch@v2
         with:
@@ -116,3 +120,11 @@ jobs:
           event-type: trigger-ci-cleanup
           # pass the same payload that was received.
           client-payload: ${{ toJSON(github.event.client_payload) }}
+
+  echoComplete:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [triggerWorkflow]
+    steps:
+      - name: Complete Message
+        run: echo 'Workflow complete'


### PR DESCRIPTION
**Description:** Currently the new test pipeline is working as intended. Workflows are correctly triggering the next step in the pipeline. An odd behavior is occurring where upon completion of the repository dispatch, the workflow will complete successfully but show as cancelled in the GitHub UI. It is not entirely clear why this is happening and the repository dispatch actions documentation does not provide an immediate answer. 

We use this repository dispatch action in our main CI workflow and do not see this behavior. The current hypothesis is that this is due to the dispatch being the last job. I have added a job after the repository dispatch that does a simple echo to test this theory. 

**Testing:** No testing was done, this is a simple change to test a working hypothesis. This change has very low blast radius. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
