### PR TITLE
[chore] Add replace statement for `tparallel`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -375,3 +375,6 @@ replace github.com/outcaste-io/ristretto v0.2.0 => github.com/outcaste-io/ristre
 
 // openshift removed all tags from their repo, use the pseudoversion from the release-3.9 branch HEAD
 replace github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api v0.0.0-20180801171038-322a19404e37
+
+// The v0.3.0 tag was overwritten, replacing with v0.3.1
+replace github.com/moricho/tparallel v0.3.0 => github.com/moricho/tparallel v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -375,6 +375,3 @@ replace github.com/outcaste-io/ristretto v0.2.0 => github.com/outcaste-io/ristre
 
 // openshift removed all tags from their repo, use the pseudoversion from the release-3.9 branch HEAD
 replace github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api v0.0.0-20180801171038-322a19404e37
-
-// The v0.3.0 tag was overwritten, replacing with v0.3.1
-replace github.com/moricho/tparallel v0.3.0 => github.com/moricho/tparallel v0.3.1

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -210,3 +210,6 @@ replace github.com/tomarrell/wrapcheck v1.0.0 => github.com/tomarrell/wrapcheck 
 
 // v0.6.1 has a bad tag
 replace github.com/blizzy78/varnamelen v0.6.1 => github.com/blizzy78/varnamelen v0.6.2
+
+// The v0.3.0 tag was overwritten, replacing with v0.3.1
+replace github.com/moricho/tparallel v0.3.0 => github.com/moricho/tparallel v0.3.1


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Add replace statement for `tparallel` version. The `v0.3.0` tag was overwritten, and caused a checksum mismatch. A new `v0.3.1` tag is used. The checksum in `go.sum` doesn't change for `tparallel` because `v0.3.0` and `v0.3.1` are the same




<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
