### PR TITLE
Change s3 release to overwrite latest

### DIFF
--- a/tools/release/image-binary-release/s3-release.sh
+++ b/tools/release/image-binary-release/s3-release.sh
@@ -96,16 +96,10 @@ for i in "${local_to_s3_path[@]}"; do
     fi
 
     if [ $upload_to_latest -eq 1 ]; then
-        echo "check if package is already there: ${s3_latest_url}"
-        aws s3api head-object --bucket "${s3_bucket_name}" --key "${s3_latest_key}" >/dev/null || latest_not_exist=true
-        if [ ${latest_not_exist} ]; then
-            echo "upload package ${local_path} to ${s3_latest_url}"
-            aws s3 cp "${local_path}" "${s3_latest_url}" --acl public-read
-        else
-            echo "package ${s3_latest_url} is already there, skip it"
-        fi
+        echo "upload package ${local_path} to ${s3_latest_url}"
+        aws s3 cp "${local_path}" "${s3_latest_url}" --acl public-read
     else
-        echo "skip latest uploading for testing"
+        echo "skip publishing ${s3_latest_url}"
     fi
 
 done


### PR DESCRIPTION
**Description:** Adjusts the logic in the s3 image release used during CD to always upload to latest if the flag is env var is set. Previously the latest upload would skip if there was already a latest image uploaded. 

**Link to tracking Issue:** closes #1210 

**Testing:** Verified that `aws s3 cp` would overwrite a file that was already uploaded on a dev account. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
