### PR TITLE
Force terraform version to 1.1.9 in perf test

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -135,6 +135,8 @@ jobs:
       
       - name: Set up terraform
         uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.1.9
       
       - name: Check out testing framework
         uses: actions/checkout@v3


### PR DESCRIPTION
**Description:** Pins terraform version to side step issue reported [here](https://github.com/hashicorp/terraform/issues/31081) that was introduced with version 1.2


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
