### PR TITLE
Revert "Create default components after initializing feature gates"

### DIFF
--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -51,6 +51,12 @@ func main() {
 	}
 
 	logger.SetupErrorLogger()
+
+	factories, err := defaultcomponents.Components()
+	if err != nil {
+		log.Fatalf("failed to build components: %v", err)
+	}
+
 	// set the collector config from extracfg file
 	if extraConfig != nil {
 		setCollectorConfigFromExtraCfg(extraConfig)
@@ -63,6 +69,7 @@ func main() {
 	}
 
 	params := otelcol.CollectorSettings{
+		Factories:      factories,
 		BuildInfo:      info,
 		LoggingOptions: []zap.Option{logger.WrapCoreOpt()},
 	}
@@ -102,21 +109,13 @@ func newCommand(params otelcol.CollectorSettings) *cobra.Command {
 		Use:          params.BuildInfo.Command,
 		Version:      params.BuildInfo.Version,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			reg := featuregate.GlobalRegistry()
 			for id, enabled := range config.GetFeatureGatesFlag(flagSet) {
 				if err := reg.Set(id, enabled); err != nil {
 					return err
 				}
 			}
-			return nil
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			factories, err := defaultcomponents.Components()
-			if err != nil {
-				log.Fatalf("failed to build components: %v", err)
-			}
-			params.Factories = factories
 			// Initialize provider after flags have been set
 			params.ConfigProvider = config.GetConfigProvider(flagSet)
 			col, err := otelcol.NewCollector(params)

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -68,7 +68,7 @@ import (
 func Components() (otelcol.Factories, error) {
 	var errs error
 
-	extensionsList := []extension.Factory{
+	extensions, err := extension.MakeFactoryMap(
 		awsproxy.NewFactory(),
 		ecsobserver.NewFactory(),
 		healthcheckextension.NewFactory(),
@@ -76,14 +76,13 @@ func Components() (otelcol.Factories, error) {
 		sigv4authextension.NewFactory(),
 		zpagesextension.NewFactory(),
 		ballastextension.NewFactory(),
-	}
-	extensions, err := extension.MakeFactoryMap(extensionsList...)
+	)
 
 	if err != nil {
 		errs = multierr.Append(errs, err)
 	}
 
-	receiverList := []receiver.Factory{
+	receivers, err := receiver.MakeFactoryMap(
 		awsecscontainermetricsreceiver.NewFactory(),
 		awscontainerinsightreceiver.NewFactory(),
 		awsxrayreceiver.NewFactory(),
@@ -92,15 +91,13 @@ func Components() (otelcol.Factories, error) {
 		jaegerreceiver.NewFactory(),
 		zipkinreceiver.NewFactory(),
 		otlpreceiver.NewFactory(),
-	}
-
-	receivers, err := receiver.MakeFactoryMap(receiverList...)
+	)
 
 	if err != nil {
 		errs = multierr.Append(errs, err)
 	}
 
-	processorList := []processor.Factory{
+	processors, err := processor.MakeFactoryMap(
 		attributesprocessor.NewFactory(),
 		resourceprocessor.NewFactory(),
 		probabilisticsamplerprocessor.NewFactory(),
@@ -113,15 +110,15 @@ func Components() (otelcol.Factories, error) {
 		deltatorateprocessor.NewFactory(),
 		batchprocessor.NewFactory(),
 		memorylimiterprocessor.NewFactory(),
-	}
-	processors, err := processor.MakeFactoryMap(processorList...)
+	)
 
 	if err != nil {
 		errs = multierr.Append(errs, err)
 	}
 
 	// enable the selected exporters
-	exporterList := []exporter.Factory{
+
+	exporters, err := exporter.MakeFactoryMap(awsxrayexporter.NewFactory(),
 		awsemfexporter.NewFactory(),
 		prometheusremotewriteexporter.NewFactory(),
 		prometheusexporter.NewFactory(),
@@ -134,9 +131,7 @@ func Components() (otelcol.Factories, error) {
 		loggingexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),
-		awsxrayexporter.NewFactory(),
-	}
-	exporters, err := exporter.MakeFactoryMap(exporterList...)
+	)
 
 	if err != nil {
 		errs = multierr.Append(errs, err)


### PR DESCRIPTION
Reverts aws-observability/aws-otel-collector#1911

This PR missed the issue of starting a new Windows service handler. That operation happens [here](https://github.com/aws-observability/aws-otel-collector/blob/51b93922f4a62faa080e381eeaf111df52a2136e/cmd/awscollector/main_windows.go#L45). The factories are required to be set before calling the creation script and the we cannot maintain a copy of `NewSvcHandler` as upstream does not export `[windowsService](https://github.com/open-telemetry/opentelemetry-collector/blob/release/v0.72.x/otelcol/collector_windows.go)`. There are [upcoming changes](https://github.com/open-telemetry/opentelemetry-collector/commit/a70c017046a80725c659d053322923d5bd5d27dc) to `flags.go` and the feature gate repository in `v0.74.0`. 

I will revert this PR, upgrade to `v0.74.0` and re address this feature. I believe we may be able to accomplish this easier after `v0.74.0` is released. 