### PR TITLE
Add arm64 manifest for debian

### DIFF
--- a/tools/ssm/ssm_manifest.py
+++ b/tools/ssm/ssm_manifest.py
@@ -98,7 +98,12 @@ if __name__ == "__main__":
                 "arm64": {"file": "linux-arm64-deb.zip"},
             }
         },
-        "debian": {"_any": {"x86_64": {"file": "linux-amd64-deb.zip"}}},
+        "debian": {
+            "_any": {
+                "x86_64": {"file": "linux-amd64-deb.zip"},
+                "arm64": {"file": "linux-arm64-deb.zip"},
+            }
+        },
         "redhat": {
             "_any": {
                 "x86_64": {"file": "linux-amd64-rpm.zip"},


### PR DESCRIPTION
**Description:** 

Add `arm64` manifest  for `debian` 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
