### PR TITLE
Cleanup resources in us-east-2

### DIFF
--- a/.github/workflows/weekly-resources-clean.yml
+++ b/.github/workflows/weekly-resources-clean.yml
@@ -34,6 +34,7 @@ jobs:
       max-parallel: 3
       matrix:
         resource: [autoscaling, ec2, ecs, efs, iam, launchconfig, loadbalancer, ebs]
+        region: [us-west-2, us-east-2]
     steps:
       - uses: actions/checkout@v3
 
@@ -42,7 +43,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
-          aws-region: us-west-2
+          aws-region: ${{ matrix.region }}
 
       - name: Update days to keep
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
**Description:**  This PR adds an additional matrix item to the `weekly-resources-clean.yml`. This will ensure that all cleaners are also ran in `us-east-2`. 

**Testing:** None. Cleaners are already running but region needed to be added. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
