### PR TITLE
Use latest version tag in go install for workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           go-version: '^1.17.7'
       - name: Install Go tools
-        run: cd /tmp && go install golang.org/x/tools/cmd/goimports
+        run: cd /tmp && go install golang.org/x/tools/cmd/goimports@latest
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           go-version: '^1.17.7'
       - name: Install Go tools
-        run: cd /tmp && go install golang.org/x/tools/cmd/goimports
+        run: cd /tmp && go install golang.org/x/tools/cmd/goimports@latest
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil


### PR DESCRIPTION
**Description:** Go install requires a version tag when not installing from with a module. 



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
