### PR TITLE
Change Collector CD workflow to trigger on new tag push

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -14,14 +14,9 @@
 name: C/D
 
 on:        
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'the version number to release'
-        required: true
-      sha:
-        description: 'the github sha to release'
-        required: true
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
     
 env:
   IMAGE_NAME: aws-otel-collector
@@ -61,7 +56,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
 
       - name: Download candidate
-        run: aws s3 cp "s3://aws-otel-collector-release-candidate/${{ github.event.inputs.sha }}.tar.gz" candidate.tar.gz
+        run: aws s3 cp "s3://aws-otel-collector-release-candidate/${{ github.sha }}.tar.gz" candidate.tar.gz
 
       - name: Uncompress the candidate package
         run: tar zxvf candidate.tar.gz
@@ -73,12 +68,12 @@ jobs:
           version_in_release_candidate=`cat $PACKAGING_ROOT/TESTING_VERSION`
           sha_in_candidate=`cat $PACKAGING_ROOT/GITHUB_SHA`
 
-          if [ $version_in_release != ${{ github.event.inputs.version }} ]; then
-            echo "::error::Wrong version is detected: $version_in_release != ${{ github.event.inputs.version }}"
+          if [ $version_in_release != ${{ github.ref_name }} ]; then
+            echo "::error::Wrong version is detected: $version_in_release != ${{ github.ref_name }}"
             exit 1
           fi
-          if [ $sha_in_candidate != ${{ github.event.inputs.sha }} ]; then
-            echo "::error::Wrong SHA is detected: $sha_in_candidate != ${{ github.event.inputs.sha }}"
+          if [ $sha_in_candidate != ${{ github.sha }} ]; then
+            echo "::error::Wrong SHA is detected: $sha_in_candidate != ${{ github.sha }}"
             exit 1
           fi
 
@@ -199,7 +194,7 @@ jobs:
         with:
           workflow: release SSM package
           token: ${{ secrets.REPO_WRITE_ACCESS_TOKEN }}
-          inputs: '{ "version": "${{ needs.release-checking.outputs.version }}", "sha": "${{ github.event.inputs.sha }}", "public": "true", "pkgname": "${{ env.SSM_RELEASE_PACKAGE_NAME }}" }'
+          inputs: '{ "version": "${{ needs.release-checking.outputs.version }}", "sha": "${{ github.sha }}", "public": "true", "pkgname": "${{ env.SSM_RELEASE_PACKAGE_NAME }}" }'
 
   release-to-github:
     runs-on: ubuntu-latest
@@ -208,7 +203,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.sha }}
+          ref: ${{ github.sha }}
 
       - name: Generate release-note
         run: sh tools/release/generate-release-note.sh
@@ -219,7 +214,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
           tag_name: ${{ needs.release-checking.outputs.version }}
-          commitish: ${{ github.event.inputs.sha }}
+          commitish: ${{ github.sha }}
           release_name: ${{ needs.release-checking.outputs.version }}
           body_path: release-note
           draft: true

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -16,7 +16,7 @@ name: C/D
 on:        
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
     
 env:
   IMAGE_NAME: aws-otel-collector

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -45,19 +45,21 @@ jobs:
   release-checking: 
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.checking_sha_version.outputs.version }}
+      version: ${{ steps.set-input-vars.outputs.version }}
       testing_version: ${{ steps.checking_sha_version.outputs.testing_version }}
       latest-or-newer: ${{ steps.version.outputs.latest-or-newer }}
+      sha: ${{ steps.set-input-vars.outputs.sha }}
     steps: 
       - uses: actions/checkout@v3
-      - name: Set env
+      - name: Set Input Variables
+        id: set-input-vars
         run: |
           if ${{ github.event_name == 'workflow_dispatch' }}; then
-            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-            echo "SHA=${{ github.event.inputs.sha }}" >> $GITHUB_ENV
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            echo "sha=${{ github.event.inputs.sha }}" >> $GITHUB_OUTPUT
           else
-            echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
-            echo "SHA=${{ github.sha }}" >> $GITHUB_ENV
+            echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -72,7 +74,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
 
       - name: Download candidate
-        run: aws s3 cp "s3://aws-otel-collector-release-candidate/${{ env.SHA }}.tar.gz" candidate.tar.gz
+        run: aws s3 cp "s3://aws-otel-collector-release-candidate/${{ steps.set-input-vars.outputs.sha }}.tar.gz" candidate.tar.gz
 
       - name: Uncompress the candidate package
         run: tar zxvf candidate.tar.gz
@@ -84,16 +86,15 @@ jobs:
           version_in_release_candidate=`cat $PACKAGING_ROOT/TESTING_VERSION`
           sha_in_candidate=`cat $PACKAGING_ROOT/GITHUB_SHA`
 
-          if [ $version_in_release != ${{ env.VERSION }} ]; then
-            echo "::error::Wrong version is detected: $version_in_release != ${{ env.VERSION }}"
+          if [ $version_in_release != ${{ steps.set-input-vars.outputs.version }} ]; then
+            echo "::error::Wrong version is detected: $version_in_release != ${{ steps.set-input-vars.outputs.version }}"
             exit 1
           fi
-          if [ $sha_in_candidate != ${{ env.SHA }} ]; then
-            echo "::error::Wrong SHA is detected: $sha_in_candidate != ${{ env.SHA }}"
+          if [ $sha_in_candidate != ${{ steps.set-input-vars.outputs.sha }} ]; then
+            echo "::error::Wrong SHA is detected: $sha_in_candidate != ${{ steps.set-input-vars.outputs.sha }}"
             exit 1
           fi
 
-          echo "::set-output name=version::$version_in_release"
           echo "::set-output name=testing_version::$version_in_release_candidate"
           
       - name: Compare version with Dockerhub latest
@@ -210,7 +211,7 @@ jobs:
         with:
           workflow: release SSM package
           token: ${{ secrets.REPO_WRITE_ACCESS_TOKEN }}
-          inputs: '{ "version": "${{ needs.release-checking.outputs.version }}", "sha": "${{ env.SHA }}", "public": "true", "pkgname": "${{ env.SSM_RELEASE_PACKAGE_NAME }}" }'
+          inputs: '{ "version": "${{ needs.release-checking.outputs.version }}", "sha": "${{ needs.release-checking.outputs.sha }}", "public": "true", "pkgname": "${{ env.SSM_RELEASE_PACKAGE_NAME }}" }'
 
   release-to-github:
     runs-on: ubuntu-latest
@@ -219,7 +220,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.SHA }}
+          ref: ${{ needs.release-checking.outputs.sha }}
 
       - name: Generate release-note
         run: sh tools/release/generate-release-note.sh
@@ -230,7 +231,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
           tag_name: ${{ needs.release-checking.outputs.version }}
-          commitish: ${{ env.SHA }}
+          commitish: ${{ needs.release-checking.outputs.sha }}
           release_name: ${{ needs.release-checking.outputs.version }}
           body_path: release-note
           draft: true

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -13,7 +13,15 @@
 
 name: C/D
 
-on:        
+on:     
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'the version number to release'
+        required: true
+      sha:
+        description: 'the github sha to release'
+        required: true   
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
@@ -42,7 +50,15 @@ jobs:
       latest-or-newer: ${{ steps.version.outputs.latest-or-newer }}
     steps: 
       - uses: actions/checkout@v3
-
+      - name: Set env
+        run: |
+          if ${{ github.event_name == 'workflow_dispatch' }}; then
+            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+            echo "SHA=${{ github.event.inputs.sha }}" >> $GITHUB_ENV
+          else
+            echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "SHA=${{ github.sha }}" >> $GITHUB_ENV
+          fi
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -56,7 +72,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
 
       - name: Download candidate
-        run: aws s3 cp "s3://aws-otel-collector-release-candidate/${{ github.sha }}.tar.gz" candidate.tar.gz
+        run: aws s3 cp "s3://aws-otel-collector-release-candidate/${{ env.SHA }}.tar.gz" candidate.tar.gz
 
       - name: Uncompress the candidate package
         run: tar zxvf candidate.tar.gz
@@ -68,12 +84,12 @@ jobs:
           version_in_release_candidate=`cat $PACKAGING_ROOT/TESTING_VERSION`
           sha_in_candidate=`cat $PACKAGING_ROOT/GITHUB_SHA`
 
-          if [ $version_in_release != ${{ github.ref_name }} ]; then
-            echo "::error::Wrong version is detected: $version_in_release != ${{ github.ref_name }}"
+          if [ $version_in_release != ${{ env.VERSION }} ]; then
+            echo "::error::Wrong version is detected: $version_in_release != ${{ env.VERSION }}"
             exit 1
           fi
-          if [ $sha_in_candidate != ${{ github.sha }} ]; then
-            echo "::error::Wrong SHA is detected: $sha_in_candidate != ${{ github.sha }}"
+          if [ $sha_in_candidate != ${{ env.SHA }} ]; then
+            echo "::error::Wrong SHA is detected: $sha_in_candidate != ${{ env.SHA }}"
             exit 1
           fi
 
@@ -194,7 +210,7 @@ jobs:
         with:
           workflow: release SSM package
           token: ${{ secrets.REPO_WRITE_ACCESS_TOKEN }}
-          inputs: '{ "version": "${{ needs.release-checking.outputs.version }}", "sha": "${{ github.sha }}", "public": "true", "pkgname": "${{ env.SSM_RELEASE_PACKAGE_NAME }}" }'
+          inputs: '{ "version": "${{ needs.release-checking.outputs.version }}", "sha": "${{ env.SHA }}", "public": "true", "pkgname": "${{ env.SSM_RELEASE_PACKAGE_NAME }}" }'
 
   release-to-github:
     runs-on: ubuntu-latest
@@ -203,7 +219,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ env.SHA }}
 
       - name: Generate release-note
         run: sh tools/release/generate-release-note.sh
@@ -214,7 +230,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
           tag_name: ${{ needs.release-checking.outputs.version }}
-          commitish: ${{ github.sha }}
+          commitish: ${{ env.SHA }}
           release_name: ${{ needs.release-checking.outputs.version }}
           body_path: release-note
           draft: true


### PR DESCRIPTION
**Description:** Changed the ADOT Collector CD workflow to be triggered on a new tag push.  Version number and commit hash is grabbed from Github Contexts.

**Testing:** Tested in the sample workflow in my own forked repo.

**Documentation:** documentation for collector release and patch release will be updated to reflect the changes.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
