### PR TITLE
Add aws_region `us-east-1` I weekly resource cleaners

### DIFF
--- a/.github/workflows/weekly-resources-clean.yml
+++ b/.github/workflows/weekly-resources-clean.yml
@@ -34,7 +34,7 @@ jobs:
       max-parallel: 3
       matrix:
         resource: [autoscaling, ec2, ecs, efs, iam, launchconfig, loadbalancer, ebs]
-        region: [us-west-2, us-east-2]
+        region: [us-west-2, us-east-1, us-east-2]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
**Description:**

Add `us-east-1` in the list for weekly resource cleaners

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
