### PR TITLE
Add operator rollback workflow

### DIFF
--- a/.github/workflows/rollback-operator.yml
+++ b/.github/workflows/rollback-operator.yml
@@ -1,0 +1,51 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+name: Operator Release rollback
+
+on:
+  workflow_dispatch:
+    inputs:
+      rollback-version:
+        description: 'the version number to rollback to'
+        required: true
+
+env:
+  ECR_REPO: aws-observability/adot-operator
+
+jobs:
+  image-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check version exists on Release ECR/DockerHub repos
+        run: |
+          docker manifest inspect public.ecr.aws/$ECR_REPO:${{ github.event.inputs.rollback-version }} > /dev/null
+
+  image-rollback:
+    runs-on: ubuntu-latest
+    needs: [image-check]
+    if: always() && needs.image-check.result == 'success'
+    steps:
+      - name: Login to Public Release ECR
+        uses: docker/login-action@v2
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.RELEASE_KEY_ID }}
+          password: ${{ secrets.RELEASE_SECRET }}
+        env:
+          AWS_REGION: us-east-1
+      - name: Rollback ECR latest
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: public.ecr.aws/${{ env.ECR_REPO }}:${{ github.event.inputs.rollback-version }}
+          dst: public.ecr.aws/${{ env.ECR_REPO }}:latest


### PR DESCRIPTION
**Description:** This PR adds a GitHub Action workflow which will allow us to rollback the latest operator version when necessary. The logic mirrors the image rollback steps for the Collector. No images will be deleted during the rollback. The only change that will be made is updating the `latest` tag. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
