### PR TITLE
Fix sed command in bump version script

### DIFF
--- a/tools/release/bump-version-and-create-release-note.sh
+++ b/tools/release/bump-version-and-create-release-note.sh
@@ -37,7 +37,7 @@ echo "${RELEASE_VERSION}" >VERSION
 
 #Update aws-otel-collector wxs template file. 
 # Note: Only supports [0-9]*.[0-9]*.[0-9]* version pattern. If we decide to release with a full sem ver vX.XX.XX-prerelease then the .wxs file will need to be manually updated
-sed -i '' "s/^Version\=\"[0-9]+.[0-9]+.[0-9]+\"/Version=\"${RELEASE_VERSION:1}\"/" tools/packaging/windows/aws-otel-collector.wxs
+sed -E -i '' "s/^Version\=\"[0-9]+.[0-9]+.[0-9]+\"/Version=\"${RELEASE_VERSION:1}\"/" ./tools/packaging/windows/aws-otel-collector.wxs
 
 # git commit
 git add VERSION "docs/releases/${RELEASE_VERSION}.md"


### PR DESCRIPTION
**Description:** During the release for `v0.26.0` I noticed that the bump version script did not correctly update the version in the `.wxs` file. This PR updates the `sed` command to use `-E` for extended regular expressions. 
**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Tested with 
```
RELEASE_VERSION=v0.26.1 ./tools/release/bump-version-and-create-release-note.sh
```

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
