### PR TITLE
Fix get operator tag script to be more reliable

### DIFF
--- a/tools/release/adot-operator-images-mirror/get-operator-tag.sh
+++ b/tools/release/adot-operator-images-mirror/get-operator-tag.sh
@@ -13,13 +13,15 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-COLLECTOR_TAG=$(cat go.mod | grep "go.opentelemetry.io/collector " | cut -d " " -f 2 | cut -d "." -f 1,2)
+COLLECTOR_VERSION_FULL=$(cat ../../../go.mod | grep "go.opentelemetry.io/collector " | cut -d " " -f 2)
+COLLECTOR_VERSION_MAJOR_MINOR=$(echo $COLLECTOR_VERSION_FULL | cut -d "." -f 1,2)
 
-OPERATOR_TAG=$(curl https://api.github.com/repos/open-telemetry/opentelemetry-operator/tags | jq -r "sort_by(.name) | reverse | map(select( .name | startswith(\"${COLLECTOR_TAG}\"))) | first | .name")
+OPERATOR_TAG_FULL=$(curl https://api.github.com/repos/open-telemetry/opentelemetry-operator/tags | jq -r "sort_by(.name) | reverse | map(select( .name | startswith(\"${COLLECTOR_VERSION_MAJOR_MINOR}\"))) | first | .name")
+OPERATOR_TAG_MAJOR_MINOR=$(echo $OPERATOR_TAG_FULL | cut -d "." -f 1,2)
 
-if [[ $OPERATOR_TAG == "" ]]; then
+if [[ $OPERATOR_TAG_MAJOR_MINOR == $COLLECTOR_VERSION_MAJOR_MINOR ]]; then
+    echo "operator-tag=$OPERATOR_TAG_FULL"
+else
     echo "NO OPERATOR IMAGE EXISTS FOR THIS COLLECTOR IMAGE"
     exit 1
-else
-    echo "operator-tag=$OPERATOR_TAG" >> $GITHUB_OUTPUT
 fi


### PR DESCRIPTION
**Description:** I was noticing that sometimes the `get-operator-tag.sh` script would make it exit with a 0 exit code even though no operator tag existed for that minor version. See [here](https://github.com/aws-observability/aws-otel-collector/actions/runs/4000218623/jobs/6865074462#step:14:33) for an example. This is because the `OPERATOR_TAG` would sometimes be set as `null` after the JQ query. I have modified the script to work more reliably as it was originally intended. It was written to search for a matching`major.minor` version. See test results below for the script run with `set -x`. On the second test I hard coded `COLLECTOR_VERSION_MAJOR_MINOR=v0.68` to show that it could actually search. 

**Testing:** 
`set -x`
```
bryaag@147ddac12c15 adot-operator-images-mirror % ./get-operator-tag.sh                                                                                                                                                     
++ cat ../../../go.mod                                                                                                                                                                                                      
++ grep 'go.opentelemetry.io/collector '                                                                                                                                                                                    
++ cut -d ' ' -f 2                                                                                                                                                                                                          
+ COLLECTOR_VERSION_FULL=v0.70.0                                                                                                                                                                                            
++ echo v0.70.0                                                                                                                                                                                                             
++ cut -d . -f 1,2                                                                                                                                                                                                          
+ COLLECTOR_VERSION_MAJOR_MINOR=v0.70                                                                                                                                                                                       
++ curl https://api.github.com/repos/open-telemetry/opentelemetry-operator/tags                                                                                                                                             
++ jq -r 'sort_by(.name) | reverse | map(select( .name | startswith("v0.70"))) | first | .name'                                                                                                                             
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current                                                                                                                                             
                                 Dload  Upload   Total   Spent    Left  Speed                                                                                                                                               
100 16053  100 16053    0     0  42936      0 --:--:-- --:--:-- --:--:-- 43741
+ OPERATOR_TAG_FULL=null
++ echo null
++ cut -d . -f 1,2
+ OPERATOR_TAG_MAJOR_MINOR=null
+ [[ null == v0.70 ]]
+ echo 'NO OPERATOR IMAGE EXISTS FOR THIS COLLECTOR IMAGE'
NO OPERATOR IMAGE EXISTS FOR THIS COLLECTOR IMAGE
+ exit 1
```
`COLLECTOR_VERSION_MAJOR_MINOR=v0.68`
```
bryaag@147ddac12c15 adot-operator-images-mirror % ./get-operator-tag.sh
++ cat ../../../go.mod
++ grep 'go.opentelemetry.io/collector '
++ cut -d ' ' -f 2
+ COLLECTOR_VERSION_FULL=v0.70.0
++ echo v0.68.0
++ cut -d . -f 1,2
+ COLLECTOR_VERSION_MAJOR_MINOR=v0.68
++ curl https://api.github.com/repos/open-telemetry/opentelemetry-operator/tags
++ jq -r 'sort_by(.name) | reverse | map(select( .name | startswith("v0.68"))) | first | .name'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 16053  100 16053    0     0  67599      0 --:--:-- --:--:-- --:--:-- 69795
+ OPERATOR_TAG_FULL=v0.68.0
++ echo v0.68.0
++ cut -d . -f 1,2
+ OPERATOR_TAG_MAJOR_MINOR=v0.68
+ [[ v0.68 == v0.68 ]]
+ echo operator-tag=v0.68.0
operator-tag=v0.68.0
```



**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
