### PR TITLE
Fixed incorrect docker-compose command

### DIFF
--- a/docs/developers/docker-demo.md
+++ b/docs/developers/docker-demo.md
@@ -68,7 +68,7 @@ Please make sure you have the right aws credential path (eg, `~/.aws:/root/.aws`
 ```
 2. Once you have the ```docker-compose.yaml``` file setup and saved, run the following make command.
 ```
-cd examples; docker-compose up 
+cd examples; docker-compose -f ./docker/docker-compose.yaml up 
 ```
 3. Now you can view you data in AWS console
 


### PR DESCRIPTION
**Description:** Fixed incorrect docker-compose command.

**Link to tracking Issue:** N/A

**Testing:** N/A

**Documentation:** The `docker-compose` command, when called from the `examples` directory, does not find the `docker-compose.yaml` file. The updated command uses the `-f` flag to point `docker-compose` to it.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
