### PR TITLE
Cherry picks workflow changes into release/v0.17.x branch

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -602,7 +602,7 @@ jobs:
         if: steps.release-latest-image.outputs.cache-hit != 'true'
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: '~1.17.7'
 
       - name: Compare version with Dockerhub latest
         id: version

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -35,12 +35,27 @@ env:
   TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
   TF_VAR_aoc_vpc_name: aoc-vpc-large
   TF_VAR_aoc_vpc_security_group: aoc-vpc-security-group-large
-  TESTING_FRAMEWORK_REPO: "aws-observability/aws-otel-collector-test-framework"
+  TESTING_FRAMEWORK_REPO: "aws-observability/aws-otel-test-framework"
   SSM_RELEASE_S3_BUCKET: "aws-otel-collector-ssm"
   SSM_RELEASE_PACKAGE_NAME: "AWSDistroOTel-Collector"
   RELEASE_S3_BUCKET: "aws-otel-collector"
 
 jobs:
+  create-test-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      testRef: ${{ steps.setRef.outputs.ref }}
+    steps:
+      - name: Set testRef output
+        id: setRef
+        run: |
+          if [[ ${{ github.ref_name }} == release/v* ]]; then 
+            echo "::set-output name=ref::${{github.ref_name}}"
+          else
+            echo "::set-output name=ref::terraform"
+          fi
+
+
   release-checking: 
     runs-on: ubuntu-latest
     outputs:
@@ -163,7 +178,7 @@ jobs:
 
   s3-release-validation-1:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, release-to-s3, release-checking]
+    needs: [get-testing-suites, release-to-s3, release-checking, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -206,6 +221,7 @@ jobs:
         with:
           repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Run testing suite on ec2
         if: steps.s3-release-validation-1.outputs.cache-hit != 'true'
@@ -225,7 +241,7 @@ jobs:
           
   s3-release-validation-2:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, release-to-s3, release-checking]
+    needs: [get-testing-suites, release-to-s3, release-checking, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -269,6 +285,7 @@ jobs:
         with:
           repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Run testing suite on ec2
         if: steps.s3-release-validation-2.outputs.cache-hit != 'true'
@@ -288,7 +305,7 @@ jobs:
           
   s3-release-validation-3:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, release-to-s3, release-checking]
+    needs: [get-testing-suites, release-to-s3, release-checking, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -332,6 +349,7 @@ jobs:
         with:
           repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef}}
 
       - name: Run testing suite on ec2
         if: steps.s3-release-validation-3.outputs.cache-hit != 'true'
@@ -379,7 +397,7 @@ jobs:
 
   release-validation-ecs:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, release-version-image, release-checking]
+    needs: [get-testing-suites, release-version-image, release-checking, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -423,6 +441,7 @@ jobs:
         with:
           repository: "${{ env.TESTING_FRAMEWORK_REPO }}"
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
           
       - name: Run testing suite on ecs
         if: steps.release-validation-ecs.outputs.cache-hit != 'true'
@@ -442,7 +461,7 @@ jobs:
                   
   release-validation-eks:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, release-version-image, release-checking]
+    needs: [get-testing-suites, release-version-image, release-checking, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -486,6 +505,7 @@ jobs:
         with:
           repository: "${{ env.TESTING_FRAMEWORK_REPO }}"
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef}}
       
       - name: Run testing suite on eks
         if: steps.release-validation-eks.outputs.cache-hit != 'true'

--- a/.github/workflows/CI-Batched.yml
+++ b/.github/workflows/CI-Batched.yml
@@ -78,6 +78,8 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '~1.17.7'
+      - name: Install Go tools
+        run: cd /tmp && go get -u golang.org/x/tools/cmd/goimports
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil

--- a/.github/workflows/CI-Batched.yml
+++ b/.github/workflows/CI-Batched.yml
@@ -78,8 +78,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '~1.17.7'
-      - name: Install Go tools
-        run: cd /tmp && go get -u golang.org/x/tools/cmd/goimports
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,19 +44,39 @@ env:
   WIN_SIGNED_PKG_FOLDER: OTelCollectorAuthenticode/AuthenticodeSigner-SHA256-RSA
   SSM_PACKAGE_NAME: "testAWSDistroOTel-Collector"
   US_EAST_2_AMP_ENDPOINT: "https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-1de68e95-0680-42bb-8e55-67e7fd5d0861"
+  TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
+
+
+
 concurrency:
   group: ci-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
+  create-test-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      testRef: ${{ steps.setRef.outputs.ref }}
+    steps:
+      - name: Set testRef output
+        id: setRef
+        run: |
+          if [[ ${{ github.ref_name }} == release/v* ]]; then 
+            echo "::set-output name=ref::${{github.ref_name}}"
+          else
+            echo "::set-output name=ref::terraform"
+          fi
+
   build-aotutil:
     runs-on: ubuntu-latest
+    needs: create-test-ref
     steps:
       - name: Check out testing framework
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
@@ -583,7 +603,7 @@ jobs:
 
   e2etest-ec2-1:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -623,8 +643,9 @@ jobs:
         if: steps.e2etest-ec2-1.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Restore aoutil
         if: steps.e2etest-ec2-1.outputs.cache-hit != 'true'
@@ -662,7 +683,7 @@ jobs:
 
   e2etest-ec2-2:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -702,8 +723,9 @@ jobs:
         if: steps.e2etest-ec2-2.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Restore aoutil
         if: steps.e2etest-ec2-2.outputs.cache-hit != 'true'
@@ -741,7 +763,7 @@ jobs:
 
   e2etest-ec2-3:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -781,8 +803,9 @@ jobs:
         if: steps.e2etest-ec2-3.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Restore aoutil
         if: steps.e2etest-ec2-3.outputs.cache-hit != 'true'
@@ -820,7 +843,7 @@ jobs:
 
   e2etest-ecs:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -860,8 +883,9 @@ jobs:
         if: steps.e2etest-ecs.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Run testing suite on ecs
         if: steps.e2etest-ecs.outputs.cache-hit != 'true'
@@ -892,7 +916,7 @@ jobs:
 
   e2etest-eks:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -932,8 +956,9 @@ jobs:
         if: steps.e2etest-eks.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Run testing suite on eks
         if: steps.e2etest-eks.outputs.cache-hit != 'true'
@@ -953,7 +978,7 @@ jobs:
 
   e2etest-eks-arm64:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -993,8 +1018,9 @@ jobs:
         if: steps.e2etest-eks-arm64.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Run testing suite on eks
         if: steps.e2etest-eks-arm64.outputs.cache-hit != 'true'
@@ -1015,7 +1041,7 @@ jobs:
 
   e2etest-eks-fargate:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -1055,8 +1081,9 @@ jobs:
         if: steps.e2etest-eks-fargate.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Run testing suite on eks
         if: steps.e2etest-eks-fargate.outputs.cache-hit != 'true'
@@ -1090,7 +1117,7 @@ jobs:
 
   e2etest-eks-adot-operator:
     runs-on: ubuntu-latest
-    needs: [get-testing-suites, e2etest-release, e2etest-preparation]
+    needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref]
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -1130,8 +1157,9 @@ jobs:
         if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Run ADOT Operator testing suite on eks
         if: steps.e2etest-eks-adot-operator.outputs.cache-hit != 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,8 +81,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '~1.17.7'
-      - name: Install Go tools
-        run: cd /tmp && go get -u golang.org/x/tools/cmd/goimports
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: '~1.17.7'
       - name: Install Go tools
         run: cd /tmp && go get -u golang.org/x/tools/cmd/goimports
       - name: Build aotutil
@@ -101,7 +101,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: '~1.17.7'
 
     - uses: actions/checkout@v2
 

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -24,12 +24,27 @@ on:
 env:
   IMAGE_NAME: aws-otel-collector
   PACKAGING_ROOT: build/packages 
+  TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
 
 concurrency:
   group: pr-build-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
+  create-test-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      testRef: ${{ steps.setRef.outputs.ref }}
+    steps:
+      - name: Set testRef output
+        id: setRef
+        run: |
+          if [[ ${{ github.ref_name }} == release/v* ]]; then 
+            echo "::set-output name=ref::${{github.ref_name}}"
+          else
+            echo "::set-output name=ref::terraform"
+          fi
+
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -202,7 +217,7 @@ jobs:
           
   run-test-case:
     runs-on: ubuntu-latest
-    needs: [changes, get-test-cases, build]
+    needs: [changes, get-test-cases, build, create-test-ref]
     strategy:
       matrix: ${{ fromJson(needs.get-test-cases.outputs.matrix) }}
     steps:
@@ -210,8 +225,9 @@ jobs:
         if: ${{ needs.changes.outputs.changed == 'true' }}
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
 
       - name: Check out Collector
         if: ${{ needs.changes.outputs.changed == 'true' }}

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -76,7 +76,7 @@ jobs:
       if: ${{ needs.changes.outputs.changed == 'true' }}
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: '~1.17.7'
 
     - name: Checkout
       if: ${{ needs.changes.outputs.changed == 'true' }}

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -55,9 +55,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
-      - name: Install Go tools
-        run: cd /tmp && go get -u golang.org/x/tools/cmd/goimports
+          go-version: '~1.17.7'
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -24,16 +24,34 @@ env:
   TF_VAR_aws_access_key_id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
   TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
   TF_VAR_patch: 'true'
+  TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
 
 jobs:
+  create-test-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      testRef: ${{ steps.setRef.outputs.ref }}
+    steps:
+      - name: Set testRef output
+        id: setRef
+        run: |
+          if [[ ${{ github.ref_name }} == release/v* ]]; then 
+            echo "::set-output name=ref::${{github.ref_name}}"
+          else
+            echo "::set-output name=ref::terraform"
+          fi
+
   build-aotutil:
     runs-on: ubuntu-latest
+    needs: create-test-ref
     steps:
       - name: Check out testing framework
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
+
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
@@ -68,7 +86,7 @@ jobs:
 
   run-canary-test:
     runs-on: ubuntu-latest
-    needs: [get-canary-test-cases]
+    needs: [get-canary-test-cases, create-test-ref]
     strategy:
       matrix: ${{ fromJson(needs.get-canary-test-cases.outputs.canary_matrix) }}
       fail-fast: false
@@ -96,8 +114,10 @@ jobs:
       - name: Check out testing framework
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
+
       - name: Restore aoutil
         uses: actions/cache@v2
         with:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -28,8 +28,23 @@ env:
   MAX_BENCHMARKS_TO_KEEP: 100
   COMMIT_USER: Github Actions
   COMMIT_EMAIL: actions@github.com
+  TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   
 jobs:
+  create-test-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      testRef: ${{ steps.setRef.outputs.ref }}
+    steps:
+      - name: Set testRef output
+        id: setRef
+        run: |
+          if [[ ${{ github.ref_name }} == release/v* ]]; then 
+            echo "::set-output name=ref::${{github.ref_name}}"
+          else
+            echo "::set-output name=ref::terraform"
+          fi
+
   get-testing-version:
     runs-on: ubuntu-latest
     outputs:
@@ -98,7 +113,7 @@ jobs:
           
   run-perf-test:
     runs-on: ubuntu-latest
-    needs: [get-perf-test-cases, get-testing-version]
+    needs: [get-perf-test-cases, get-testing-version, create-test-ref]
     strategy:
       matrix: ${{ fromJson(needs.get-perf-test-cases.outputs.perf_matrix) }}
       max-parallel: 10
@@ -124,8 +139,9 @@ jobs:
       - name: Check out testing framework
         uses: actions/checkout@v2
         with:
-          repository: 'aws-observability/aws-otel-collector-test-framework'
+          repository: ${{ env.TESTING_FRAMEWORK_REPO}}
           path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
           
       - name: Run Performance test
         run: |


### PR DESCRIPTION
**Description:** Cherry picks commits `b841c9e` and `d407841` into `release/v0.17.x` branch. These commits force a go versions and ensure the correct release branch is targeted in the test framework repo. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
