### PR TITLE
CI OperatorAdd checkout to run-batch job

### DIFF
--- a/.github/workflows/CI-Operator.yml
+++ b/.github/workflows/CI-Operator.yml
@@ -96,6 +96,9 @@ jobs:
       matrix: ${{ fromJson(needs.get-testing-suites.outputs.test-case-batch-key) }}
 
     steps:
+        # required for versioning
+      - uses: actions/checkout@v3
+
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
**Description:** Add checkout of local repository in `CI-Operator` so version can correctly be built. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
