### PR TITLE
Update allowlist to include Operator v0.61.0

### DIFF
--- a/tools/release/adot-operator-images-mirror/config.yaml
+++ b/tools/release/adot-operator-images-mirror/config.yaml
@@ -5,6 +5,7 @@ sourceRepos:
     host: ghcr.io
     allowed_tags: 
       - latest
+      - v0.61.0
       - v0.58.0
       - v0.56.0
       - v0.54.0


### PR DESCRIPTION
For the Operator release, I have updated the allowlist to include the the new Operator v0.61.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
