### PR TITLE
Revert "Create and use a new user for the container image"

### DIFF
--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -4,24 +4,10 @@
 ARG BUILDMODE=build
 
 ################################
-#	Base Stage      #
+#	Certificate Stage      #
 #			       #
 ################################
-FROM alpine:latest AS base
-
-ARG USERNAME=aoc
-ARG USER_UID=4317
-
-RUN addgroup \
-    -g $USER_UID \
-    $USERNAME && \
-    adduser \
-    -D \
-    -g $USERNAME \
-    -h "/home/${USERNAME}"\
-    -G $USERNAME \
-    -u $USER_UID \
-    $USERNAME
+FROM alpine:latest AS certs
 
 RUN apk --update add ca-certificates
 
@@ -81,21 +67,13 @@ COPY config/ /workspace/config/
 ################################
 FROM scratch
 
-ARG USERNAME=aoc
-
-COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=base /etc/passwd /etc/passwd
-COPY --from=base /etc/group /etc/group
-COPY --from=base /home/$USERNAME/ /home/$USERNAME
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=package /workspace/awscollector /awscollector
 COPY --from=package /workspace/config/ /etc/
 
 ENV RUN_IN_CONTAINER="True"
-
-USER $USERNAME
 # aws-sdk-go needs $HOME to look up shared credentials
-ENV HOME=/home/$USERNAME
-
+ENV HOME=/root
 ENTRYPOINT ["/awscollector"]
 CMD ["--config=/etc/otel-config.yaml"]
 EXPOSE 4317 55681 2000


### PR DESCRIPTION
Reverts aws-observability/aws-otel-collector#1549 due to container insights failures. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.