### PR TITLE
Allow default config to be overridden in Dockerfile

### DIFF
--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -3,17 +3,19 @@
 # the copy mode copies in a pre-built binary.
 ARG BUILDMODE=build
 
+# The default configuration file. A custom configuration
+# file can be used by setting the --build-arg.
+ARG CONFIGFILE=config.yaml
+
 ################################
-#	Certificate Stage      #
-#			       #
+#	Certificate Stage          #
 ################################
 FROM alpine:latest AS certs
 
 RUN apk --update add ca-certificates
 
 ################################
-#	Build Stage            #
-#			       #
+#	Build Stage                #
 ################################
 FROM golang:1.18 AS prep-build
 
@@ -39,8 +41,7 @@ RUN make ${TARGETARCH}-build
 RUN mv /workspace/build/linux/$TARGETARCH/aoc /workspace/awscollector
 
 ################################
-#	Copy Stage             #
-#			       #	
+#	Copy Stage                 #
 ################################
 FROM scratch AS prep-copy
 
@@ -54,17 +55,16 @@ COPY build/linux/$TARGETARCH/aoc /workspace/awscollector
 COPY build/linux/$TARGETARCH/healthcheck /workspace/healthcheck
 
 ################################
-#	Packing Stage          #
-#			       #
+#	Packing Stage              #
 ################################
+ARG CONFIGFILE
 FROM prep-${BUILDMODE} AS package
 
-COPY config.yaml /workspace/config/otel-config.yaml
+COPY ${CONFIGFILE} /workspace/config/otel-config.yaml
 COPY config/ /workspace/config/
 
 ################################
-#	Final Stage            #	
-#			       #	
+#	Final Stage                #
 ################################
 FROM scratch
 

--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -8,14 +8,16 @@ ARG BUILDMODE=build
 ARG CONFIGFILE=config.yaml
 
 ################################
-#	Certificate Stage          #
+#	Certificate Stage      #
+#			       #
 ################################
 FROM alpine:latest AS certs
 
 RUN apk --update add ca-certificates
 
 ################################
-#	Build Stage                #
+#	Build Stage            #
+#			       #
 ################################
 FROM golang:1.18 AS prep-build
 
@@ -41,7 +43,8 @@ RUN make ${TARGETARCH}-build
 RUN mv /workspace/build/linux/$TARGETARCH/aoc /workspace/awscollector
 
 ################################
-#	Copy Stage                 #
+#	Copy Stage             #
+#			       #	
 ################################
 FROM scratch AS prep-copy
 
@@ -55,7 +58,8 @@ COPY build/linux/$TARGETARCH/aoc /workspace/awscollector
 COPY build/linux/$TARGETARCH/healthcheck /workspace/healthcheck
 
 ################################
-#	Packing Stage              #
+#	Packing Stage          #
+#			       #
 ################################
 ARG CONFIGFILE
 FROM prep-${BUILDMODE} AS package
@@ -64,7 +68,8 @@ COPY ${CONFIGFILE} /workspace/config/otel-config.yaml
 COPY config/ /workspace/config/
 
 ################################
-#	Final Stage                #
+#	Final Stage            #	
+#			       #	
 ################################
 FROM scratch
 


### PR DESCRIPTION
**Description:**
I've been exploring options to customise the collector config used in the AWS provided  Docker image. At present, it does not seem possible to alter the configurations baked into the Docker image, meaning you have to use either the default config or those available in the `config` directory. If this is possible, please do let me know!

One option I have found is to [build the Docker image yourself](https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/build-docker.md) and manually insert custom configs into the `config` directory prior to building the Docker image. Said custom configs would be copied into the image and usable by overriding the `--config` option when running the image.

Another option, would be to make the default config file selectable when building the Docker image. This would enable people to build the Docker image themselves but reference a custom config to be used by default. This PR implements this option and introduces an `ARG` into the `cmd/awscollector/Dockerfile` that allows users to specify which config file should be copied into the image and used by default. This option can be used in combination with the first option described above or instead of.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
