### PR TITLE
Add ref for cache-from value

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -544,7 +544,7 @@ jobs:
             public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.e2etest-preparation.outputs.version }}
             public.ecr.aws/${{ env.ECR_REPO }}:latest
           build-args: BUILDMODE=copy
-          cache-from: type=registry
+          cache-from: type=registry,ref=public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.e2etest-preparation.outputs.version }}
           cache-to: type=inline
           platforms : linux/amd64, linux/arm64
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
**Description:** The CI job for `e2e-release` started to fail in the build push step for `buildx failed with: ERROR: registry cache importer requires ref`. The last time this job was ran successfully buildx used version `v0.9.0` and the latest run uses `v0.10.0`.[ Release notes](https://github.com/docker/buildx/releases) for buildx do not reference this change anywhere but the official [docs](https://docs.docker.com/build/ci/github-actions/examples/#inline-cache) have this value listed in their recommended configuration. 


The latest [`build-push-action` ](https://github.com/docker/build-push-action/releases)release also had a change that may affect us. I do not think the latest provenance related changes would result in this error message though. If this continues to fail for this reason I will try setting to provenance to off. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
