### PR TITLE
Set operator image from go.mod collector dependency

### DIFF
--- a/.github/workflows/CI-Operator.yml
+++ b/.github/workflows/CI-Operator.yml
@@ -162,6 +162,7 @@ jobs:
         run: |
           export TTL_DATE=${{ steps.date.outputs.ttldate }}
           export TF_VAR_aoc_version=${{ steps.versioning.outputs.version }}
+          export TF_VAR_operator_tag=$(cat go.mod | grep "go.opentelemetry.io/collector " | cut -d " " -f2)
           cd testing-framework/terraform
           make execute-batch-test
           


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR follows [PR 750](https://github.com/aws-observability/aws-otel-test-framework/pull/750) in the test-framework repo that allows the Operator image to be set as a variable. This PR sets the variable tag to be the same as the collector dependency taken from the `go.mod` file. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
