### PR TITLE
Parse flags before creating confmap provider

### DIFF
--- a/cmd/awscollector/main_windows.go
+++ b/cmd/awscollector/main_windows.go
@@ -48,6 +48,10 @@ func run(params otelcol.CollectorSettings) error {
 func runService(params otelcol.CollectorSettings) error {
 	// do not need to supply service name when startup is invoked through Service Control Manager directly
 	flagSet := config.Flags(featuregate.GlobalRegistry())
+	// Parse all the flags manually. Flags need to be parsed so URIs can be set in confmap provider.
+	if err := flagSet.Parse(os.Args[1:]); err != nil {
+		return err
+	}
 	params.ConfigProvider = config.GetConfigProvider(flagSet)
 	if err := svc.Run("", otelcol.NewSvcHandler(params)); err != nil {
 		return errors.Wrap(err, "failed to start service")


### PR DESCRIPTION
**Description:** Fixes an issue that arose after merging #1921. The flags need to be manually parsed before creating the config map provider so URIs can be correctly set. Previously the collector service would not start because `Err on creating Config Provider: invalid map resolver config: no URIs` error. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
