### PR TITLE
Add create-test-ref need in CI-Batched job `release/v0.17.x` branch

### DIFF
--- a/.github/workflows/CI-Batched.yml
+++ b/.github/workflows/CI-Batched.yml
@@ -664,7 +664,7 @@ jobs:
 
   validate-all-tests-pass:
     runs-on: ubuntu-latest
-    needs: [run-batch-job,e2etest-preparation]
+    needs: [run-batch-job,e2etest-preparation,create-test-ref]
     outputs:
       release-candidate-ready: ${{ steps.set-release-candidate.outputs.release-candidate-ready }}
     steps:


### PR DESCRIPTION
**Description:** Adds missing need to ensure the correct ref is checked out in `validate-test-passed` job in `CI-Batched


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
