### PR TITLE
Remove usage of `go get` in favor of `go install`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           go-version: '^1.17.7'
       - name: Install Go tools
-        run: cd /tmp && go get -u golang.org/x/tools/cmd/goimports
+        run: cd /tmp && go install golang.org/x/tools/cmd/goimports
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           go-version: '^1.17.7'
       - name: Install Go tools
-        run: cd /tmp && go get -u golang.org/x/tools/cmd/goimports
+        run: cd /tmp && go install golang.org/x/tools/cmd/goimports
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil


### PR DESCRIPTION
**Description:** The use of `go get` to install Go packages was removed in Go `v1.18`. This PR updates the deprecated commands to use `go install` instead. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
