### PR TITLE
Changed comment in canary workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -14,7 +14,7 @@
 name: 'Canary Test'
 on:
   schedule:
-    - cron: '0 */3 * * *' # triggers the workflow every four hours
+    - cron: '0 */3 * * *' # triggers the workflow every three hours
 
   # we can manually trigger this workflow by using dispatch for debuging
   repository_dispatch:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The comment describing the schedule the canary runs on is wrong.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
