### PR TITLE
Remove amazon linux from test cases

### DIFF
--- a/e2etest/get-testcases.py
+++ b/e2etest/get-testcases.py
@@ -9,7 +9,6 @@ if __name__ == "__main__":
 
     ec2_matrix_1 = {"testcase": [], "testing_ami": [
         "amazonlinux2", 
-        "amazonlinux", 
         "ubuntu18", 
         "ubuntu16", 
         "debian10", 


### PR DESCRIPTION
**Description:** 

This PR removes amazon-linux form the tests. Changes in [test-framework](https://github.com/aws-observability/aws-otel-test-framework/pull/818)

**Link to tracking Issue:** N/A

**Testing:**  N/A
**Documentation:**  N/A

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
