### PR TITLE
Remove default for services and increase max jobs

### DIFF
--- a/.github/workflows/CI-Batched.yml
+++ b/.github/workflows/CI-Batched.yml
@@ -18,11 +18,10 @@ on:
       SERVICES:
           description: list of services to run tests again. comma separated. EC2,ECS,EKS,EKS_ADOT_OPERATOR,EKS_ARM64,EKS_FARGATE
           required: false
-          default: ECS
       MAX_JOBS:
           description: maximum number of allowed jobs
           required: false
-          default: '40'
+          default: '90'
 
 env:
   IMAGE_NAME: aws-otel-collector


### PR DESCRIPTION
**Description:** This PR increases the default max jobs and removes the default for service input. This means that if no service values are provided it will run all services by default. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
