### PR TITLE
Modify Dockerfile to include target file.

### DIFF
--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -11,6 +11,7 @@ FROM alpine:latest AS certs
 
 RUN apk --update add ca-certificates
 
+# Create ecs_sd_targets.yaml for prometheus receiver to use ecsoberver extension
 FROM alpine:latest AS ecstarget
 RUN touch ecs_sd_targets.yaml
 

--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -11,6 +11,9 @@ FROM alpine:latest AS certs
 
 RUN apk --update add ca-certificates
 
+FROM alpine:latest AS ecstarget
+RUN touch ecs_sd_targets.yaml
+
 ################################
 #	Build Stage            #
 #			       #
@@ -72,6 +75,7 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=package /workspace/awscollector /awscollector
 COPY --from=package /workspace/config/ /etc/
 COPY --from=package /workspace/healthcheck /healthcheck
+COPY --from=ecstarget ecs_sd_targets.yaml /etc/
 
 ENV RUN_IN_CONTAINER="True"
 # aws-sdk-go needs $HOME to look up shared credentials

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -48,6 +48,10 @@
 		"platforms": ["ECS"]
 	},
 	{
+		"case_name": "containerinsight_ecs_prometheus",
+		"platforms": ["ECS"]
+	},
+	{
 		"case_name": "otlp_trace_resourcedetection_eks",
 		"platforms": ["EKS", "EKS_ARM64"]
 	},


### PR DESCRIPTION
**Description:**
This PR is created as a workaround for [ecsobserver extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/ecsobserver) to auto-discover Prometheus targets. More details here :  [#5373](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5373). By creating the file `ecs_sd_targets.yaml` at this path, the collector can auto-discover Prometheus targets and scrape them.

**Link to tracking Issue:** #1636 

**Testing:** 

This PR is dependent and to be merged after https://github.com/aws-observability/aws-otel-test-framework/pull/1069




<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
