### PR TITLE
Improve Mirroring Tool in ADOT Operator CD

### DIFF
--- a/tools/release/adot-operator-images-mirror/config.yaml
+++ b/tools/release/adot-operator-images-mirror/config.yaml
@@ -29,6 +29,7 @@ sourceRepos:
     host: ghcr.io
     allowed_tags:
       - 1.11.1
+      - 1.18.0
   - registry: open-telemetry/opentelemetry-operator
     name: autoinstrumentation-nodejs
     host: ghcr.io
@@ -42,11 +43,13 @@ sourceRepos:
       - 0.28b1
       - 0.30b1
       - 0.32b0
+      - 0.33b0
   - registry: open-telemetry/opentelemetry-operator
     name: autoinstrumentation-dotnet
     host: ghcr.io
     allowed_tags:
       - 0.2.0-beta.1
+      - 0.3.1-beta.1
 
 targetRepos:
   - registry: public.ecr.aws/aws-observability

--- a/tools/release/adot-operator-images-mirror/config.yaml
+++ b/tools/release/adot-operator-images-mirror/config.yaml
@@ -19,9 +19,17 @@ sourceRepos:
       - v0.11.0
       - v0.8.0
       - v0.5.0
+  - registry: open-telemetry/opentelemetry-operator
+    name: target-allocator
+    host: ghcr.io
+    allowed_tags:
+      - latest
+      - 0.1.0
 
 targetRepos:
   - registry: public.ecr.aws/aws-observability
     name: adot-operator
   - registry: public.ecr.aws/aws-observability
     name: mirror-kube-rbac-proxy
+  - registry: public.ecr.aws/aws-observability
+    name: mirror-target-allocator

--- a/tools/release/adot-operator-images-mirror/config.yaml
+++ b/tools/release/adot-operator-images-mirror/config.yaml
@@ -23,8 +23,30 @@ sourceRepos:
     name: target-allocator
     host: ghcr.io
     allowed_tags:
-      - latest
       - 0.1.0
+  - registry: open-telemetry/opentelemetry-operator
+    name: autoinstrumentation-java
+    host: ghcr.io
+    allowed_tags:
+      - 1.11.1
+  - registry: open-telemetry/opentelemetry-operator
+    name: autoinstrumentation-nodejs
+    host: ghcr.io
+    allowed_tags:
+      - 0.27.0
+      - 0.31.0
+  - registry: open-telemetry/opentelemetry-operator
+    name: autoinstrumentation-python
+    host: ghcr.io
+    allowed_tags:
+      - 0.28b1
+      - 0.30b1
+      - 0.32b0
+  - registry: open-telemetry/opentelemetry-operator
+    name: autoinstrumentation-dotnet
+    host: ghcr.io
+    allowed_tags:
+      - 0.2.0-beta.1
 
 targetRepos:
   - registry: public.ecr.aws/aws-observability
@@ -33,3 +55,11 @@ targetRepos:
     name: mirror-kube-rbac-proxy
   - registry: public.ecr.aws/aws-observability
     name: mirror-target-allocator
+  - registry: public.ecr.aws/aws-observability
+    name: mirror-autoinstrumentation-java
+  - registry: public.ecr.aws/aws-observability
+    name: mirror-autoinstrumentation-nodejs
+  - registry: public.ecr.aws/aws-observability
+    name: mirror-autoinstrumentation-python
+  - registry: public.ecr.aws/aws-observability
+    name: mirror-autoinstrumentation-dotnet

--- a/tools/release/adot-operator-images-mirror/mirror.go
+++ b/tools/release/adot-operator-images-mirror/mirror.go
@@ -131,7 +131,7 @@ func (m *mirror) getTagResponse(url string) error {
 
 	// Sets the authorization header necessary for accessing ghcr.io
 	if m.sourceRepo.Host == ghcr {
-		tokenURL := "https://ghcr.io/token?scope=repository:open-telemetry/opentelemetry-operator/opentelemetry-operator:pull"
+		tokenURL := fmt.Sprintf("https://ghcr.io/token?scope=repository:%s:pull", m.sourceRepositoryName())
 		tokenRes, err := http.Get(tokenURL)
 		if err != nil {
 			return err
@@ -170,7 +170,7 @@ func (m *mirror) getTagResponse(url string) error {
 				return err
 			}
 			for _, tag := range tags.Tags {
-				// Check if Operator image is on allowlist
+				// Check if the ghcr image is on allowlist
 				if tagInAllowlist(tag, m.sourceRepo.AllowedTags) {
 					allTags = append(allTags, RepositoryTag{
 						Name: tag,

--- a/tools/release/adot-operator-images-mirror/mirror.go
+++ b/tools/release/adot-operator-images-mirror/mirror.go
@@ -60,9 +60,6 @@ func (m *mirror) setup(repos []Repository) error {
 	// Fetch remote tags from source repository.
 	m.getRemoteTags()
 
-	// Filter the tags we got.
-	m.filterTags()
-
 	return nil
 }
 
@@ -96,19 +93,6 @@ func (m *mirror) getRemoteTags() {
 	}
 
 	log.Printf("Finished scraping remote tags from %s", m.sourceRepositoryFullName())
-}
-
-func (m *mirror) filterTags() {
-	tmp := make([]RepositoryTag, 0)
-
-	for _, remoteTag := range m.remoteTags {
-		// We only keep the tags starting with "v" or with the name "latest".
-		if string(remoteTag.Name[0]) == "v" || remoteTag.Name == "latest" {
-			tmp = append(tmp, remoteTag)
-		}
-	}
-
-	m.remoteTags = tmp
 }
 
 func (m *mirror) sourceRepositoryName() string {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR improves the mirroring tool that the ADOT Operator CD uses, to include the mirroring of several more `ghcr.io` images, those being select `target-allocator` `autoinstrumentation-*` images. This PR also removes a now unnecessary `filterTags()` method that is irrelevant now due to the recent addition of an allowlist for mirroring.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
