### PR TITLE
Add opamp repository to Operator mirror, and mirror 0.70.0 image

### DIFF
--- a/tools/release/adot-operator-images-mirror/config.yaml
+++ b/tools/release/adot-operator-images-mirror/config.yaml
@@ -68,6 +68,11 @@ sourceRepos:
       - 0.3.1-beta.1
       - 0.4.0-beta.1
       - 0.5.0
+  - registry: open-telemetry/opentelemetry-operator
+    name: operator-opamp-bridge
+    host: ghcr.io
+    allowed_tags:
+      - 0.70.0
 
 targetRepos:
   - registry: public.ecr.aws/aws-observability
@@ -84,3 +89,5 @@ targetRepos:
     name: mirror-autoinstrumentation-python
   - registry: public.ecr.aws/aws-observability
     name: mirror-autoinstrumentation-dotnet
+  - registry: public.ecr.aws/aws-observability
+    name: mirror-operator-opamp-bridge


### PR DESCRIPTION
<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
