### PR TITLE
Separate Collector and Operator CI

### DIFF
--- a/.github/workflows/CI-Batched.yml
+++ b/.github/workflows/CI-Batched.yml
@@ -571,7 +571,8 @@ jobs:
           ./batchTestGenerator github --testCaseFilePath=./testcases.json --maxBatch=${{ env.MAX_JOBS }} \
             --eksarm64amp=${{ env.EKS_ARM_64_AMP_ENDPOINT }} \
             --eksarm64region=${{ env.EKS_ARM_64_REGION }} \
-            --eksarm64cluster=${{ env.EKS_ARM_64_CLUSTER_NAME }}
+            --eksarm64cluster=${{ env.EKS_ARM_64_CLUSTER_NAME }} \
+            --include=EKS,ECS,EC2,EKS_ARM64,EKS_FARGATE
       - name: List testing suites
         run: |
           echo ${{ steps.set-batches.outputs.batch-keys }}

--- a/.github/workflows/CI-Operator.yml
+++ b/.github/workflows/CI-Operator.yml
@@ -1,0 +1,150 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+name: C/I-Operator
+on: workflow_dispatch
+
+env:
+  EKS_ARM_64_AMP_ENDPOINT: "https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-1de68e95-0680-42bb-8e55-67e7fd5d0861"
+  EKS_ARM_64_CLUSTER_NAME: "integ-test-arm64-cluster"
+  EKS_ARM_64_REGION: "us-east-2"
+  TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
+  # DDB_TABLE_NAME: BatchTestCache
+  NUM_BATCHES: 1
+
+
+concurrency:
+  group: ci-batched${{ github.ref_name }}
+  cancel-in-progress: true  
+
+jobs:
+  create-test-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      testRef: ${{ steps.setRef.outputs.ref }}
+    steps:
+      - name: Set testRef output
+        id: setRef
+        run: |
+          if [[ ${{ github.ref_name }} == release/v* ]]; then 
+            echo "::set-output name=ref::${{github.ref_name}}"
+          else
+            echo "::set-output name=ref::terraform"
+          fi
+
+  get-testing-suites: 
+    runs-on: ubuntu-latest
+    needs: [create-test-ref]
+    outputs:
+      test-case-batch-key: ${{ steps.set-batches.outputs.batch-keys }}
+      test-case-batch-value: ${{ steps.set-batches.outputs.batch-values }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
+          path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~1.17.7'
+
+      - name: Create test batch key values
+        id: set-batches
+        run: |
+          cd testing-framework/tools/batchTestGenerator
+          go build
+          ./batchTestGenerator github --testCaseFilePath=./testcases.json --maxBatch=${{ env.NUM_BATCHES }} \
+            --eksarm64amp=${{ env.EKS_ARM_64_AMP_ENDPOINT }} \
+            --eksarm64region=${{ env.EKS_ARM_64_REGION }} \
+            --eksarm64cluster=${{ env.EKS_ARM_64_CLUSTER_NAME }} \
+            --include=EKS_ADOT_OPERATOR
+      - name: List testing suites
+        run: |
+          echo ${{ steps.set-batches.outputs.batch-keys }}
+          echo ${{ steps.set-batches.outputs.batch-values }}
+
+  run-batch-job:
+    runs-on: ubuntu-latest
+    needs: [get-testing-suites, create-test-ref]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.get-testing-suites.outputs.test-case-batch-key) }}
+
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Set up terraform
+        uses: hashicorp/setup-terraform@v2
+
+      - name: Configure AWS Credentials
+        if: steps.e2etest-eks.outputs.cache-hit != 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+          aws-region: us-west-2
+      
+      - name: Checkout testing framework
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
+          path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
+
+      - name: create test-case-batch file
+        run: |
+          jsonStr='${{ needs.get-testing-suites.outputs.test-case-batch-value }}'
+          jsonStr="$(jq -r '.${{ matrix.BatchKey }} | join("\n")' <<< "${jsonStr}")"
+          echo "$jsonStr" >> testing-framework/terraform/test-case-batch
+          cat testing-framework/terraform/test-case-batch
+
+      - name: Get TTL_DATE for cache
+        id: date
+        run: echo "::set-output name=ttldate::$(date -u -d "+7 days" +%s)"
+
+      # version used is the same as determined during 'e2etest-preparation' to ensure same 'adot-collector-integration-test' image is used
+      - name: Versioning for testing
+        id: versioning
+        run: |
+          version="$(cat VERSION)-$(git rev-parse --short HEAD)"
+          echo $version > $PACKAGING_ROOT/VERSION
+          cat $PACKAGING_ROOT/VERSION
+          echo "::set-output name=version::$version"
+
+      - name: run tests
+        run: |
+          export TTL_DATE=${{ steps.date.outputs.ttldate }}
+          export TF_VAR_aoc_version=${{ steps.versioning.outputs.version }}
+          cd testing-framework/terraform
+          make execute-batch-test
+          
+      - name: output cache misses
+        if: ${{ failure() }}
+        run: |
+          export TF_VAR_aoc_version=${{ steps.versioning.outputs.version }}
+          cd testing-framework/terraform
+          make checkCacheHits
+      
+      #This is here just in case workflow cancel
+      - name: Destroy resources
+        if: ${{ cancelled() }}
+        run: |
+          cd testing-framework/terraform
+          make terraformCleanup


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR removes the Operator tests from the Collector CI. Additionally, a new workflow, `CI-Operator`, is created, that includes only the Operator CI tests. It runs one batch tests, the `EKS_ADOT_OPERATOR` tests, and is triggered manually. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
