### PR TITLE
Trigger canary tests every 3 hours

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -14,7 +14,7 @@
 name: 'Canary Test'
 on:
   schedule:
-    - cron: '0 */4 * * *' # triggers the workflow every four hours
+    - cron: '0 */3 * * *' # triggers the workflow every four hours
 
   # we can manually trigger this workflow by using dispatch for debuging
   repository_dispatch:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Change canary test trigger time from every 4 hours to every 3 hours.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
