### PR TITLE
Pin go version to ~1.17.7

### DIFF
--- a/.github/workflows/CD-adot-operator.yml
+++ b/.github/workflows/CD-adot-operator.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.17.7
+          go-version: ~1.17.7
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -610,7 +610,7 @@ jobs:
         if: steps.release-latest-image.outputs.cache-hit != 'true'
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.7'
+          go-version: '~1.17.7'
 
       - name: Compare version with Dockerhub latest
         id: version

--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.7'
+          go-version: '~1.17.7'
       - name: Install Go tools
         run: cd /tmp && go get -u golang.org/x/tools/cmd/goimports
       - name: Build aotutil
@@ -88,7 +88,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.17.7'
+        go-version: '~1.17.7'
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.7'
+          go-version: '~1.17.7'
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil
@@ -99,7 +99,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.17.7'
+        go-version: '~1.17.7'
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -76,7 +76,7 @@ jobs:
       if: ${{ needs.changes.outputs.changed == 'true' }}
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.17.7'
+        go-version: '~1.17.7'
 
     - name: Checkout
       if: ${{ needs.changes.outputs.changed == 'true' }}

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.7'
+          go-version: '~1.17.7'
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil


### PR DESCRIPTION
**Description:** Pins go version to `~1.17.7` which includes all patch versions up to `v1.18.0` according to semver doc [here](https://github.com/npm/node-semver#tilde-ranges-123-12-1). 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
