### PR TITLE
Update go build version to v1.18

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -610,7 +610,7 @@ jobs:
         if: steps.release-latest-image.outputs.cache-hit != 'true'
         uses: actions/setup-go@v3
         with:
-          go-version: '~1.17.7'
+          go-version: '~1.18.1'
 
       - name: Compare version with Dockerhub latest
         id: version

--- a/.github/workflows/CI-Batched.yml
+++ b/.github/workflows/CI-Batched.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: '~1.17.7'
+          go-version: '~1.18.1'
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil
@@ -104,7 +104,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '~1.17.7'
+        go-version: '~1.18.1'
 
     - uses: actions/checkout@v3
 
@@ -559,7 +559,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: '~1.17.7'
+          go-version: '~1.18.1'
 
         # getting the batches would look something like this
         # max jobs could be read as env or passed in as arg depending
@@ -692,7 +692,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: '~1.17.7'
+          go-version: '~1.18.1'
           
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/CI-Operator.yml
+++ b/.github/workflows/CI-Operator.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: '~1.17.7'
+          go-version: '~1.18.1'
 
       - name: Create test batch key values
         id: set-batches

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: '~1.17.7'
+          go-version: '~1.18.1'
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil
@@ -99,7 +99,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: '~1.17.7'
+        go-version: '~1.18.1'
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -76,7 +76,7 @@ jobs:
       if: ${{ needs.changes.outputs.changed == 'true' }}
       uses: actions/setup-go@v3
       with:
-        go-version: '~1.17.7'
+        go-version: '~1.18.1'
 
     - name: Checkout
       if: ${{ needs.changes.outputs.changed == 'true' }}

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: '~1.17.7'
+          go-version: '~1.18.1'
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil


### PR DESCRIPTION
**Description:** Updates the go version used to build the collector with go version `~v1.18.1`


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
