### PR TITLE
[windows][CI/CD] ADOT collector delayed start

### DIFF
--- a/tools/packaging/windows/aws-otel-collector.wxs
+++ b/tools/packaging/windows/aws-otel-collector.wxs
@@ -64,6 +64,7 @@ Account="LocalSystem"
 ErrorControl="normal"
 Arguments=" --config=&quot;[INSTALLDIR]config.yaml&quot;"
 Interactive="no">
+<ServiceConfig DelayedAutoStart="yes" OnInstall="yes" OnReinstall ="yes" />
     </ServiceInstall>
     <ServiceControl
 Id="StartService"


### PR DESCRIPTION
**Description:** 

Sets ADOT collector agent as Automatic (delayed start) services to mitigate known go windows issues with 1.9.2: https://github.com/golang/go/issues/23479

Services would not restart across reboots on Automatic services, they would timeout before coming up and the service control manager would give up spawning them. 

**Link to tracking Issue:** https://github.com/aws-observability/aws-otel-collector/issues/1767



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
