### PR TITLE
Test separate go cache and shared windows cache in PR Build

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -102,9 +102,7 @@ jobs:
         path: |
           ${{ env.cache }}
           ${{ env.modcache }}
-        key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
-        restore-keys: |
-          ${{ env.cache_name }}-${{ runner.os }}-go-
+        key: collector-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
         enableCrossOsArchive: true
 
     - name: install tools
@@ -148,11 +146,7 @@ jobs:
         path: |
           ${{ env.cache }}
           ${{ env.modcache }}
-        key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
-        restore-keys: |
-          ${{ env.cache_name }}-${{ runner.os }}-go-
-
-
+        key: collector-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
     - name: Cache binaries
       id: cached_binaries
       if: ${{ needs.changes.outputs.changed == 'true' }}

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -110,12 +110,12 @@ jobs:
         
     - name: Lint
       if: ${{ needs.changes.outputs.changed == 'true'}}
-      run: make golint
+      run: make golint -j4
      
     # only run unit tests on windows. The unix build job will lint, test, and build. 
     - name: Unit test
       if: ${{ needs.changes.outputs.changed == 'true'}}
-      run: make gotest
+      run: make gotest -j4
 
 
   test-windows:

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -73,7 +73,7 @@ jobs:
         run: echo "This is a version bump PR!"
 
   test:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     needs: [changes]
     steps:
     - name: Checkout
@@ -103,7 +103,6 @@ jobs:
           ${{ env.cache }}
           ${{ env.modcache }}
         key: collector-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
-        enableCrossOsArchive: true
 
     - name: install tools
       if: ${{ needs.changes.outputs.changed == 'true' }}
@@ -118,10 +117,10 @@ jobs:
       if: ${{ needs.changes.outputs.changed == 'true'}}
       run: make gotest
 
-      
+
   test-windows:
     runs-on: windows-latest
-    needs: [changes]
+    needs: [changes, test]
     steps:
     - name: Checkout
       if: ${{ needs.changes.outputs.changed == 'true' }}
@@ -168,7 +167,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [changes]
+    needs: [changes, test]
     steps:
     - name: Checkout
       if: ${{ needs.changes.outputs.changed == 'true' }}

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -86,11 +86,11 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
         cache: false
-
+        
     - name: Get Go environment
       run: |
-        echo "cache=$(go env GOCACHE)" >> $env:GITHUB_ENV
-        echo "modcache=$(go env GOMODCACHE)" >> $env:GITHUB_ENV
+        echo "cache=$(go env GOCACHE)" >> $GITHUB_ENV
+        echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
 
     - run: |
         echo ${{env.cache }}
@@ -135,8 +135,8 @@ jobs:
 
     - name: Get Go environment
       run: |
-        echo "cache=$(go env GOCACHE)" >> $GITHUB_ENV
-        echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
+        echo "cache=$(go env GOCACHE)" >> $env:GITHUB_ENV
+        echo "modcache=$(go env GOMODCACHE)" >> $env:GITHUB_ENV
 
     - run: |
         echo ${{env.cache }}
@@ -159,6 +159,7 @@ jobs:
       if: ${{ needs.changes.outputs.changed == 'true'}}
       run: make golint
      
+    # only run unit tests on windows. The unix build job will lint, test, and build. 
     - name: Unit test
       if: ${{ needs.changes.outputs.changed == 'true'}}
       run: make gotest
@@ -166,7 +167,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [changes, test]
+    needs: [changes, ]
     steps:
     - name: Checkout
       if: ${{ needs.changes.outputs.changed == 'true' }}

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -72,7 +72,54 @@ jobs:
         if: steps.filter.outputs.version == 'true'
         run: echo "This is a version bump PR!"
 
-  build-windows:
+  test:
+    runs-on: windows-latest
+    needs: [changes]
+    steps:
+    - name: Checkout
+      if: ${{ needs.changes.outputs.changed == 'true' }}
+      uses: actions/checkout@v3
+    # Set up building environment, patch the dev repo code on dispatch events.  
+    - name: Set up Go 1.x
+      if: ${{ needs.changes.outputs.changed == 'true' }}
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache: false
+
+    - name: Get Go environment
+      run: |
+        echo "cache=$(go env GOCACHE)" >> $env:GITHUB_ENV
+        echo "modcache=$(go env GOMODCACHE)" >> $env:GITHUB_ENV
+
+    - run: |
+        echo ${{env.cache }}
+        echo ${{ env.modcache}}
+
+    - name: Set up cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{ env.cache }}
+          ${{ env.modcache }}
+        key: collector-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
+        enableCrossOsArchive: true
+
+    - name: install tools
+      if: ${{ needs.changes.outputs.changed == 'true' }}
+      run: make install-tools
+        
+    - name: Lint
+      if: ${{ needs.changes.outputs.changed == 'true'}}
+      run: make golint
+     
+    # only run unit tests on windows. The unix build job will lint, test, and build. 
+    - name: Unit test
+      if: ${{ needs.changes.outputs.changed == 'true'}}
+      run: make gotest
+
+      
+  test-windows:
     runs-on: windows-latest
     needs: [changes]
     steps:

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -92,6 +92,10 @@ jobs:
         echo "cache=$(go env GOCACHE)" >> $env:GITHUB_ENV
         echo "modcache=$(go env GOMODCACHE)" >> $env:GITHUB_ENV
 
+    - run: |
+        echo ${{env.cache }}
+        echo ${{ env.modcache}}
+
     - name: Set up cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -89,8 +89,8 @@ jobs:
 
     - name: Get Go environment
       run: |
-        echo "cache=$(go env GOCACHE)" >> $GITHUB_ENV
-        echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
+        echo "cache=$(go env GOCACHE)" >> $env:GITHUB_ENV
+        echo "modcache=$(go env GOMODCACHE)" >> $env:GITHUB_ENV
 
     - name: Set up cache
       uses: actions/cache@v3

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -135,8 +135,8 @@ jobs:
 
     - name: Get Go environment
       run: |
-        echo "cache=$(go env GOCACHE)" >> $env:GITHUB_ENV
-        echo "modcache=$(go env GOMODCACHE)" >> $env:GITHUB_ENV
+        echo "cache=$(go env GOCACHE)" >> $GITHUB_ENV
+        echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
 
     - run: |
         echo ${{env.cache }}
@@ -159,7 +159,6 @@ jobs:
       if: ${{ needs.changes.outputs.changed == 'true'}}
       run: make golint
      
-    # only run unit tests on windows. The unix build job will lint, test, and build. 
     - name: Unit test
       if: ${{ needs.changes.outputs.changed == 'true'}}
       run: make gotest

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -72,7 +72,7 @@ jobs:
         if: steps.filter.outputs.version == 'true'
         run: echo "This is a version bump PR!"
 
-  test:
+  lint:
     runs-on: ubuntu-latest
     needs: [changes]
     steps:
@@ -112,6 +112,39 @@ jobs:
       if: ${{ needs.changes.outputs.changed == 'true'}}
       run: make golint -j4
      
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [changes]
+    steps:
+    - name: Checkout
+      if: ${{ needs.changes.outputs.changed == 'true' }}
+      uses: actions/checkout@v3
+    # Set up building environment, patch the dev repo code on dispatch events.  
+    - name: Set up Go 1.x
+      if: ${{ needs.changes.outputs.changed == 'true' }}
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache: false
+        
+    - name: Get Go environment
+      run: |
+        echo "cache=$(go env GOCACHE)" >> $GITHUB_ENV
+        echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
+
+    - run: |
+        echo ${{env.cache }}
+        echo ${{ env.modcache}}
+
+    - name: Set up cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{ env.cache }}
+          ${{ env.modcache }}
+        key: collector-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
+     
     # only run unit tests on windows. The unix build job will lint, test, and build. 
     - name: Unit test
       if: ${{ needs.changes.outputs.changed == 'true'}}
@@ -120,7 +153,7 @@ jobs:
 
   test-windows:
     runs-on: windows-latest
-    needs: [changes, test]
+    needs: [changes, test, lint]
     steps:
     - name: Checkout
       if: ${{ needs.changes.outputs.changed == 'true' }}
@@ -154,7 +187,9 @@ jobs:
     - name: install tools
       if: ${{ needs.changes.outputs.changed == 'true' }}
       run: make install-tools
-        
+
+    # TODO: Cache golangci-lint cache ~/.cache/golangci-lint
+    # https://github.com/golangci/golangci-lint/blob/cb6390d7ca5eea5e37d9ac92925b5ef2a6593c03/internal/cache/default.go#L84
     - name: Lint
       if: ${{ needs.changes.outputs.changed == 'true'}}
       run: make golint
@@ -167,7 +202,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [changes, test ]
+    needs: [changes, test, lint ]
     steps:
     - name: Checkout
       if: ${{ needs.changes.outputs.changed == 'true' }}

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -85,6 +85,23 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
+        cache: false
+
+    - name: Get Go environment
+      run: |
+        echo "cache=$(go env GOCACHE)" >> $GITHUB_ENV
+        echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
+
+    - name: Set up cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{ env.cache }}
+          ${{ env.modcache }}
+        key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
+        restore-keys: |
+          ${{ env.cache_name }}-${{ runner.os }}-go-
+        enableCrossOsArchive: true
 
     - name: install tools
       if: ${{ needs.changes.outputs.changed == 'true' }}
@@ -114,6 +131,23 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
+        cache: false
+
+    - name: Get Go environment
+      run: |
+        echo "cache=$(go env GOCACHE)" >> $GITHUB_ENV
+        echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
+
+    - name: Set up cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{ env.cache }}
+          ${{ env.modcache }}
+        key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
+        restore-keys: |
+          ${{ env.cache_name }}-${{ runner.os }}-go-
+
 
     - name: Cache binaries
       id: cached_binaries
@@ -139,14 +173,6 @@ jobs:
       if: ${{ needs.changes.outputs.changed == 'true' && steps.cached_binaries.outputs.cache-hit != 'true' }}
       run: make build
 
-    # upload the binaries to artifact as well because cache@v2 hasn't support windows
-    - name: Upload
-      if: ${{ needs.changes.outputs.changed == 'true' }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: binary_artifacts
-        path: build
-
   packaging-msi:
     runs-on: windows-latest
     needs: [changes, build]
@@ -155,12 +181,14 @@ jobs:
         if: ${{ needs.changes.outputs.changed == 'true' }}
         uses: actions/checkout@v3
 
-      - name: Download built artifacts
+      - name: restore cached binaries
         if: ${{ needs.changes.outputs.changed == 'true' }}
-        uses: actions/download-artifact@v3
+        uses: actions/cache@v3
         with:
-          name: binary_artifacts
+          key: "cached_binaries_${{ github.run_id }}"
           path: build
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
 
       - name: Display structure of downloaded files
         run: ls -R

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -167,7 +167,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [changes, ]
+    needs: [changes, test ]
     steps:
     - name: Checkout
       if: ${{ needs.changes.outputs.changed == 'true' }}

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ dependabot-generate: install-dbotconf
 	@$(DBOTCONF) generate > $(DEPENDABOT_CONFIG); 
 
 .PHONY: build
-build: install-tools golint
+build:
 	GOOS=darwin GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o ./build/darwin/amd64/aoc ./cmd/awscollector
 	GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o ./build/linux/amd64/aoc ./cmd/awscollector
 	GOOS=linux GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o ./build/linux/arm64/aoc ./cmd/awscollector

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -27,7 +27,7 @@ fmt:
 
 .PHONY: lint
 lint:
-	$(TOOL_BIN)/$(LINT) run --timeout 5m --enable gosec
+	$(TOOL_BIN)/$(LINT) run --timeout 5m --enable gosec --allow-parallel-runners
 
 .PHONY: mod-tidy
 mod-tidy:


### PR DESCRIPTION
### This is a working experiment. The PR is not in draft status so that caching can be actively tested in a GitHub workflow. 
**Description:** In an effort to speed up PR Build times this PR introduces back the `cache` action in two places. First, for caching go dependencies. This was introduced back to test out the `enableCrossOsArchive` flag. This would allow us to preserve the go cache across both windows and linux runners. The feature is not currently available in the `setup-go` action. 

This also attempts to use `enableOsArchive` for restoring cached binaries instead of uploading the artifacts. 

This PR also removes the `lint and test` from the `make build` target. An additional job was added before the build step specifically to execute test. The reason for this is to help prepopulate the build and module cache. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
