### PR TITLE
Deprecate lambdacomponents module

### DIFF
--- a/pkg/lambdacomponents/go.mod
+++ b/pkg/lambdacomponents/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Use https://github.com/aws-observability/aws-otel-lambda/tree/main/adot/collector/lambdacomponents instead. v0.29.0 will be final release. 
 module github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents
 
 go 1.19


### PR DESCRIPTION
**Description:** Deprecate lambda module. This module is no longer necessary since default components are derived from module inside `aws-otel-lambda` repository. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
