### PR TITLE
[chore] Update operator mirror only for kuberbac

### DIFF
--- a/tools/release/adot-operator-images-mirror/config.yaml
+++ b/tools/release/adot-operator-images-mirror/config.yaml
@@ -1,93 +1,15 @@
 ## The source repositories and target repositories are one-to-one correspondence.
 sourceRepos:
-  - registry: open-telemetry/opentelemetry-operator
-    name: opentelemetry-operator
-    host: ghcr.io
-    allowed_tags:
-      - v0.70.0
-      - v0.68.0
-      - v0.66.0
-      - v0.62.1
-      - v0.61.0
-      - v0.58.0
-      - v0.56.0
-      - v0.54.0
-      - v0.51.0
-      - v0.50.0
-      - v0.49.0
   - registry: kubebuilder
     name: kube-rbac-proxy
     host: gcr.io
     allowed_tags: 
+      - v0.14.1
       - v0.13.0
       - v0.11.0
       - v0.8.0
       - v0.5.0
-  - registry: open-telemetry/opentelemetry-operator
-    name: target-allocator
-    host: ghcr.io
-    allowed_tags:
-      - 0.1.0
-      - 0.60.0
-      - 0.66.0
-      - 0.68.0
-      - 0.70.0
-  - registry: open-telemetry/opentelemetry-operator
-    name: autoinstrumentation-java
-    host: ghcr.io
-    allowed_tags:
-      - 1.11.1
-      - 1.18.0
-      - 1.19.1
-      - 1.20.2
-      - 1.22.1
-      - 1.23.0
-  - registry: open-telemetry/opentelemetry-operator
-    name: autoinstrumentation-nodejs
-    host: ghcr.io
-    allowed_tags:
-      - 0.27.0
-      - 0.31.0
-      - 0.34.0
-  - registry: open-telemetry/opentelemetry-operator
-    name: autoinstrumentation-python
-    host: ghcr.io
-    allowed_tags:
-      - 0.28b1
-      - 0.30b1
-      - 0.32b0
-      - 0.33b0
-      - 0.34b0
-      - 0.35b0
-      - 0.36b0
-  - registry: open-telemetry/opentelemetry-operator
-    name: autoinstrumentation-dotnet
-    host: ghcr.io
-    allowed_tags:
-      - 0.2.0-beta.1
-      - 0.3.1-beta.1
-      - 0.4.0-beta.1
-      - 0.5.0
-  - registry: open-telemetry/opentelemetry-operator
-    name: operator-opamp-bridge
-    host: ghcr.io
-    allowed_tags:
-      - 0.70.0
 
 targetRepos:
   - registry: public.ecr.aws/aws-observability
-    name: adot-operator
-  - registry: public.ecr.aws/aws-observability
     name: mirror-kube-rbac-proxy
-  - registry: public.ecr.aws/aws-observability
-    name: mirror-target-allocator
-  - registry: public.ecr.aws/aws-observability
-    name: mirror-autoinstrumentation-java
-  - registry: public.ecr.aws/aws-observability
-    name: mirror-autoinstrumentation-nodejs
-  - registry: public.ecr.aws/aws-observability
-    name: mirror-autoinstrumentation-python
-  - registry: public.ecr.aws/aws-observability
-    name: mirror-autoinstrumentation-dotnet
-  - registry: public.ecr.aws/aws-observability
-    name: mirror-operator-opamp-bridge


### PR DESCRIPTION
**Description:** Update operator mirror config to mirror only kube rbac dependency 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
