### PR TITLE
Modify Dockerfile to include target file.

### DIFF
--- a/.github/workflows/CD-adot-operator.yml
+++ b/.github/workflows/CD-adot-operator.yml
@@ -39,7 +39,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.COLLECTOR_PROD_RELEASE_ROLE_ARN }}
-          aws-region: us-east-1
+          aws-region: us-west-2
 
       - name: Login to Public Release ECR
         uses: docker/login-action@v2

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -265,6 +265,7 @@ jobs:
         with:
           max_attempts: 2
           timeout_minutes: 10
+          retry_wait_seconds: 10
           command: |
             if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi
             cd testing-framework/terraform/mock && terraform init && terraform apply -auto-approve -var="testcase=../testcases/${{ matrix.testcase }}" $opts

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -220,6 +220,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes, get-test-cases, build, create-test-ref]
     strategy:
+      max-parallel: 4
       matrix: ${{ fromJson(needs.get-test-cases.outputs.matrix) }}
     steps:
       - name: Check out testing framework

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -30,6 +30,10 @@ concurrency:
   group: pr-build-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   create-test-ref:
     runs-on: ubuntu-latest
@@ -258,6 +262,12 @@ jobs:
       - name: copy binary
         if: ${{ needs.changes.outputs.changed == 'true' }}
         run: cp -R build aws-otel-collector/build
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.COLLECTOR_PR_BUILD_ROLE_ARN }}
+          aws-region: us-east-1
 
       - name: Login to Public Integration Test ECR
         uses: docker/login-action@v2

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -259,6 +259,13 @@ jobs:
         if: ${{ needs.changes.outputs.changed == 'true' }}
         run: cp -R build aws-otel-collector/build
 
+      - name: Login to Public Integration Test ECR
+        uses: docker/login-action@v2
+        with:
+          registry: public.ecr.aws
+        env:
+          AWS_REGION: us-east-1
+          
       - name: Run test
         if: ${{ needs.changes.outputs.changed == 'true' }}
         uses: nick-invision/retry@v2

--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -11,6 +11,9 @@ FROM alpine:latest AS certs
 
 RUN apk --update add ca-certificates
 
+FROM alpine:latest AS ecstarget
+RUN touch ecs_sd_targets.yaml
+
 ################################
 #	Build Stage            #
 #			       #
@@ -72,6 +75,7 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=package /workspace/awscollector /awscollector
 COPY --from=package /workspace/config/ /etc/
 COPY --from=package /workspace/healthcheck /healthcheck
+COPY --from=ecstarget ecs_sd_targets.yaml /etc/
 
 ENV RUN_IN_CONTAINER="True"
 # aws-sdk-go needs $HOME to look up shared credentials

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -48,6 +48,10 @@
 		"platforms": ["ECS"]
 	},
 	{
+		"case_name": "containerinsight_ecs_prometheus",
+		"platforms": ["ECS"]
+	},
+	{
 		"case_name": "otlp_trace_resourcedetection_eks",
 		"platforms": ["EKS", "EKS_ARM64"]
 	},

--- a/tools/release/adot-operator-images-mirror/config.yaml
+++ b/tools/release/adot-operator-images-mirror/config.yaml
@@ -3,7 +3,8 @@ sourceRepos:
   - registry: open-telemetry/opentelemetry-operator
     name: opentelemetry-operator
     host: ghcr.io
-    allowed_tags: 
+    allowed_tags:
+      - v0.68.0
       - v0.66.0
       - v0.62.1
       - v0.61.0
@@ -28,6 +29,7 @@ sourceRepos:
       - 0.1.0
       - 0.60.0
       - 0.66.0
+      - 0.68.0
   - registry: open-telemetry/opentelemetry-operator
     name: autoinstrumentation-java
     host: ghcr.io
@@ -36,12 +38,14 @@ sourceRepos:
       - 1.18.0
       - 1.19.1
       - 1.20.2
+      - 1.22.1
   - registry: open-telemetry/opentelemetry-operator
     name: autoinstrumentation-nodejs
     host: ghcr.io
     allowed_tags:
       - 0.27.0
       - 0.31.0
+      - 0.34.0
   - registry: open-telemetry/opentelemetry-operator
     name: autoinstrumentation-python
     host: ghcr.io
@@ -52,6 +56,7 @@ sourceRepos:
       - 0.33b0
       - 0.34b0
       - 0.35b0
+      - 0.36b0
   - registry: open-telemetry/opentelemetry-operator
     name: autoinstrumentation-dotnet
     host: ghcr.io


### PR DESCRIPTION
**Description:**
This PR is created as a workaround for [ecsobserver extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/ecsobserver) to auto-discover Prometheus targets. By creating the file `ecs_sd_targets.yaml` at this path, the collector can auto-discover Prometheus targets and scrape them.

**Link to tracking Issue:** [#5373](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5373)

**Testing:** 



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
