### PR TITLE
[main] Add terraform aws env creds to ci-operator workflow

### DIFF
--- a/.github/workflows/CI-Batched.yml
+++ b/.github/workflows/CI-Batched.yml
@@ -22,6 +22,7 @@ on:
     paths-ignore:
       - '.github/**'
       - '!.github/workflows/CI-Batched.yml'
+      - '!.github/workflows/CI-Operator.yml'
       - '**.md'
 
   # from collector and contrib repo

--- a/.github/workflows/CI-Operator.yml
+++ b/.github/workflows/CI-Operator.yml
@@ -36,6 +36,10 @@ env:
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   DDB_TABLE_NAME: BatchTestCache
   NUM_BATCHES: 1
+  TF_VAR_aws_access_key_id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
+  TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
+  TF_VAR_aoc_vpc_name: aoc-vpc-large
+  TF_VAR_aoc_vpc_security_group: aoc-vpc-security-group-large
 
 
 concurrency:


### PR DESCRIPTION
**Description:** Cherry-picks changes from #1340 to `main` branch.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
