### PR TITLE
Prevent Operator CI from running on dev branch

### DIFF
--- a/.github/workflows/CI-Operator.yml
+++ b/.github/workflows/CI-Operator.yml
@@ -29,7 +29,6 @@ on:
       - '!.github/workflows/CI-Operator.yml'
       - '**.md'
 
-
 env:
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   DDB_TABLE_NAME: BatchTestCache

--- a/.github/workflows/CI-Operator.yml
+++ b/.github/workflows/CI-Operator.yml
@@ -24,8 +24,6 @@ on:
     branches:
       - main
       - release/v*
-      - dev
-      - test/*
     paths-ignore:
       - '.github/**'
       - '!.github/workflows/CI-Operator.yml'


### PR DESCRIPTION
**Description:** Prevent CI-Operator tests from running when changes are pushed to dev branch. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
