### PR TITLE
Update OTel-http port to match the specification

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:55681
+        endpoint: 0.0.0.0:4318
   awsxray:
     endpoint: 0.0.0.0:2000
     transport: udp

--- a/config/apprunner/apprunner-default-config.yaml
+++ b/config/apprunner/apprunner-default-config.yaml
@@ -5,7 +5,7 @@ receivers:
   otlp:
     protocols:
       grpc: # default endpoint: 0.0.0.0:4317
-      http: # two default endpoints: 0.0.0.0:4318 and 0.0.0.0:55681
+      http: # default endpoint: 0.0.0.0:4318
 
 processors:
   batch:

--- a/config/ecs/container-insights/otel-task-metrics-config.yaml
+++ b/config/ecs/container-insights/otel-task-metrics-config.yaml
@@ -7,7 +7,7 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:55681
+        endpoint: 0.0.0.0:4318
   awsxray:
     endpoint: 0.0.0.0:2000
     transport: udp

--- a/config/ecs/ecs-default-config.yaml
+++ b/config/ecs/ecs-default-config.yaml
@@ -7,7 +7,7 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:55681
+        endpoint: 0.0.0.0:4318
   awsxray:
     endpoint: 0.0.0.0:2000
     transport: udp

--- a/pkg/config/testdata/config.yaml
+++ b/pkg/config/testdata/config.yaml
@@ -7,7 +7,7 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:55681
+        endpoint: 0.0.0.0:4318
   awsxray:
     endpoint: "${XRAY_ENDPOINT}"
     transport: udp


### PR DESCRIPTION
**Description:** 

This PR updates the OTel http port to `4318`, it includes the changes that might have missed in previous PR's

Reference:

 * https://github.com/open-telemetry/opentelemetry-collector/pull/3743

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
