### PR TITLE
Update canary workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -15,14 +15,9 @@ name: 'Canary Test'
 on:
   schedule:
     - cron: '0 */3 * * *' # triggers the workflow every three hours
-
-  # we can manually trigger this workflow by using dispatch for debuging
-  repository_dispatch:
-    types: [canary-test]
+  workflow_dispatch:
 
 env:
-  TF_VAR_aws_access_key_id: ${{ secrets.INTEG_TEST_AWS_KEY_ID }}
-  TF_VAR_aws_secret_access_key: ${{ secrets.INTEG_TEST_AWS_KEY_SECRET }}
   TF_VAR_patch: 'true'
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
 
@@ -126,7 +121,7 @@ jobs:
           path: testing-framework/cmd/aotutil/aotutil
 
       - name: Run Canary test
-        uses: nick-invision/retry@v2
+        uses: nick-fields/retry@v2
         with:
           max_attempts: 3
           timeout_minutes: 60
@@ -135,18 +130,10 @@ jobs:
             if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
             cd testing-framework/terraform/canary
             terraform init
-            if terraform apply -auto-approve -lock=false $opts -var="aoc_version=latest" -var="testcase=../testcases/${{ matrix.testcase }}" -var="testing_ami=${{ matrix.testing_ami }}" ; then
-              terraform destroy -auto-approve -var="region=us-west-2"
-            else
-              terraform destroy -auto-approve -var="region=us-west-2" && exit 1
-            fi
-
-      #This is here just in case workflow cancel
+            terraform apply -auto-approve -lock=false $opts -var="aoc_version=latest" -var="testcase=../testcases/${{ matrix.testcase }}" -var="testing_ami=${{ matrix.testing_ami }}"
+       
       - name: Destroy terraform resources
-        if: ${{ cancelled() }}
-        uses: nick-invision/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 8
-          retry_wait_seconds: 20
-          command: cd testing-framework/terraform/canary && terraform destroy -auto-approve -var="region=us-west-2"
+        if: ${{ always() }}
+        run: |
+          cd testing-framework/terraform/canary && terraform destroy -auto-approve -var="region=us-west-2"
+


### PR DESCRIPTION
**Description:** 
Some canary tests have been failing because they hit timeout before finishing the `terraform` destroy portion. This PR makes destroy a separate step with no retry/timeout. This will give adequate time for destroys to complete. 

This PR also:
- Updates the retry action. see ownership info [here](https://github.com/bryan-aguilar/aws-otel-collector/pull/new/canarydestroy). 
- Remove terraform vars that are no longer required for the validator. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
