### PR TITLE
Always run validate tests pass

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -692,6 +692,7 @@ jobs:
   validate-all-tests-pass:
     runs-on: ubuntu-latest
     needs: [run-batch-job,e2etest-preparation,create-test-ref,get-testing-suites]
+    if: always()
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
**Description:** This PR enables the `validate-all-tests-pass-job` to run on every CI run. Previously this only ran if all of the batch's passed. Enabling this to run on each workflow run will allow easier visibility on which tests pass when manually inspecting workflow failures. This will correlate all failures from a workflow into a single spot. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
