### PR TITLE
fix: make collector control script posix compliant

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -158,7 +158,7 @@ jobs:
     # Unit Test and attach test coverage badge
     - name: Linting && Unit Test
       if: steps.cached_binaries.outputs.cache-hit != 'true'
-      run: make test
+      run: make test-all
 
     - name: Upload Coverage report to CodeCov
       if: steps.cached_binaries.outputs.cache-hit != 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -156,9 +156,9 @@ jobs:
         path: build
 
     # Unit Test and attach test coverage badge
-    - name: Unit Test
+    - name: Linting && Unit Test
       if: steps.cached_binaries.outputs.cache-hit != 'true'
-      run: make gotest
+      run: make test
 
     - name: Upload Coverage report to CodeCov
       if: steps.cached_binaries.outputs.cache-hit != 'true'

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -107,7 +107,7 @@ jobs:
     # Linting && Unit Test and attach test coverage badge
     - name: Tests - Lint and unit test
       if: ${{ needs.changes.outputs.changed == 'true' && steps.cached_binaries.outputs.cache-hit != 'true' }}
-      run: make test
+      run: make test-all
 
     - name: Upload Coverage report to CodeCov
       if: ${{ needs.changes.outputs.changed == 'true' && steps.cached_binaries.outputs.cache-hit != 'true' }}

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -104,10 +104,10 @@ jobs:
         key: "cached_binaries_${{ github.run_id }}"
         path: build
 
-    # Unit Test and attach test coverage badge
-    - name: Unit Test
+    # Linting && Unit Test and attach test coverage badge
+    - name: Tests - Lint and unit test
       if: ${{ needs.changes.outputs.changed == 'true' && steps.cached_binaries.outputs.cache-hit != 'true' }}
-      run: make gotest
+      run: make test
 
     - name: Upload Coverage report to CodeCov
       if: ${{ needs.changes.outputs.changed == 'true' && steps.cached_binaries.outputs.cache-hit != 'true' }}

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ ALL_SRC := $(shell find . -name '*.go' \
 # ALL_MODULES includes ./* dirs (excludes . dir)
 ALL_MODULES := $(shell find . -type f -name "go.mod" -exec dirname {} \; | sort | egrep  '^./' )
 
+# TODO: replace by a find command that looks for all the ".sh" files + other scripts
+ALL_SHELL_SCRIPTS := "tools/ctl/linux/aws-otel-collector-ctl"
+
 BUILD_INFO_IMPORT_PATH=$(AOC_IMPORT_PATH)/tools/version
 
 GOBUILD=GO111MODULE=on CGO_ENABLED=0 installsuffix=cgo go build -trimpath
@@ -156,6 +159,13 @@ docker-stop:
 .PHONY: gotest
 gotest:
 	@$(MAKE) for-all-target TARGET="test"
+
+.PHONY: lint-sh
+lint-sh:
+	shellcheck ${ALL_SHELL_SCRIPTS}
+
+.PHONY: test
+test: gotest lint-sh
 
 .PHONY: gofmt
 gofmt:

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ lint-sh:
 	shellcheck ${ALL_SHELL_SCRIPTS}
 
 .PHONY: test-all
-test: gotest lint-sh
+test-all: gotest lint-sh
 
 .PHONY: gofmt
 gofmt:

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ gotest:
 lint-sh:
 	shellcheck ${ALL_SHELL_SCRIPTS}
 
-.PHONY: test
+.PHONY: test-all
 test: gotest lint-sh
 
 .PHONY: gofmt

--- a/tools/ctl/linux/aws-otel-collector-ctl
+++ b/tools/ctl/linux/aws-otel-collector-ctl
@@ -21,7 +21,6 @@ readonly CMDDIR="${AGENTDIR}/bin"
 readonly CONFDIR="${AGENTDIR}/etc"
 readonly ENV_FILE="${CONFDIR}/.env"
 readonly DFT_CONFDIR="${AGENTDIR}/var"
-readonly LOGDIR="${AGENTDIR}/logs"
 readonly VERSION_FILE="${CMDDIR}/VERSION"
 
 SYSTEMD='false'
@@ -57,6 +56,7 @@ aoc_config_remote_uri() {
     echo "config=\"--config ${config}\"" > $ENV_FILE
 }
 
+
 aoc_config_local_uri() {
     config="${1:-}"
 
@@ -65,8 +65,8 @@ aoc_config_local_uri() {
 
     echo "config=\"--config /opt/aws/aws-otel-collector/etc/config.yaml\"" > $ENV_FILE
 
-    if [ ! -z $config ] && [ -f $config ]; then
-        cp $config $CONFDIR/config.yaml
+    if [ -n "$config" ] && [ -f "$config" ]; then
+        cp "$config" $CONFDIR/config.yaml
     fi
 
     if [ ! -f $CONFDIR/config.yaml ]; then
@@ -77,7 +77,8 @@ aoc_config_local_uri() {
 is_remote_uri() {
     config="${1:-}"
 
-    if [[ $config =~ ^[a-zA-Z0-9]+:// && ! $config =~ ^file: ]]; then
+    if echo "$config" | grep -E -q "^[a-zA-Z0-9]+://" && \
+       ! echo "$config" | grep -E -q "^file:"; then
         return 0;
     fi
     return 1
@@ -87,9 +88,9 @@ aoc_start() {
     config="${1:-}"
 
     if is_remote_uri "$config"; then
-        aoc_config_remote_uri $config
+        aoc_config_remote_uri "$config"
     else
-        aoc_config_local_uri $config
+        aoc_config_local_uri "$config"
     fi
 
     if [ "${SYSTEMD}" = 'true' ]; then
@@ -132,7 +133,7 @@ aoc_status() {
     fi
 
     starttime_fmt=''
-    if [ ${pid} ] && [ ${pid} -ne 0 ]; then
+    if [ -n "${pid}" ] && [ "${pid}" -ne "0" ]; then
         starttime="$(TZ=UTC ps -o lstart= "${pid}")"
         starttime_fmt="$(TZ=UTC date -Isec -d "${starttime}")"
     fi
@@ -169,7 +170,6 @@ aoc_runstatus() {
 
 main() {
     action=''
-    restart='false'
     mode='ec2'
     config_location=''
 
@@ -187,13 +187,12 @@ main() {
     fi
 
     OPTIND=1
-    while getopts ":hsa:r:c:m:" opt; do
+    while getopts ":ha:c:m:" opt; do
         case "${opt}" in
         h)
             echo "${UsageString}"
             exit 0
             ;;
-        s) restart='true' ;;
         a) action="${OPTARG}" ;;
         c) config_location="${OPTARG}" ;;
         m) mode="${OPTARG}" ;;
@@ -206,7 +205,7 @@ main() {
             ;;
         esac
     done
-    shift "$((${OPTIND} - 1))"
+    shift "$(( OPTIND - 1))"
 
     case "${mode}" in
     ec2) ;;


### PR DESCRIPTION
**Description:**  `sh` is symlinked to `bash` in RHEL based distros while on Debian distros it is symlinked to dash. `[[` style of tests are not supported by dash. This PR will make the control script posix compliant again.

On top of that we are adding support to test shell scripts with `shellcheck` and including that in the CI and pr-build workflows.

**Testing:** yes, tested the expressions using grep locally and also deployed to debian and amazonlinux.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
