### PR TITLE
Modify Dockerfile to include target file

### DIFF
--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -11,7 +11,7 @@ FROM alpine:latest AS certs
 
 RUN apk --update add ca-certificates
 
-# Create ecs_sd_targets.yaml for prometheus receiver to use ecsobserver extension, see below issue for more info
+# Create ecs_sd_targets.yaml for prometheus receiver to use ecsobserver extension, see below issue for more info:
 # issue :https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5373
  FROM alpine:latest AS ecstarget
  RUN touch ecs_sd_targets.yaml

--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -11,6 +11,11 @@ FROM alpine:latest AS certs
 
 RUN apk --update add ca-certificates
 
+# Create ecs_sd_targets.yaml for prometheus receiver to use ecsobserver extension, see below issue for more info
+# issue :https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5373
+ FROM alpine:latest AS ecstarget
+ RUN touch ecs_sd_targets.yaml
+
 ################################
 #	Build Stage            #
 #			       #
@@ -72,6 +77,7 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=package /workspace/awscollector /awscollector
 COPY --from=package /workspace/config/ /etc/
 COPY --from=package /workspace/healthcheck /healthcheck
+COPY --from=ecstarget ecs_sd_targets.yaml /etc/
 
 ENV RUN_IN_CONTAINER="True"
 # aws-sdk-go needs $HOME to look up shared credentials

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -48,6 +48,10 @@
 		"platforms": ["ECS"]
 	},
 	{
+		"case_name": "containerinsight_ecs_prometheus",
+		"platforms": ["ECS"]
+	},
+	{
 		"case_name": "otlp_trace_resourcedetection_eks",
 		"platforms": ["EKS", "EKS_ARM64"]
 	},


### PR DESCRIPTION
**Description:**
This PR is created as a workaround for [ecsobserver extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/ecsobserver) to auto-discover Prometheus targets. More details here :  [#5373](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5373). By creating the file `ecs_sd_targets.yaml` at this path, the collector can auto-discover Prometheus targets and scrape them.


**Link to tracking Issue:** #1636 


**Testing:** 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
