### PR TITLE
Set TTL_Date in CI-Batched

### DIFF
--- a/.github/workflows/CI-Batched.yml
+++ b/.github/workflows/CI-Batched.yml
@@ -587,9 +587,13 @@ jobs:
           jsonStr="$(jq -r '.${{ matrix.BatchKey }} | join("\n")' <<< "${jsonStr}")"
           echo "$jsonStr" >> testing-framework/terraform/test-case-batch
           cat testing-framework/terraform/test-case-batch
+      - name: Get TTL_DATE for cache
+        id: date
+        run: echo "::set-output name=ttldate::$(date -u -d "+10 days")"
 
       - name: run tests
         run: |
+          export TTL_DATE=${{ steps.date.outputs.ttldate }}
           export TF_VAR_aoc_version=${{ needs.e2etest-preparation.outputs.version }}
           cd testing-framework/terraform
           make execute-batch-test


### PR DESCRIPTION
**Description:** Sets TTL date using unix compatible date command for use in DDB cache


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
