### PR TITLE
Limit Concurrent jobs in PR build

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -220,6 +220,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes, get-test-cases, build, create-test-ref]
     strategy:
+      max-parallel: 4
       matrix: ${{ fromJson(needs.get-test-cases.outputs.matrix) }}
     steps:
       - name: Check out testing framework


### PR DESCRIPTION
**Description:** 

Limit Concurrent jobs in `PR build` to `4` as we seem to be hitting [rate limit in ECR](https://github.com/aws-observability/aws-otel-collector/actions/runs/4056278325/jobs/6981716029#step:8:756) as we concurrent run all jobs in PR build workflow. 



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
