### PR TITLE
Remove Highlight from `statsdreceiver` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This table represents the supported components of the ADOT Collector. The highli
 | otlpreceiver                    | resourceprocessor             | `awsemfexporter`                   | pprofextension         |
 | `awsecscontainermetricsreceiver`| batchprocessor                | `awsprometheusremotewriteexporter`* | zpagesextension        |
 | `awsxrayreceiver`               | memorylimiterprocessor        | loggingexporter                    | `ecsobserver`          |
-| `statsdreceiver`                | probabilisticsamplerprocessor | otlpexporter                       | `awsproxy`             |
+| statsdreceiver                  | probabilisticsamplerprocessor | otlpexporter                       | `awsproxy`             |
 | zipkinreceiver                  | metricstransformprocessor     | fileexporter                       | ballastextention       |
 | jaegerreceiver                  | spanprocessor                 | otlphttpexporter                   | `sigv4authextension`   |
 | `awscontainerinsightreceiver`   | filterprocessor               | prometheusexporter                 |                        |


### PR DESCRIPTION
**Description:** 
Remove the highlight from `statsdreceiver` as it is not developed by AWS in-house.




<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
