### PR TITLE
Make the release script compatible between Linux and MacOS

### DIFF
--- a/tools/release/bump-version-and-create-release-note.sh
+++ b/tools/release/bump-version-and-create-release-note.sh
@@ -37,7 +37,8 @@ echo "${RELEASE_VERSION}" >VERSION
 
 #Update aws-otel-collector wxs template file. 
 # Note: Only supports [0-9]*.[0-9]*.[0-9]* version pattern. If we decide to release with a full sem ver vX.XX.XX-prerelease then the .wxs file will need to be manually updated
-sed -E -i '' "s/^Version\=\"[0-9]+.[0-9]+.[0-9]+\"/Version=\"${RELEASE_VERSION:1}\"/" ./tools/packaging/windows/aws-otel-collector.wxs
+sed -E "s/^Version\=\"[0-9]+.[0-9]+.[0-9]+\"/Version=\"${RELEASE_VERSION:1}\"/" ./tools/packaging/windows/aws-otel-collector.wxs > ./tools/packaging/windows/aws-otel-collector.wxs.tmp
+mv ./tools/packaging/windows/aws-otel-collector.wxs.tmp ./tools/packaging/windows/aws-otel-collector.wxs
 
 # git commit
 git add VERSION "docs/releases/${RELEASE_VERSION}.md"


### PR DESCRIPTION
**Description:** Make the release script compatible between Linux and MacOS

The `-i` parameter behaves differently between osx sed and gnu sed.
* https://ss64.com/osx/sed.html
* https://linux.die.net/man/1/sed

This PR avoid using the -i parameter.

**Testing:** Tested manually.

PS: DO NOT MERGE THIS PR YET.

**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
