### PR TITLE
Update terraform cleanup steps on cancel

### DIFF
--- a/.github/workflows/CI-Operator.yml
+++ b/.github/workflows/CI-Operator.yml
@@ -182,9 +182,14 @@ jobs:
           cd testing-framework/terraform
           make checkCacheHits
       
-      #This is here just in case workflow cancel
+      # This is here just in case workflow cancel
+      # We first kill terraform processes to ensure that no state
+      # file locks are being held from SIGTERMS dispatched in previous
+      # steps. 
       - name: Destroy resources
         if: ${{ cancelled() }}
+        shell: bash {0}
         run: |
+          ps -ef | grep terraform | grep -v grep | awk '{print $2}' | xargs -n 1 kill
           cd testing-framework/terraform
           make terraformCleanup

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -644,6 +644,7 @@ jobs:
       # steps. 
       - name: Destroy resources
         if: ${{ cancelled() }}
+        shell: bash {0}
         run: |
           ps -ef | grep terraform | grep -v grep | awk '{print $2}' | xargs -n 1 kill
           cd testing-framework/terraform


### PR DESCRIPTION
**Description:** Update terraform cleanup steps to use bash with no input args. [Default shell](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference) uses `-e` which will cause the run command to exit early if the `kill` command fails. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
