### PR TITLE
Update release note generator excluded labels

### DIFF
--- a/tools/release/bump-version-and-create-release-note.sh
+++ b/tools/release/bump-version-and-create-release-note.sh
@@ -30,7 +30,7 @@ docker run --rm -it -v "$(pwd)":/usr/local/src/your-app ferrarimarco/github-chan
     --since-tag "${VERSION}" \
     --future-release "${RELEASE_VERSION}" \
     --output "${OUTPUT}" \
-    --exclude-labels bumpversion
+    --exclude-labels bumpversion,'Skip Changelog'
 
 # bump the version
 echo "${RELEASE_VERSION}" >VERSION


### PR DESCRIPTION
**Description:**  Updates release note generator to not include PRs with the `Skip Changelog` label.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
