### PR TITLE
Remove Operator release from Collector CD

### DIFF
--- a/.github/workflows/CD-refactor.yml
+++ b/.github/workflows/CD-refactor.yml
@@ -179,35 +179,6 @@ jobs:
             public.ecr.aws/${{ env.ECR_REPO }}:latest
             ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
 
-  release-adot-operator:
-    runs-on: ubuntu-latest
-    needs: [ release-version-image,release-to-s3, release-checking ]
-    steps:
-      #Since the tools in workflow are always up-to-date with the github workflow, we don't need to use the tools in workflows from the committed sha
-      #but using the tools in workflows from the branch triggered with workflow_dispatch.
-      - uses: actions/checkout@v3
-
-      - name: Cache if success
-        id: release-adot-operator
-        uses: actions/cache@v3
-        with:
-          key: release-adot-operator-${{ github.run_id }}
-          path: VERSION
-
-      - name: Configure AWS Credentials
-        if: steps.release-adot-operator.outputs.cache-hit != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.RELEASE_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.RELEASE_SECRET }}
-          aws-region: us-west-2
-
-      - name: Mirror ADOT operator
-        if: ${{ needs.release-checking.outputs.latest-or-newer == 'true' && steps.release-adot-operator.outputs.cache-hit != 'true'}}
-        run: cd tools/release/adot-operator-images-mirror && go run ./
-        env:
-          AWS_SDK_LOAD_CONFIG: true
-  
   release-ssm:
     runs-on: ubuntu-latest
     needs:  [release-version-image,release-to-s3, release-checking]
@@ -229,7 +200,7 @@ jobs:
 
   release-to-github:
     runs-on: ubuntu-latest
-    needs: [ release-ssm, release-to-s3, release-version-image, release-adot-operator, release-checking]
+    needs: [ release-ssm, release-to-s3, release-version-image, release-checking]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
**Description:** ADOT Operator now has isolated CI/CD workflows. ADOT Operator CD should not be a part of ADOT Collector CD

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
