### PR TITLE
Build and restore aotutil in perf test

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -111,6 +111,28 @@ jobs:
         run: |
           perf_matrix=$(python e2etest/get-testcases.py perf_matrix)
           echo "::set-output name=perf_matrix::$perf_matrix"
+
+  build-aotutil:
+    runs-on: ubuntu-latest
+    needs: create-test-ref
+    steps:
+      - name: Check out testing framework
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.TESTING_FRAMEWORK_REPO }}
+          path: testing-framework
+          ref: ${{ needs.create-test-ref.outputs.testRef }}
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Build aotutil
+        run: cd testing-framework/cmd/aotutil && make build
+      - name: Cache aotutil
+        uses: actions/cache@v3
+        with:
+          key: "aotutil_${{ hashFiles('testing-framework/cmd/aotutil/*.go') }}_${{ hashFiles('testing-framework/cmd/aotutil/go.sum') }}"
+          path: testing-framework/cmd/aotutil/aotutil
           
   run-perf-test:
     runs-on: ubuntu-latest
@@ -128,7 +150,7 @@ jobs:
           aws-region: us-west-2
           # 3 hours
           role-duration-seconds: 10800
-          
+
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
@@ -146,6 +168,12 @@ jobs:
           repository: ${{ env.TESTING_FRAMEWORK_REPO}}
           path: testing-framework
           ref: ${{ needs.create-test-ref.outputs.testRef }}
+
+      - name: Restore aotutil
+        uses: actions/cache@v3
+        with:
+          key: "aotutil_${{ hashFiles('testing-framework/cmd/aotutil/*.go') }}_${{ hashFiles('testing-framework/cmd/aotutil/go.sum') }}"
+          path: testing-framework/cmd/aotutil/aotutil
           
       - name: Run Performance test
         run: |

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,6 +27,7 @@ env:
   COMMIT_USER: Github Actions
   COMMIT_EMAIL: actions@github.com
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
+  GO_VERSION: ~1.18.6
 
 permissions:
   id-token: write


### PR DESCRIPTION
**Description:** Build `aotutil` in performance test in the same way that the `CI` workflow does. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
