### PR TITLE
Add routing and groupbyattrs processor from opentelemetry-collector-contrib source

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ This table represents the supported components of the ADOT Collector. The highli
 |                                 | `metricsgenerationprocessor`  | dynatraceexporter                  |                        |
 |                                 | cumulativetodeltaprocessor    | sapmexporter                       |                        |
 |                                 | deltatorateprocessor          | signalfxexporter                   |                        |
-|                                 |                               | logzioexporter                     |                        |
+|                                 | routing                       | logzioexporter                     |                        |
+|                                 | groupbyattrs                  |                                    |                        |
 
 
 #### ADOT Collector AWS Components

--- a/go.mod
+++ b/go.mod
@@ -199,6 +199,8 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.47.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/signalfx v0.47.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.47.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.47.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.47.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1652,6 +1652,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatoratep
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor v0.47.0/go.mod h1:Ko01lEjKsB82oItKGuHNdHKh+zzNQHYQ5RqRFckzHCQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.47.0 h1:nqieRUCVLO9gw0ZCja5G7iAvpM5DkjKw9GPVx9zg7PY=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.47.0/go.mod h1:ZMde9yYtbJiiX8iVYGiQ8xRqbyVjRVL1/TcX4huHH/4=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.47.0 h1:1QxX4Z7h3F+WQ0mLP8iMxP0+y3O4ZZ+R+tY7D4U/8nA=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.47.0/go.mod h1:oPnRiXoQQfp2AZv8U8nGNt/c2gl4fQ1M/iM+nwkBQpM=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor v0.47.0 h1:lWvqZt6OCY7nbxreyDjXMyaZ8B1wiIi/2VeJyV8HyHE=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor v0.47.0/go.mod h1:h8ncCBqkLgbRh8FhoTGZ/w1k3HkRSjNnj9GOwV81MZA=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.47.0 h1:36Wa7aQB+3+pYx9IXZB/Wx/uyKC3/U0sveh78ZDsd7s=
@@ -1662,6 +1664,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedete
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.47.0/go.mod h1:dr5S/hsCAcI+6ecdhQQGxxtddwxo2ibzrlnJoctrYhY=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.47.0 h1:x6dXToy1mjfrXlIn6T28QuAW3C2Qz9aXBBset6PipUk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.47.0/go.mod h1:ridn83v8vPHwUbXlLL+55DJJTwVZVTqAJIpqfEJEfW0=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.47.0 h1:fFhKKNHXDbzM4tRgHdLifvO8SpFU7N2nAksEvpb69+s=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.47.0/go.mod h1:0zECJ0PuPaizfw1WXat0w8yhuFppm9adBs2T0+vV6aU=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.47.0 h1:Z/R/KRL550aS/o8AQjjZF19TiY7CI6dwza4otfSktdo=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.47.0/go.mod h1:R5bWKcomtePzavm3rOx3vT427Sy8/CidT8mwedSK22A=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.47.0 h1:kqcAQDmxaPd8HBkHhrhhgTWbUB06bdr1AFElc66I1LU=

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -34,11 +34,13 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver"
@@ -104,6 +106,8 @@ func Components() (component.Factories, error) {
 		deltatorateprocessor.NewFactory(),
 		batchprocessor.NewFactory(),
 		memorylimiterprocessor.NewFactory(),
+		routingprocessor.NewFactory(),
+		groupbyattrsprocessor.NewFactory(),
 	)
 
 	if err != nil {

--- a/pkg/defaultcomponents/defaults_test.go
+++ b/pkg/defaultcomponents/defaults_test.go
@@ -25,7 +25,7 @@ const (
 	exportersCount  = 13
 	receiversCount  = 8
 	extensionsCount = 6
-	processorCount  = 12
+	processorCount  = 14
 )
 
 func TestComponents(t *testing.T) {

--- a/pkg/defaultcomponents/defaults_test.go
+++ b/pkg/defaultcomponents/defaults_test.go
@@ -93,4 +93,6 @@ func TestComponents(t *testing.T) {
 	require.NotNil(t, processors["resourcedetection"])
 	require.NotNil(t, processors["cumulativetodelta"])
 	require.NotNil(t, processors["deltatorate"])
+	require.NotNil(t, processors["routing"])
+	require.NotNil(t, processors["groupbyattrs"])
 }


### PR DESCRIPTION
**Description:** 
[OpenTelemetry Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) repo has `routing` and `groupbyattrs` processors but the aws otel collector does not have it.

Adding those two processors. 

**Link to tracking Issue:**
#1100 

**Testing:** 
Added test for the number of processors and both processor availability in existing tests

**Documentation:**
Changed Readme.md file and added those two processors

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
