### PR TITLE
Fix null strings for Cron job trigger

### DIFF
--- a/.github/workflows/aws-resources-clean.yml
+++ b/.github/workflows/aws-resources-clean.yml
@@ -40,8 +40,8 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        resource: ${{ fromJson(github.event.inputs.resource) || "[ \"aps\", \"autoscaling\", \"ec2\",\"ecs\",\"efs\",\"iam\",\"launchconfig\",\"loadbalancer\",\"ebs\"]" }}
-        region: ${{ fromJson(github.event.inputs.aws_region) || "[ \"us-west-2\", \"us-east-1\", \"us-east-2\",\"eu-central-1\",\"eu-west-1\",\"eu-west-2\",\"eu-north-1\"]" }}
+        resource: ${{ fromJson(github.event.inputs.resource) || '[aps, autoscaling, ec2, ecs, efs, iam, launchconfig, loadbalancer, ebs]' }}
+        region: ${{ fromJson(github.event.inputs.aws_region) || '[ us-west-2, us-east-1, us-east-2,eu-central-1,eu-west-1,eu-west-2,eu-north-1]' }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/aws-resources-clean.yml
+++ b/.github/workflows/aws-resources-clean.yml
@@ -40,8 +40,8 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        resource: ${{ fromJson(github.event.inputs.resource) }}
-        region: ${{ fromJson(github.event.inputs.aws_region) }}
+        resource: ${{ fromJson(github.event.inputs.resource) || "[ \"aps\", \"autoscaling\", \"ec2\",\"ecs\",\"efs\",\"iam\",\"launchconfig\",\"loadbalancer\",\"ebs\"]" }}
+        region: ${{ fromJson(github.event.inputs.aws_region) || "[ \"us-west-2\", \"us-east-1\", \"us-east-2\",\"eu-central-1\",\"eu-west-1\",\"eu-west-2\",\"eu-north-1\"]" }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
**Description:** 

This PR fixes the `Null` string bug inside the `aws-resourse-cleaner` workflow when it trigged though a cron job.

**Link to tracking Issue:** 

https://github.com/aws-observability/aws-otel-collector/actions/workflows/aws-resources-clean.yml

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
