### PR TITLE
Update GHA runners to use go ver ~1.18.6

### DIFF
--- a/.github/workflows/CD-adot-operator.yml
+++ b/.github/workflows/CD-adot-operator.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: ~1.18.1
+          go-version: ~1.18.6
 
       - name: Login to Public Release ECR
         uses: docker/login-action@v2

--- a/.github/workflows/CI-Operator.yml
+++ b/.github/workflows/CI-Operator.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: '~1.18.1'
+          go-version: '~1.18.6'
 
       - name: Create test batch key values
         id: set-batches

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,6 +52,7 @@ env:
   DDB_TABLE_NAME: BatchTestCache
   MAX_JOBS: 90
   BATCH_INCLUDED_SERVICES: EKS,ECS,EC2,EKS_ARM64,EKS_FARGATE
+  GO_VERSION: ~1.18.6
 
 
 concurrency:
@@ -86,7 +87,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: '~1.18.1'
+          go-version: ${{ env.GO_VERSION }}
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil
@@ -105,7 +106,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '~1.18.1'
+        go-version: ${{ env.GO_VERSION }}
 
     - uses: actions/checkout@v3
 
@@ -560,7 +561,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: '~1.18.1'
+          go-version: ${{ env.GO_VERSION }}
 
         # getting the batches would look something like this
         # max jobs could be read as env or passed in as arg depending
@@ -693,7 +694,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: '~1.18.1'
+          go-version: ${{ env.GO_VERSION }}
           
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -76,7 +76,7 @@ jobs:
       if: ${{ needs.changes.outputs.changed == 'true' }}
       uses: actions/setup-go@v3
       with:
-        go-version: '~1.18.1'
+        go-version: '~1.18.6'
 
     - name: Checkout
       if: ${{ needs.changes.outputs.changed == 'true' }}

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: '~1.18.1'
+          go-version: '~1.18.6'
       - name: Build aotutil
         run: cd testing-framework/cmd/aotutil && make build
       - name: Cache aotutil


### PR DESCRIPTION
**Description:** Updates GitHub actions workflows to use go version `~1.18.6`


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
