### PR TITLE
execute cache miss output on failure

### DIFF
--- a/.github/workflows/CI-Batched.yml
+++ b/.github/workflows/CI-Batched.yml
@@ -612,6 +612,7 @@ jobs:
           make execute-batch-test
           
       - name: output cache misses
+        if: ${{ failure() }}
         run: |
           export TF_VAR_aoc_version=${{ needs.e2etest-preparation.outputs.version }}
           cd testing-framework/terraform


### PR DESCRIPTION
**Description:** Currently cache miss output does not execute on failure. This will ensure that this step is only ran if previous step does not finish successfully. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
