### PR TITLE
Update configure-aws-credentials to use node16

### DIFF
--- a/.github/workflows/CD-adot-operator.yml
+++ b/.github/workflows/CD-adot-operator.yml
@@ -41,7 +41,7 @@ jobs:
           AWS_REGION: us-east-1
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_SECRET }}

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2
@@ -119,7 +119,7 @@ jobs:
 
       - name: Configure AWS Credentials
         if: steps.release-to-s3.outputs.cache-hit != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_SECRET }}

--- a/.github/workflows/CI-Operator.yml
+++ b/.github/workflows/CI-Operator.yml
@@ -115,7 +115,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -483,7 +483,7 @@ jobs:
           path: build
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2
@@ -599,7 +599,7 @@ jobs:
 
       - name: Configure AWS Credentials
         if: steps.e2etest-eks.outputs.cache-hit != 'true'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2
@@ -661,7 +661,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2
@@ -707,7 +707,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2
@@ -732,7 +732,7 @@ jobs:
     needs: validate-all-tests-pass
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2
@@ -769,7 +769,7 @@ jobs:
     if: always()
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2

--- a/.github/workflows/aws-resources-clean.yml
+++ b/.github/workflows/aws-resources-clean.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: ${{ matrix.region }}
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: ${{ matrix.region }}

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
       
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/checkout@v3
         
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -78,7 +78,7 @@ jobs:
             type: msi
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_SECRET }}
@@ -117,42 +117,42 @@ jobs:
     steps:
       - name: Configure AWS Credentials
         if: matrix.type == 'global'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_SECRET }}
           aws-region: us-west-2
       - name: Configure AWS Credentials for HKG
         if: matrix.type == 'hkg'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_HKG_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_HKG_SECRET }}
           aws-region: ap-east-1
       - name: Configure AWS Credentials for BAH
         if: matrix.type == 'bah'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_BAH_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_BAH_SECRET }}
           aws-region: me-south-1
       - name: Configure AWS Credentials for CPT
         if: matrix.type == 'cpt'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_CPT_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_CPT_SECRET }}
           aws-region: af-south-1
       - name: Configure AWS Credentials for MXP
         if: matrix.type == 'mxp'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_MXP_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_MXP_SECRET }}
           aws-region: eu-south-1
       - name: Configure AWS Credentials for CN
         if: matrix.type == 'cn'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_CN_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_CN_SECRET }}
@@ -247,7 +247,7 @@ jobs:
             type: msi
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_SECRET }}
@@ -284,42 +284,42 @@ jobs:
     steps:
       - name: Configure AWS Credentials
         if: matrix.type == 'global'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_SECRET }}
           aws-region: us-west-2
       - name: Configure AWS Credentials for HKG
         if: matrix.type == 'hkg'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_HKG_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_HKG_SECRET }}
           aws-region: ap-east-1
       - name: Configure AWS Credentials for BAH
         if: matrix.type == 'bah'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_BAH_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_BAH_SECRET }}
           aws-region: me-south-1
       - name: Configure AWS Credentials for CPT
         if: matrix.type == 'cpt'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_CPT_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_CPT_SECRET }}
           aws-region: af-south-1
       - name: Configure AWS Credentials for MXP
         if: matrix.type == 'mxp'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_MXP_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_MXP_SECRET }}
           aws-region: eu-south-1
       - name: Configure AWS Credentials for CN
         if: matrix.type == 'cn'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_CN_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_CN_SECRET }}

--- a/.github/workflows/ssm-release.yml
+++ b/.github/workflows/ssm-release.yml
@@ -54,7 +54,7 @@ jobs:
           ref: ${{ github.event.inputs.sha }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2
@@ -67,7 +67,7 @@ jobs:
           python3 tools/ssm/ssm_manifest.py ${{ github.event.inputs.version }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_SECRET }}
@@ -103,7 +103,7 @@ jobs:
           done
 
       - name: Configure AWS Credentials for HKG
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_HKG_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_HKG_SECRET }}
@@ -135,7 +135,7 @@ jobs:
           done
 
       - name: Configure AWS Credentials for BAH
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_BAH_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_BAH_SECRET }}
@@ -167,7 +167,7 @@ jobs:
           done
 
       - name: Configure AWS Credentials for CPT
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_CPT_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_CPT_SECRET }}
@@ -199,7 +199,7 @@ jobs:
           done
 
       - name: Configure AWS Credentials for MXP
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_MXP_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_MXP_SECRET }}
@@ -231,7 +231,7 @@ jobs:
           done
 
       - name: Configure AWS Credentials for CN regions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.RELEASE_CN_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RELEASE_CN_SECRET }}


### PR DESCRIPTION
**Description:** 

Update `aws-actions/configure-aws-credentials` to use node16 as node14 is getting deprecated by github actions


**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
