### PR TITLE
Remove launch config delete from ASG cleaner

### DIFF
--- a/tools/workflow/cleaner/autoscaling/clean.go
+++ b/tools/workflow/cleaner/autoscaling/clean.go
@@ -70,15 +70,6 @@ func Clean(sess *session.Session, expirationDate time.Time) error {
 				return err
 			}
 
-			logger.Printf("deleting launch configuration: %s", *asg.LaunchConfigurationName)
-			deleteLaunchConfigurationInput := &autoscaling.DeleteLaunchConfigurationInput{
-				LaunchConfigurationName: asg.LaunchConfigurationName,
-			}
-
-			if _, err = autoscalingclient.DeleteLaunchConfiguration(deleteLaunchConfigurationInput); err != nil {
-				return err
-			}
-
 			logger.Printf("Deleted asg %s successfully", *asg.AutoScalingGroupName)
 		}
 


### PR DESCRIPTION
**Description:** Removes launch config delete from ASG cleaner. A launch template cleaner will be added in the future. Currently ASGs that this cleaner targets do not use launch configurations. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
