### PR TITLE
Add validate and release-candidate jobs

### DIFF
--- a/.github/workflows/CI-Batched.yml
+++ b/.github/workflows/CI-Batched.yml
@@ -662,3 +662,72 @@ jobs:
         run: |
           aws ssm describe-document --name ${{ env.SSM_PACKAGE_NAME }} --version-name ${{ steps.versioning.outputs.ssm_pkg_version }} >/dev/null 2>&1 && \
             aws ssm delete-document --name ${{ env.SSM_PACKAGE_NAME }} --version-name ${{ steps.versioning.outputs.ssm_pkg_version }}
+
+  validate-all-tests-pass:
+    runs-on: ubuntu-latest
+    needs: [run-batch-job,e2etest-preparation]
+    outputs:
+      release-candidate-ready: ${{ steps.set-release-candidate.outputs.release-candidate-ready }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
+          path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~1.17.7'
+
+      - name: Create test batch key values
+        id: set-release-candidate
+        run: |
+          cd testing-framework/tools/batchTestGenerator
+          go build
+          ./batchTestGenerator validate --testCaseFilePath=./testcases.json \
+            --eksarm64amp=${{ env.EKS_ARM_64_AMP_ENDPOINT }} \
+            --eksarm64region=${{ env.EKS_ARM_64_REGION }} \
+            --eksarm64cluster=${{ env.EKS_ARM_64_CLUSTER_NAME }} \
+            --ddbtable=${{ env.DDB_TABLE_NAME }} \
+            --aocVersion=${{ needs.e2etest-preparation.outputs.version }}
+
+  release-candidate:
+    runs-on: ubuntu-latest
+    # TODO after this becomes primary CI workflow, add in conditional to not release on Dispatch. See CI.yml release-candidate job.
+    if:   needs.validate-all-tests-pass.outputs.release-candidate-ready == 'true' 
+    needs: validate-all-tests-pass
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+
+      - name: restore cached packages
+        uses: actions/cache@v3
+        with:
+          path: "${{ env.PACKAGING_ROOT }}"
+          key: "cached_packages_${{ github.run_id }}"
+
+      - name: prepare production version
+        run: |
+          TESTING_VERSION=`cat $PACKAGING_ROOT/VERSION`
+          VERSION=`echo $TESTING_VERSION | awk -F "-" '{print $1}'`
+          echo $VERSION > $PACKAGING_ROOT/VERSION
+          echo $GITHUB_SHA > $PACKAGING_ROOT/GITHUB_SHA
+          echo $TESTING_VERSION > $PACKAGING_ROOT/TESTING_VERSION
+
+      - name: upload packages as release candidate on s3
+        run: |
+          tar czvf $GITHUB_SHA.tar.gz build
+          aws s3 cp $GITHUB_SHA.tar.gz s3://aws-otel-collector-release-candidate/$GITHUB_SHA.tar.gz
+
+      - name: Trigger performance test
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: "${{ secrets.REPO_WRITE_ACCESS_TOKEN }}"
+          event-type: trigger-perf
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
**Description:** Adds `validate-all-tests-pass` and `release-candidate` job to `CI-Batched` workflow. The validate jobs ensure that all jobs are present in the DDB table before setting `release-candidate-ready` output. `Release-candidate` is a direct copy from `CI.yml` with updated `needs` and `if`. 




<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
