### PR TITLE
Add ls to gain permission

### DIFF
--- a/.github/workflows/CI-Operator.yml
+++ b/.github/workflows/CI-Operator.yml
@@ -145,6 +145,7 @@ jobs:
             echo "::set-output name=INPUT_VER::${{ github.event.inputs.version }}"
           fi
 
+      - run: ls -R
       # version used is the same as determined during 'e2etest-preparation' to ensure same 'adot-collector-integration-test' image is used
       # if version is specified during manual run of workflow, then that version is used.
       - name: Versioning for testing


### PR DESCRIPTION
**Description:** Add `ls -r` run command to mirror `e2e-test-preparation` in `CI-Batched`. Current workflow run is giving a permission [error](https://github.com/aws-observability/aws-otel-collector/runs/7102404366?check_suite_focus=true#step:10:22) when trying to access `VERSION` file. 




<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
