### PR TITLE
Add APIGateway cleaner to resource cleaner

### DIFF
--- a/.github/workflows/aws-resources-clean.yml
+++ b/.github/workflows/aws-resources-clean.yml
@@ -37,7 +37,37 @@ jobs:
       max-parallel: 3
       matrix:
         resource: [aps, autoscaling, ec2, ecs, efs, iam, launchconfig, loadbalancer, ebs]
-        region: [us-west-2, us-east-1, us-east-2,eu-central-1,eu-west-1,eu-west-2,eu-north-1]
+        region: [us-east-1, us-east-2, us-west-1, us-west-2, ap-south-1, ap-northeast-2, ap-southeast-1, ap-southeast-2,
+                 ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, eu-north-1, sa-east-1]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
+          aws-region: ${{ matrix.region }}
+
+      - name: Update days to keep
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "DAYS_TO_KEEP=${{ github.event.inputs.daystokeep }}" >> $GITHUB_ENV
+
+      - name: Clean old aws resources
+        run: go run tools/workflow/cleaner/main.go -keep $DAYS_TO_KEEP -clean ${{ matrix.resource }}
+        env:
+          AWS_SDK_LOAD_CONFIG: true
+
+  # API GW api has a limit of one delete request per 30 seconds. Thus it cannot be run in parallel
+  # with the other tests
+  clean-apigw:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        resource: [apigw]
+        region: [us-east-1, us-east-2, us-west-1, us-west-2, ap-south-1, ap-northeast-2, ap-southeast-1, ap-southeast-2,
+                  ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, eu-north-1, sa-east-1]
     steps:
       - uses: actions/checkout@v3
 

--- a/tools/workflow/cleaner/apigw/clean.go
+++ b/tools/workflow/cleaner/apigw/clean.go
@@ -40,21 +40,20 @@ func Clean(sess *session.Session, expirationDate time.Time) error {
 			break
 		}
 		nextToken = getRestApisOutput.Position
+	}
+	if len(deleteGatewayIds) < 1 {
+		logger.Printf("No API Gateways to delete")
+		return nil
+	}
 
-		if len(deleteGatewayIds) < 1 {
-			logger.Printf("No API Gateways to delete")
-			return nil
+	for _, id := range deleteGatewayIds {
+		terminateGatewayInput := &apigateway.DeleteRestApiInput{RestApiId: id}
+		if _, err := apigwclient.DeleteRestApi(terminateGatewayInput); err != nil {
+			return fmt.Errorf("unable to delete gateway: %w", err)
 		}
-
-		for _, id := range deleteGatewayIds {
-			terminateGatewayInput := &apigateway.DeleteRestApiInput{RestApiId: id}
-			if _, err := apigwclient.DeleteRestApi(terminateGatewayInput); err != nil {
-				return fmt.Errorf("unable to delete workspace: %w", err)
-			}
-			// 30 second request limit to delete ap
-			// https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html#api-gateway-control-service-limits-table
-			time.Sleep(31 * time.Second)
-		}
+		// 30 second request limit to delete rest api
+		// https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html#api-gateway-control-service-limits-table
+		time.Sleep(31 * time.Second)
 	}
 	return nil
 }

--- a/tools/workflow/cleaner/apigw/clean.go
+++ b/tools/workflow/cleaner/apigw/clean.go
@@ -1,0 +1,80 @@
+package apigw
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"log"
+	"os"
+	"regexp"
+	"time"
+)
+
+const Type = "apigw"
+
+var logger = log.New(os.Stdout, fmt.Sprintf("[%s] ", Type), log.LstdFlags)
+
+func Clean(sess *session.Session, expirationDate time.Time) error {
+	logger.Printf("Begin to clean APIGW clients")
+
+	apigwclient := apigateway.New(sess)
+	var deleteGatewayIds []*string
+	var nextToken *string
+	for {
+		getRestApisInput := &apigateway.GetRestApisInput{Position: nextToken}
+		getRestApisOutput, err := apigwclient.GetRestApis(getRestApisInput)
+		if err != nil {
+			return fmt.Errorf("unable to retrieve APIs: %w", err)
+		}
+		for _, gw := range getRestApisOutput.Items {
+			doesNameMatch, err := shouldDelete(gw)
+			if err != nil {
+				return fmt.Errorf("error during pattern match: %w", err)
+			}
+			if expirationDate.After(*gw.CreatedDate) && doesNameMatch {
+				logger.Printf("Try to delete gateway %s created-at %v", *gw.Id, gw.CreatedDate)
+				deleteGatewayIds = append(deleteGatewayIds, gw.Id)
+			}
+		}
+		if getRestApisOutput.Position == nil {
+			break
+		}
+		nextToken = getRestApisOutput.Position
+
+		if len(deleteGatewayIds) < 1 {
+			logger.Printf("No API Gateways to delete")
+			return nil
+		}
+
+		for _, id := range deleteGatewayIds {
+			terminateGatewayInput := &apigateway.DeleteRestApiInput{RestApiId: id}
+			if _, err := apigwclient.DeleteRestApi(terminateGatewayInput); err != nil {
+				return fmt.Errorf("unable to delete workspace: %w", err)
+			}
+			// 30 second request limit to delete ap
+			// https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html#api-gateway-control-service-limits-table
+			time.Sleep(31 * time.Second)
+		}
+	}
+	return nil
+}
+
+func shouldDelete(gw *apigateway.RestApi) (bool, error) {
+	gwName := gw.Name
+	regexList := []string{
+		"\\Alambda-[a-z]+-aws-sdk-.*$",
+		"\\Ahello-lambda-[a-z]+-okhttp-.*",
+		"\\Alambda-[a-z]+-okhttp-wrapper-.*$",
+	}
+
+	for _, rx := range regexList {
+		matches, err := regexp.MatchString(rx, *gwName)
+		if err != nil {
+			return false, fmt.Errorf("error during regex match: %w", err)
+		}
+		if matches {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/tools/workflow/cleaner/apigw/clean_test.go
+++ b/tools/workflow/cleaner/apigw/clean_test.go
@@ -1,0 +1,60 @@
+package apigw
+
+import (
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestShouldDelete(t *testing.T) {
+	namesToTest := []struct {
+		testName    string
+		mockApiName string
+		expected    bool
+	}{
+		{
+			testName:    "aws-sdk",
+			mockApiName: "lambda-python-aws-sdk-wrapper-arm64-1234-ap-south-1",
+			expected:    true,
+		},
+		{
+			testName:    "ok-http",
+			mockApiName: "lambda-java-okhttp-wrapper-arm64-1234-ap-south-1",
+			expected:    true,
+		},
+		{
+			testName:    "aws-sdk-agent",
+			mockApiName: "lambda-java-aws-sdk-agent-amd64-1234-ap-south-1",
+			expected:    true,
+		},
+		{
+			testName:    "hello-lambda",
+			mockApiName: "hello-lambda-java-okhttp-wrapper-1234-ap-south-1",
+			expected:    true,
+		},
+		{
+			testName:    "invalid",
+			mockApiName: "i-am-a-bad-apigateway-name",
+			expected:    false,
+		},
+		{
+			testName: "empty",
+			expected: false,
+		},
+		{
+			testName:    "almost matching",
+			mockApiName: "bad-lambda-worse-aws-sdk-agent-maybe",
+			expected:    false,
+		},
+	}
+	for _, test := range namesToTest {
+		t.Run(test.testName, func(*testing.T) {
+			mockInput := &apigateway.RestApi{
+				Name: &test.mockApiName,
+			}
+			actual, err := shouldDelete(mockInput)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/tools/workflow/cleaner/main.go
+++ b/tools/workflow/cleaner/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 
+	"github.com/aws-observability/aws-otel-collector/tools/workflow/cleaner/apigw"
 	"github.com/aws-observability/aws-otel-collector/tools/workflow/cleaner/aps"
 	"github.com/aws-observability/aws-otel-collector/tools/workflow/cleaner/autoscaling"
 	"github.com/aws-observability/aws-otel-collector/tools/workflow/cleaner/ebs"
@@ -46,7 +47,7 @@ var (
 	daysToKeep    int
 	cleanersToRun string
 
-	cleanerTypes   = []string{aps.Type, autoscaling.Type, ec2.Type, ecs.Type, efs.Type, iam.Type, launchconfig.Type, loadbalancer.Type, ebs.Type}
+	cleanerTypes   = []string{aps.Type, autoscaling.Type, ec2.Type, ecs.Type, efs.Type, iam.Type, launchconfig.Type, loadbalancer.Type, ebs.Type, apigw.Type}
 	cleanerOptions = strings.Join(cleanerTypes, delimiter)
 )
 
@@ -108,6 +109,10 @@ func main() {
 			}
 		case ebs.Type:
 			if err := ebs.Clean(sess, expirationDate); err != nil {
+				log.Printf("%v", err)
+			}
+		case apigw.Type:
+			if err := apigw.Clean(sess, expirationDate); err != nil {
 				log.Printf("%v", err)
 			}
 		default:


### PR DESCRIPTION
**Description:** Add API Gateway cleaner to clean up leftover api gateways from lambda tests. 

**Testing:** I wrote a unit test to verify the regex works. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
