### PR TITLE
Explicitly use bash in control script

### DIFF
--- a/tools/ctl/linux/aws-otel-collector-ctl
+++ b/tools/ctl/linux/aws-otel-collector-ctl
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #


### PR DESCRIPTION
We are using features of bash while using sh in the shebang. 

In some distributions, sh is symlinked to dash (Debian based distros), while in others (RHEL based) sh is symlinked to bash.

This PR will explicitly set to use bash so that we have a uniform behavior in all distros.

References:
https://en.wikipedia.org/wiki/Almquist_shell#dash


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
