### PR TITLE
Update to use public ecr rather than dockerhub

### DIFF
--- a/deployment-template/ecs/aws-otel-ec2-sidecar-deployment-cfn.yaml
+++ b/deployment-template/ecs/aws-otel-ec2-sidecar-deployment-cfn.yaml
@@ -59,7 +59,7 @@ Resources:
       NetworkMode: bridge
       ContainerDefinitions:
         - Name: aws-collector
-          Image: 'amazon/aws-otel-collector:latest'
+          Image: 'public.ecr.aws/aws-observability/aws-otel-collector:latest'
           LogConfiguration:
             LogDriver: awslogs
             Options:

--- a/deployment-template/ecs/aws-otel-fargate-sidecar-deployment-cfn.yaml
+++ b/deployment-template/ecs/aws-otel-fargate-sidecar-deployment-cfn.yaml
@@ -67,7 +67,7 @@ Resources:
       NetworkMode: awsvpc
       ContainerDefinitions:
         - Name: aws-collector
-          Image: 'amazon/aws-otel-collector:latest'
+          Image: 'public.ecr.aws/aws-observability/aws-otel-collector:latest'
           Command: [!Ref command]
           Cpu: '256'
           Memory: '512'

--- a/deployment-template/eks/otel-cloudwatch-sidecar.yaml
+++ b/deployment-template/eks/otel-cloudwatch-sidecar.yaml
@@ -40,7 +40,7 @@ spec:
               value: "otlp"
           imagePullPolicy: Always
         - name: aws-otel-collector
-          image: amazon/aws-otel-collector:latest
+          image: public.ecr.aws/aws-observability/aws-otel-collector:latest
           env:
             - name: AWS_REGION
               value: {{region}}

--- a/deployment-template/eks/otel-container-insights-infra.yaml
+++ b/deployment-template/eks/otel-container-insights-infra.yaml
@@ -185,7 +185,7 @@ spec:
     spec:
       containers:
         - name: aws-otel-collector
-          image: amazon/aws-otel-collector:latest
+          image: public.ecr.aws/aws-observability/aws-otel-collector:latest
           env:
             - name: K8S_NODE_NAME
               valueFrom:

--- a/deployment-template/eks/otel-container-insights-prometheus.yaml
+++ b/deployment-template/eks/otel-container-insights-prometheus.yaml
@@ -74,7 +74,7 @@ spec:
       serviceAccountName: aws-otel-collector
       containers:
         - name: aws-otel-collector
-          image: amazon/aws-otel-collector:latest
+          image: public.ecr.aws/aws-observability/aws-otel-collector:latest
           command: [ "/awscollector" ]
           args: [ "--config", "/etc/eks/prometheus/config-all.yaml" ]
           env:

--- a/deployment-template/eks/otel-fargate-container-insights.yaml
+++ b/deployment-template/eks/otel-fargate-container-insights.yaml
@@ -522,7 +522,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-        - image: amazon/aws-otel-collector:latest
+        - image: public.ecr.aws/aws-observability/aws-otel-collector:latest
           name: adot-collector
           imagePullPolicy: Always
           command:

--- a/examples/ec2/aws-cloudwatch/ecs-ec2-sidecar.json
+++ b/examples/ec2/aws-cloudwatch/ecs-ec2-sidecar.json
@@ -41,7 +41,7 @@
     },
     {
       "name": "aws-otel-collector",
-      "image": "amazon/aws-otel-collector:latest",
+      "image": "public.ecr.aws/aws-observability/aws-otel-collector:latest",
       "portMappings": [
         {
           "containerPort": 4317,

--- a/examples/ec2/aws-cloudwatch/ecs-fargate-sidecar.json
+++ b/examples/ec2/aws-cloudwatch/ecs-fargate-sidecar.json
@@ -37,7 +37,7 @@
     },
     {
       "name": "aws-otel-collector",
-      "image": "amazon/aws-otel-collector:latest",
+      "image": "public.ecr.aws/aws-observability/aws-otel-collector:latest",
       "portMappings": [
         {
           "containerPort": 4317,

--- a/examples/eks/aws-cloudwatch/otel-sidecar.yaml
+++ b/examples/eks/aws-cloudwatch/otel-sidecar.yaml
@@ -38,7 +38,7 @@ spec:
             value: "otlp"
           imagePullPolicy: Always
         - name: aws-otel-collector
-          image: amazon/aws-otel-collector:latest
+          image: public.ecr.aws/aws-observability/aws-otel-collector:latest
           env:
             - name: AWS_REGION
               value: "us-west-2"


### PR DESCRIPTION
**Description:** Default to public ecr host rather than docker hub in deployment examples 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
