### PR TITLE
Remove tool installation for aotutil build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,8 +81,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '^1.17.7'
-      - name: Install Go tools
-        run: cd /tmp && go install golang.org/x/tools/cmd/goimports
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -59,8 +59,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '^1.17.7'
-      - name: Install Go tools
-        run: cd /tmp && go install golang.org/x/tools/cmd/goimports
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil


### PR DESCRIPTION
**Description:** Tool installation is no longer required to build the aotutil image. This requirement was removed in this [PR](https://github.com/aws-observability/aws-otel-test-framework/pull/614)


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
