### PR TITLE
remove replace for tparallel in main go.mod

### DIFF
--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -210,3 +210,6 @@ replace github.com/tomarrell/wrapcheck v1.0.0 => github.com/tomarrell/wrapcheck 
 
 // v0.6.1 has a bad tag
 replace github.com/blizzy78/varnamelen v0.6.1 => github.com/blizzy78/varnamelen v0.6.2
+
+// The v0.3.0 tag was overwritten, replacing with v0.3.1
+replace github.com/moricho/tparallel v0.3.0 => github.com/moricho/tparallel v0.3.1


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Add replace statement for `tparallel` version. The `v0.3.0` tag was overwritten, and caused a checksum mismatch. A new `v0.3.1` tag is used. The checksum in `go.sum` doesn't change for `tparallel` because `v0.3.0` and `v0.3.1` are the same


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
