### PR TITLE
Push Image to Private ECR repository

### DIFF
--- a/.github/workflows/CD-adot-operator.yml
+++ b/.github/workflows/CD-adot-operator.yml
@@ -23,6 +23,8 @@ on:
 jobs:           
   release-latest-image:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v3
 
@@ -40,10 +42,32 @@ jobs:
 
       - name: Version checking
         id: version
-        run: VERSION="${{ github.event.inputs.version }}" bash tools/release/adot-operator-images-mirror/version-check.sh
+        run: |
+          VERSION="${{ github.event.inputs.version }}" bash tools/release/adot-operator-images-mirror/version-check.sh
+          echo "::set-output name=version::$VERSION"
 
       - name: Mirror ADOT operator
         if: ${{ steps.version.outputs.update-operator == 'true' }}
         run: cd tools/release/adot-operator-images-mirror && go run ./
         env:
           AWS_SDK_LOAD_CONFIG: true
+
+  push-to-private-ecr:
+    runs-on: ubuntu-latest
+    needs : release-latest-image
+    steps:
+
+      - name: Login to ECR
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.INTEG_TEST_ACCOUNT }}.dkr.ecr.us-east-1.amazonaws.com
+          username: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          password: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+        env:
+          AWS_REGION: us-east-1
+
+      - name: Pull image from public ECR and upload to Private ECR Repository
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: public.ecr.aws/aws-observability/adot-operator:${{ needs.release-latest-image.outputs.version }}
+          dst: ${{ secrets.INTEG_TEST_ACCOUNT }}.dkr.ecr.us-east-1.amazonaws.com/aws-otel-test/adot-operator:${{ needs.release-latest-image.outputs.version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -529,7 +529,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: public.ecr.aws/${{ env.ECR_REPO }}
+          images: |
+            public.ecr.aws/${{ env.ECR_REPO }}
+            611364707713.dkr.ecr.us-east-1.amazonaws.com/${{ env.ECR_REPO }}
 
       #Build the adot collector image for two primary reasons:
       #-Using the adot collector image to do the integration test
@@ -545,6 +547,8 @@ jobs:
           tags: |
             public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.e2etest-preparation.outputs.version }}
             public.ecr.aws/${{ env.ECR_REPO }}:latest
+            611364707713.dkr.ecr.us-east-1.amazonaws.com/${{ env.ECR_REPO }}:${{ needs.e2etest-preparation.outputs.version }}
+            611364707713.dkr.ecr.us-east-1.amazonaws.com/${{ env.ECR_REPO }}:latest
           build-args: BUILDMODE=copy
           cache-from: type=registry
           cache-to: type=inline

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -529,9 +529,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: |
-            public.ecr.aws/${{ env.ECR_REPO }}
-            611364707713.dkr.ecr.us-east-1.amazonaws.com/${{ env.ECR_REPO }}
+          images: public.ecr.aws/${{ env.ECR_REPO }}
 
       #Build the adot collector image for two primary reasons:
       #-Using the adot collector image to do the integration test
@@ -547,8 +545,6 @@ jobs:
           tags: |
             public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.e2etest-preparation.outputs.version }}
             public.ecr.aws/${{ env.ECR_REPO }}:latest
-            611364707713.dkr.ecr.us-east-1.amazonaws.com/${{ env.ECR_REPO }}:${{ needs.e2etest-preparation.outputs.version }}
-            611364707713.dkr.ecr.us-east-1.amazonaws.com/${{ env.ECR_REPO }}:latest
           build-args: BUILDMODE=copy
           cache-from: type=registry
           cache-to: type=inline
@@ -1186,7 +1182,7 @@ jobs:
   release-candidate:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && !contains(github.ref_name,'test/') # only create the artifact when there's a push, not for dispatch.
-    needs: [e2etest-eks, e2etest-eks-arm64, e2etest-eks-adot-operator, e2etest-eks-fargate, e2etest-ecs, e2etest-ec2-1, e2etest-ec2-2, e2etest-ec2-3]
+    needs: [e2etest-preparation, e2etest-eks, e2etest-eks-arm64, e2etest-eks-adot-operator, e2etest-eks-fargate, e2etest-ecs, e2etest-ec2-1, e2etest-ec2-2, e2etest-ec2-3]
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -1194,6 +1190,21 @@ jobs:
           aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
           aws-region: us-west-2
+
+      - name: Login to ECR
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.INTEG_TEST_ACCOUNT }}.dkr.ecr.us-east-1.amazonaws.com
+          username: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          password: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+        env:
+          AWS_REGION: us-east-1
+
+      - name: Pull image from public ECR and upload to Private ECR Repository
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.e2etest-preparation.outputs.version }}
+          dst: ${{ secrets.INTEG_TEST_ACCOUNT }}.dkr.ecr.us-east-1.amazonaws.com/${{ env.ECR_REPO }}:${{ needs.e2etest-preparation.outputs.version }}
 
       - name: restore cached packages
         uses: actions/cache@v3


### PR DESCRIPTION
**Description:**

This PR allows to push the ADOT Collector image to the private registry during the CI workflow. ADOT operator image duirng the CD workflow

By pushing the image to the private repository it allows us to utilize the ECR enhanced scanning on these images to find vulnerabilities.

**Documentation:** 

N/A

Testing :
 
[local fork](https://github.com/vasireddy99/aws-otel-collector/runs/5892590795?check_suite_focus=true)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
