### PR TITLE
[release/v0.26.x] Correclty target go.mod

### DIFF
--- a/tools/release/adot-operator-images-mirror/get-operator-tag.sh
+++ b/tools/release/adot-operator-images-mirror/get-operator-tag.sh
@@ -12,13 +12,11 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-
-COLLECTOR_VERSION_FULL=$(cat ../../../go.mod | grep "go.opentelemetry.io/collector " | cut -d " " -f 2)
+COLLECTOR_VERSION_FULL=$(cat go.mod | grep "go.opentelemetry.io/collector " | cut -d " " -f 2)
 COLLECTOR_VERSION_MAJOR_MINOR=$(echo $COLLECTOR_VERSION_FULL | cut -d "." -f 1,2)
 
 OPERATOR_TAG_FULL=$(curl https://api.github.com/repos/open-telemetry/opentelemetry-operator/tags | jq -r "sort_by(.name) | reverse | map(select( .name | startswith(\"${COLLECTOR_VERSION_MAJOR_MINOR}\"))) | first | .name")
 OPERATOR_TAG_MAJOR_MINOR=$(echo $OPERATOR_TAG_FULL | cut -d "." -f 1,2)
-
 if [[ $OPERATOR_TAG_MAJOR_MINOR == $COLLECTOR_VERSION_MAJOR_MINOR ]]; then
     echo "operator-tag=$OPERATOR_TAG_FULL"
 else

--- a/tools/release/adot-operator-images-mirror/get-operator-tag.sh
+++ b/tools/release/adot-operator-images-mirror/get-operator-tag.sh
@@ -18,7 +18,7 @@ COLLECTOR_VERSION_MAJOR_MINOR=$(echo $COLLECTOR_VERSION_FULL | cut -d "." -f 1,2
 OPERATOR_TAG_FULL=$(curl https://api.github.com/repos/open-telemetry/opentelemetry-operator/tags | jq -r "sort_by(.name) | reverse | map(select( .name | startswith(\"${COLLECTOR_VERSION_MAJOR_MINOR}\"))) | first | .name")
 OPERATOR_TAG_MAJOR_MINOR=$(echo $OPERATOR_TAG_FULL | cut -d "." -f 1,2)
 if [[ $OPERATOR_TAG_MAJOR_MINOR == $COLLECTOR_VERSION_MAJOR_MINOR ]]; then
-    echo "operator-tag=$OPERATOR_TAG_FULL"
+    echo "operator-tag=$OPERATOR_TAG_FULL" >> $GITHUB_OUTPUT
 else
     echo "NO OPERATOR IMAGE EXISTS FOR THIS COLLECTOR IMAGE"
     exit 1


### PR DESCRIPTION
**Description:** Fix error in fetching operator tag. 

```
bryaag@147ddac12c15 aws-otel-collector % ./tools/release/adot-operator-images-mirror/get-operator-tag.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 16053  100 16053    0     0  39231      0 --:--:-- --:--:-- --:--:-- 39932
operator-tag=v0.70.0
```
<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
