### PR TITLE
[chore] exclude aps regionsin AWS resource cleaner

### DIFF
--- a/.github/workflows/aws-resources-clean.yml
+++ b/.github/workflows/aws-resources-clean.yml
@@ -40,6 +40,12 @@ jobs:
         resource: [aps, autoscaling, ec2, ecs, efs, iam, launchconfig, loadbalancer, ebs, lambda]
         region: [us-east-1, us-east-2, us-west-1, us-west-2, ap-south-1, ap-northeast-2, ap-southeast-1, ap-southeast-2,
                  ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, eu-north-1, sa-east-1]
+        exclude:
+          - resource: aps
+            region: us-west-1
+          - resource: aps
+            region: ca-central-1
+
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go 1.x


### PR DESCRIPTION
**Description:** Exclude APS/Region matrices that are not GA. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
