### PR TITLE
Add cache miss output step

### DIFF
--- a/.github/workflows/CI-Batched.yml
+++ b/.github/workflows/CI-Batched.yml
@@ -610,6 +610,12 @@ jobs:
           export TF_VAR_aoc_version=${{ needs.e2etest-preparation.outputs.version }}
           cd testing-framework/terraform
           make execute-batch-test
+          
+      - name: output cache misses
+        run: |
+          export TF_VAR_aoc_version=${{ needs.e2etest-preparation.outputs.version }}
+          cd testing-framework/terraform
+          make checkCacheHits
 
   clean-ssm-package:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description:** Add step to end of batch job to output cache misses which indicates that a job has not passed successfully. 



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
