### PR TITLE
Update rbac rules for for container insights eks deployment

### DIFF
--- a/deployment-template/eks/otel-container-insights-infra.yaml
+++ b/deployment-template/eks/otel-container-insights-infra.yaml
@@ -22,10 +22,10 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods", "nodes", "endpoints"]
-    verbs: ["list", "watch"]
+    verbs: ["list", "watch", "get"]
   - apiGroups: ["apps"]
     resources: ["replicasets"]
-    verbs: ["list", "watch"]
+    verbs: ["list", "watch", "get"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["list", "watch"]
@@ -38,13 +38,7 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames: ["otel-container-insight-clusterleader"]
-    verbs: ["get","update"]
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - '*'
+    verbs: ["get","update", "create", "patch"]
 
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
**Description:** Updates template to scope down RBAC rules. 

This PR will force a new CI run which will need to have a matching [PR](https://github.com/aws-observability/aws-otel-test-framework/pull/699) made in the test framework first. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
