### PR TITLE
Add support to remote uris in service control scripts in Windows and Linux

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-config=--config /opt/aws/aws-otel-collector/etc/config.yaml
+config="--config /opt/aws/aws-otel-collector/etc/config.yaml"

--- a/tools/ctl/linux/aws-otel-collector-ctl
+++ b/tools/ctl/linux/aws-otel-collector-ctl
@@ -44,7 +44,7 @@ UsageString="
   status:                                 get the status of the agent process.
 
   -c: configuration
-  <config-uri>:                           - file path on the host. E.g.: /tmp/config.yaml
+  <config-uri>:                           - file path on the host. E.g.: /tmp/config.yaml or file:/tmp/config.yaml
                                           - http uri. E.g.: http://example.com/config
                                           - https uri. E.g.: https://example.com/config
                                           - s3 uri. E.g.: s3://bucket/config
@@ -59,6 +59,9 @@ aoc_config_remote_uri() {
 
 aoc_config_local_uri() {
     config="${1:-}"
+
+    # Strip the file scheme in case it is present
+    config="${config#file:}"
 
     echo "config=\"--config /opt/aws/aws-otel-collector/etc/config.yaml\"" > $ENV_FILE
 

--- a/tools/ctl/linux/aws-otel-collector-ctl
+++ b/tools/ctl/linux/aws-otel-collector-ctl
@@ -19,16 +19,16 @@ set -u
 readonly AGENTDIR="/opt/aws/aws-otel-collector"
 readonly CMDDIR="${AGENTDIR}/bin"
 readonly CONFDIR="${AGENTDIR}/etc"
+readonly ENV_FILE="${CONFDIR}/.env"
 readonly DFT_CONFDIR="${AGENTDIR}/var"
 readonly LOGDIR="${AGENTDIR}/logs"
-readonly RESTART_FILE="${CONFDIR}/restart"
 readonly VERSION_FILE="${CMDDIR}/VERSION"
 
 SYSTEMD='false'
 
 UsageString="
 
-  usage: aws-otel-collector-ctl -a stop|start|status| [-c file:<file-path>]
+  usage: aws-otel-collector-ctl -a stop|start|status| [-c <config-uri>]
 
   e.g.
   1. start collector on onPermise host with a custom .yaml config file:
@@ -44,12 +44,23 @@ UsageString="
   status:                                 get the status of the agent process.
 
   -c: configuration
-  file:<file-path>:                       file path on the host
+  <config-uri>:                           - file path on the host. E.g.: /tmp/config.yaml
+                                          - http uri. E.g.: http://example.com/config
+                                          - https uri. E.g.: https://example.com/config
+                                          - s3 uri. E.g.: s3://bucket/config
 
   "
 
-aoc_start() {
+aoc_config_remote_uri() {
     config="${1:-}"
+
+    echo "config=\"--config ${config}\"" > $ENV_FILE
+}
+
+aoc_config_local_uri() {
+    config="${1:-}"
+
+    echo "config=\"--config /opt/aws/aws-otel-collector/etc/config.yaml\"" > $ENV_FILE
 
     if [ ! -z $config ] && [ -f $config ]; then
         cp $config $CONFDIR/config.yaml
@@ -57,6 +68,16 @@ aoc_start() {
 
     if [ ! -f $CONFDIR/config.yaml ]; then
         cp $DFT_CONFDIR/.config.yaml $CONFDIR/config.yaml
+    fi
+}
+
+aoc_start() {
+    config="${1:-}"
+
+    if [[ $config =~ ^(https|http|s3)://.* ]]; then
+        aoc_config_remote_uri $config
+    else
+        aoc_config_local_uri $config
     fi
 
     if [ "${SYSTEMD}" = 'true' ]; then

--- a/tools/ctl/linux/aws-otel-collector-ctl
+++ b/tools/ctl/linux/aws-otel-collector-ctl
@@ -71,10 +71,19 @@ aoc_config_local_uri() {
     fi
 }
 
+is_remote_uri() {
+    config="${1:-}"
+
+    if [[ $config =~ ^[a-zA-Z0-9]+:// && ! $config =~ ^file: ]]; then
+        return 0;
+    fi
+    return 1
+}
+
 aoc_start() {
     config="${1:-}"
 
-    if [[ $config =~ ^(https|http|s3)://.* ]]; then
+    if is_remote_uri "$config"; then
         aoc_config_remote_uri $config
     else
         aoc_config_local_uri $config

--- a/tools/ctl/windows/aws-otel-collector-ctl.ps1
+++ b/tools/ctl/windows/aws-otel-collector-ctl.ps1
@@ -87,17 +87,17 @@ Function Set-Service-Config-Uri ([string]$uri) {
 }
 
 Function Test-Remote-Uri ([string]$uri) {
-    return $uri -match "^(http|https|s3)://"
+    return $uri -match "^[a-zA-Z0-9]+://" -and $uri -notmatch "^file:"
 }
 
 Function AOCStart() {
 
     if($ConfigLocation -and $ConfigLocation -ne 'default') {
-        if (!(Test-Remote-Uri $ConfigLocation)) {
+        if (Test-Remote-Uri $ConfigLocation) {
+            Set-Service-Config-Uri ${ConfigLocation}
+        } else {
             Copy-Item "${ConfigLocation}" -Destination ${ProgramFilesYAML}
             Set-Service-Config-Uri ${ProgramFilesYAML}
-        } else {
-            Set-Service-Config-Uri ${ConfigLocation}
         }
     }
 

--- a/tools/ctl/windows/aws-otel-collector-ctl.ps1
+++ b/tools/ctl/windows/aws-otel-collector-ctl.ps1
@@ -48,7 +48,7 @@ $UsageString = @"
             status:                                 get the status of the agent process.
 
         -c: <config-uri>
-            - file path on the host. E.g.: /tmp/config.yaml
+            - file path on the host. E.g.: c:\tmp\config.yaml or file:c:\tmp\config.yaml
             - http uri. E.g.: http://example.com/config
             - https uri. E.g.: https://example.com/config
             - s3 uri. E.g.: s3://bucket/config
@@ -96,6 +96,9 @@ Function AOCStart() {
         if (Test-Remote-Uri $ConfigLocation) {
             Set-Service-Config-Uri ${ConfigLocation}
         } else {
+            # Strip file scheme in case it is present
+            $ConfigLocation = "$ConfigLocation" -replace "^file:", ""
+
             Copy-Item "${ConfigLocation}" -Destination ${ProgramFilesYAML}
             Set-Service-Config-Uri ${ProgramFilesYAML}
         }


### PR DESCRIPTION
**Description:** It is now possible to pass remote uris such as http, https and s3 to the control scripts in Windows an Linux.

**Testing:** Tested changes locally

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
