### PR TITLE
Add step to set input version on push event

### DIFF
--- a/.github/workflows/CI-Operator.yml
+++ b/.github/workflows/CI-Operator.yml
@@ -129,19 +129,31 @@ jobs:
         id: date
         run: echo "::set-output name=ttldate::$(date -u -d "+7 days" +%s)"
 
+      # Used to set the input string that will be used for comparison in the subsequent
+      # versioning step. This is needed since the inputs.version context will be non existent
+      # on push events. Doing this allows our shell conditional to function correctly. 
+      - name: set input string
+        id: inputString
+        run: |
+          if [[ ${{ github.event_name == push }} ]]; then
+            echo "::set-output name=INPUT_VER::''"
+          else
+            echo "::set-output name=INPUT_VER::${{ github.event.inputs.version }}"
+          fi
+
       # version used is the same as determined during 'e2etest-preparation' to ensure same 'adot-collector-integration-test' image is used
       # if version is specified during manual run of workflow, then that version is used.
       - name: Versioning for testing
         id: versioning
         run: |
-          if [[ ${{ github.event_name }} == 'push' ]] || [[ ${{ github.event.inputs.version }} == '' ]]; then
+          if [[ ${{ github.event_name }} == 'push' ]] || [[ ${{ steps.inputString.outputs.INPUT_VER }} == '' ]]; then
             version="$(cat VERSION)-$(git rev-parse --short HEAD)"
             echo $version > $PACKAGING_ROOT/VERSION
             cat $PACKAGING_ROOT/VERSION
             echo "::set-output name=version::$version"
           else
-            echo "::set-output name=version::${{github.event.inputs.version}}"
-          fi
+            echo "::set-output name=version::${{ steps.inputString.outputs.INPUT_VER }}"
+          fi     
 
       - name: run tests
         run: |

--- a/.github/workflows/CI-Operator.yml
+++ b/.github/workflows/CI-Operator.yml
@@ -18,6 +18,7 @@ on:
       version:
         description: 'the desired version of the Collector to test against the Operator'
         required: false
+        default: ''
 
   push:
     branches:


### PR DESCRIPTION
**Description:** Adds a new step which will set the `INPUT_VER` output for comparison. On `push` events the `inputs.version` context is empty which will lead to an [error in the shell comparison](https://github.com/aws-observability/aws-otel-collector/runs/7096815623?check_suite_focus=true#step:8:22). This will ensure that `INPUT` version is set to an empty string on `push` events. 

A default of `''` was also added to to the version input.

**Link to tracking Issue:** 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
