### PR TITLE
Correct Depends Typo

### DIFF
--- a/examples/ecs/aws-cloudwatch/ecs-fargate-sidecar.json
+++ b/examples/ecs/aws-cloudwatch/ecs-fargate-sidecar.json
@@ -62,7 +62,7 @@
       "memory": 512,
       "dependsOn": [
         {
-          "containerName": "aws-collector",
+          "containerName": "aws-otel-collector",
           "condition": "START"
         }
       ],


### PR DESCRIPTION
Previously the nginx container depended on 'aws-collector'. This should be 'aws-otel-collector' to match the name of the collector container. Or else the task definition will not create.

**Description:** <Describe what has changed.>
Fixing typo in task definition.

**Link to tracking Issue:** N/A

**Testing:** <Describe what testing was performed and which tests were added.>
- ran end to end testing of the ECS fargate deployment instructions.

**Documentation:** n/a


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
