### PR TITLE
Convert date to seconds

### DIFF
--- a/.github/workflows/CI-Batched.yml
+++ b/.github/workflows/CI-Batched.yml
@@ -589,7 +589,7 @@ jobs:
           cat testing-framework/terraform/test-case-batch
       - name: Get TTL_DATE for cache
         id: date
-        run: echo "::set-output name=ttldate::$(date -u -d "+10 days")"
+        run: echo "::set-output name=ttldate::$(date -u -d "+7 days" +%s)"
 
       - name: run tests
         run: |


### PR DESCRIPTION
**Description:** Convert date to second for use as the TTL time for DDB. Also change from 7 to 10 days. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
