### PR TITLE
Change format of operator version to mirror

### DIFF
--- a/.github/workflows/CD-adot-operator.yml
+++ b/.github/workflows/CD-adot-operator.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'the desired version number of the operator (ex. 0.45.0)'
+        description: 'the desired version number of the operator (ex. v0.45.0)'
         required: true
 
 jobs:           


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Updates the description in the workflow for what operator version to check for from `x.x.x` to `vx.x.x`. This is because, for some odd reason, when mirroring `0.56.0`, grep found `0.56.0` in this string from the list of ECR tags, `"imagePushedAt": "2022-02-01T02:50:56+00:00"` (`0:56+0` matches it somehow), meaning that `update-operator` would be false when it should be true. `v0.56.0` resulted in a successful mirror, and this PR should help in avoiding this in the future


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
