### PR TITLE
Setup terraform and JDK in batched worfklow

### DIFF
--- a/.github/workflows/CI-Batched.yml
+++ b/.github/workflows/CI-Batched.yml
@@ -579,6 +579,15 @@ jobs:
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.test-case-batch-key) }}
 
     steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Set up terraform
+        uses: hashicorp/setup-terraform@v2
+
       - name: Configure AWS Credentials
         if: steps.e2etest-eks.outputs.cache-hit != 'true'
         uses: aws-actions/configure-aws-credentials@v1
@@ -587,7 +596,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
           aws-region: us-west-2
       
-      - name: Checkout
+      - name: Checkout testing framework
         uses: actions/checkout@v3
         with:
           repository: ${{ env.TESTING_FRAMEWORK_REPO }}


### PR DESCRIPTION
**Description:** The PR adds the `setup-terraform` and `setup-java` actions to better match the previous `CI` workflow. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
