### PR TITLE
Use checkCacheHits instead of batchTest Validate

### DIFF
--- a/.github/workflows/CI-Batched.yml
+++ b/.github/workflows/CI-Batched.yml
@@ -680,9 +680,7 @@ jobs:
 
   validate-all-tests-pass:
     runs-on: ubuntu-latest
-    needs: [run-batch-job,e2etest-preparation,create-test-ref]
-    outputs:
-      release-candidate-ready: ${{ steps.set-release-candidate.outputs.release-candidate-ready }}
+    needs: [run-batch-job,e2etest-preparation,create-test-ref,get-testing-suites]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -703,23 +701,23 @@ jobs:
           aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
           aws-region: us-west-2
 
-      - name: Create test batch key values
-        id: set-release-candidate
+      # combine all test-case-batch values
+      - name: create test-case-batch file
         run: |
-          cd testing-framework/tools/batchTestGenerator
-          go build
-          ./batchTestGenerator validate --testCaseFilePath=./testcases.json \
-            --eksarm64amp=${{ env.EKS_ARM_64_AMP_ENDPOINT }} \
-            --eksarm64region=${{ env.EKS_ARM_64_REGION }} \
-            --eksarm64cluster=${{ env.EKS_ARM_64_CLUSTER_NAME }} \
-            --ddbtable=${{ env.DDB_TABLE_NAME }} \
-            --aocVersion=${{ needs.e2etest-preparation.outputs.version }} \
-            --include=${{ env.BATCH_INCLUDED_SERVICES }}
+          jsonStr='${{ needs.get-testing-suites.outputs.test-case-batch-value }}'
+          jsonStr="$(jq -r '.[] | join("\n")' <<< "${jsonStr}")"
+          echo "$jsonStr" >> testing-framework/terraform/test-case-batch
+          cat testing-framework/terraform/test-case-batch
+
+      - name: output cache misses
+        run: |
+          export TF_VAR_aoc_version=${{ needs.e2etest-preparation.outputs.version }}
+          cd testing-framework/terraform
+          make checkCacheHits
 
   release-candidate:
     runs-on: ubuntu-latest
-    # TODO after this becomes primary CI workflow, add in conditional to not release on Dispatch. See CI.yml release-candidate job.
-    if:   needs.validate-all-tests-pass.outputs.release-candidate-ready == 'true' 
+    if: ${{ always() && needs.validate-all-tests-pass.result == 'success' }}
     needs: validate-all-tests-pass
     steps:
       - name: Configure AWS Credentials


### PR DESCRIPTION
**Description:** This PR changes the logic of `validate-test-pass` to use the make target `checkCacheHits` instead of the BatchTestGenerator `validate` command. This removes the need to maintain the `validate` command in the batch test generator. Doing this means that the generators scope of responsibility remains in generating batch keys and values. 


**Testing:** 
Created test workflow on test branch that executed on PR Build
Test PR with changes [here](https://github.com/bryan-aguilar/aws-otel-collector/pull/147)
GHA run [here](https://github.com/bryan-aguilar/aws-otel-collector/runs/7050026430?check_suite_focus=true)



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
