### PR TITLE
Fix usage of `--make_default_version` arg in ssm_create

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -509,7 +509,7 @@ jobs:
             pip3 install boto3
             python3 tools/ssm/ssm_manifest.py ${ssm_pkg_version}
             aws s3 cp build/packages/ssm s3://aws-otel-collector-test/ssm/${ssm_pkg_version} --recursive
-            python3 tools/ssm/ssm_create.py ${SSM_PACKAGE_NAME} ${ssm_pkg_version} aws-otel-collector-test/ssm/${ssm_pkg_version} us-west-2 --make_default_version=false
+            python3 tools/ssm/ssm_create.py ${SSM_PACKAGE_NAME} ${ssm_pkg_version} aws-otel-collector-test/ssm/${ssm_pkg_version} us-west-2
           }
       - name: Upload to S3 in the testing stack
         if: steps.e2etest-release.outputs.cache-hit != 'true'

--- a/.github/workflows/ssm-release.yml
+++ b/.github/workflows/ssm-release.yml
@@ -33,7 +33,8 @@ on:
       latest:
         description: 'set true if this is the latest version'
         required: true
-        default: 'true'
+        default: true
+        type: boolean
 
 env:
   SSM_S3_BUCKET: aws-otel-collector-ssm
@@ -56,6 +57,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.sha }}
+      
+      - name: Set SSM make default env -var
+        if: ${{ inputs.latest }}
+        run: echo "SSM_ADDTL_ARGS=--make_default_version" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -88,7 +93,7 @@ jobs:
           for region in ${REGIONS}; do
             echo "Create package in ${region}"
             python3 tools/ssm/ssm_create.py ${{ github.event.inputs.pkgname }} ${{ github.event.inputs.version }} \
-              ${{ env.SSM_S3_BUCKET }}/ssmfile/${{ github.event.inputs.version }} ${region} --make_default_version=${{ github.event.inputs.latest }}
+              ${{ env.SSM_S3_BUCKET }}/ssmfile/${{ github.event.inputs.version }} ${region} ${{ env.SSM_ADDTL_ARGS }}
           done
 
       - name: Publish SSM packages to global regions
@@ -127,7 +132,7 @@ jobs:
           for region in ${REGIONS}; do
             echo "Create package in ${region}"
             python3 tools/ssm/ssm_create.py ${{ github.event.inputs.pkgname }} ${{ github.event.inputs.version }} \
-              ${{ env.SSM_S3_BICKET_HKG }}/ssmfile/${{ github.event.inputs.version }} ${region} --make_default_version=${{ github.event.inputs.latest }}
+              ${{ env.SSM_S3_BICKET_HKG }}/ssmfile/${{ github.event.inputs.version }} ${region} ${{ env.SSM_ADDTL_ARGS }}
           done
 
       - name: Publish SSM packages to HKG
@@ -163,7 +168,7 @@ jobs:
           for region in ${REGIONS}; do
             echo "Create package in ${region}"
             python3 tools/ssm/ssm_create.py ${{ github.event.inputs.pkgname }} ${{ github.event.inputs.version }} \
-              ${{ env.SSM_S3_BICKET_BAH }}/ssmfile/${{ github.event.inputs.version }} ${region} --make_default_version=${{ github.event.inputs.latest }}
+              ${{ env.SSM_S3_BICKET_BAH }}/ssmfile/${{ github.event.inputs.version }} ${region} ${{ env.SSM_ADDTL_ARGS }}
           done
 
       - name: Publish SSM packages to BAH
@@ -199,7 +204,7 @@ jobs:
           for region in ${REGIONS}; do
             echo "Create package in ${region}"
             python3 tools/ssm/ssm_create.py ${{ github.event.inputs.pkgname }} ${{ github.event.inputs.version }} \
-              ${{ env.SSM_S3_BICKET_CPT }}/ssmfile/${{ github.event.inputs.version }} ${region} --make_default_version=${{ github.event.inputs.latest }}
+              ${{ env.SSM_S3_BICKET_CPT }}/ssmfile/${{ github.event.inputs.version }} ${region} ${{ env.SSM_ADDTL_ARGS }}
           done
 
       - name: Publish SSM packages to CPT
@@ -235,7 +240,7 @@ jobs:
           for region in ${REGIONS}; do
             echo "Create package in ${region}"
             python3 tools/ssm/ssm_create.py ${{ github.event.inputs.pkgname }} ${{ github.event.inputs.version }} \
-              ${{ env.SSM_S3_BICKET_MXP }}/ssmfile/${{ github.event.inputs.version }} ${region} --make_default_version=${{ github.event.inputs.latest }}
+              ${{ env.SSM_S3_BICKET_MXP }}/ssmfile/${{ github.event.inputs.version }} ${region} ${{ env.SSM_ADDTL_ARGS }}
           done
 
       - name: Publish SSM packages to MXP
@@ -272,7 +277,7 @@ jobs:
           for region in ${REGIONS}; do
             echo "Share package to public in ${region}"
             python3 tools/ssm/ssm_create.py ${{ github.event.inputs.pkgname }} ${{ github.event.inputs.version }} \
-              ${{ env.SSM_S3_BICKET_CN }}/ssmfile/${{ github.event.inputs.version }} ${region} --make_default_version=${{ github.event.inputs.latest }}
+              ${{ env.SSM_S3_BICKET_CN }}/ssmfile/${{ github.event.inputs.version }} ${region} ${{ env.SSM_ADDTL_ARGS }}
           done
 
       - name: Publish SSM packages to CN regions


### PR DESCRIPTION
**Description:** Previously changes were made to the `ssm_create` args to utilize `make_default_version` which would control whether or not the `ssm_create` script would update the default ver. These changes incorrectly assumed that `argparse` treated `--make_default_version` as a flag rather than an on/off arg. See argparse docs [here](https://docs.python.org/3/library/argparse.html#action) for correct usage. This PR fixes the usage of that arg. 

- CI  no longer requires the arg to be passed since it will default to false
- Release SSM now adds a `boolean` type to `latest` input. This allows us to treat it as a boolean in the subsequent step. See GitHub docs [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs) related to that change. 
- We now have a prereq step to set an env var, `SSM_ADDTL_ARGS` which will be used whenever `ssm_create` is called. 


**Testing:** I had initial questions on how a GHA would behave if an env var that wasn't present was referenced. I created a t[est workflow](https://github.com/bryan-aguilar/aws-otel-collector/blob/ssmCreateArgFix_test/.github/workflows/env-var-test.yml) in a fork and ensured that no errors would be surfaced in that case. Test workflow [results](https://github.com/bryan-aguilar/aws-otel-collector/actions/runs/3906453400/jobs/6674646548). 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
