### PR TITLE
Remove packaging steps during versioning

### DIFF
--- a/.github/workflows/CI-Operator.yml
+++ b/.github/workflows/CI-Operator.yml
@@ -153,8 +153,6 @@ jobs:
         run: |
           if [[ ${{ github.event_name }} == 'push' ]] || [[ ${{ steps.inputString.outputs.INPUT_VER }} == '' ]]; then
             version="$(cat VERSION)-$(git rev-parse --short HEAD)"
-            echo $version > $PACKAGING_ROOT/VERSION
-            cat $PACKAGING_ROOT/VERSION
             echo "::set-output name=version::$version"
           else
             echo "::set-output name=version::${{ steps.inputString.outputs.INPUT_VER }}"


### PR DESCRIPTION
**Description:** The CI-Operator does not package any new images and thus the packaging steps are not required during versioning. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
