### PR TITLE
Kill terraform process on workflow cancel

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -643,10 +643,14 @@ jobs:
           cd testing-framework/terraform
           make checkCacheHits
       
-      #This is here just in case workflow cancel
+      # This is here just in case workflow cancel
+      # We first kill terraform processes to ensure that no state
+      # file locks are being held from SIGTERMS dispatched in previous
+      # steps. 
       - name: Destroy resources
         if: ${{ cancelled() }}
         run: |
+          ps -ef | grep terraform | grep -v grep | awk '{print $2}' | xargs -n 1 kill
           cd testing-framework/terraform
           make terraformCleanup
 


### PR DESCRIPTION
**Description:** During workflow cancel scenarios it is possible that a lock on a statefile will persist from the previous step. This lock will prevent the terraform destroy from correctly executing. To ensure that this lock is released we will ensure that process that holds it is terminated. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
