### PR TITLE
Change PRBuild to use base_ref instead of ref_name

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -40,7 +40,7 @@ jobs:
         id: setRef
         run: |
           if [[ ${{ github.base_ref }} == release/v* ]]; then 
-            echo "::set-output name=ref::${{github.ref_name}}"
+            echo "::set-output name=ref::${{github.base_ref}}"
           else
             echo "::set-output name=ref::terraform"
           fi

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set testRef output
         id: setRef
         run: |
-          if [[ ${{ github.ref_name }} == release/v* ]]; then 
+          if [[ ${{ github.base_ref }} == release/v* ]]; then 
             echo "::set-output name=ref::${{github.ref_name}}"
           else
             echo "::set-output name=ref::terraform"


### PR DESCRIPTION
**Description:** Updates github context to use `base_ref` instead of `ref_name` for PR-Build


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
