### PR TITLE
[dev] Remove eks from test services

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,8 +47,8 @@ env:
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   GITHB_RUN_ID: ${{ github.run_id }}
   DDB_TABLE_NAME: BatchTestCache
-  MAX_JOBS: 5
-  BATCH_INCLUDED_SERVICES: EKS,EKS_ARM64
+  MAX_JOBS: 100
+  BATCH_INCLUDED_SERVICES: EC2
   GO_VERSION: ~1.20.3
 
 


### PR DESCRIPTION
**Description:** Remove EKS clusters from dev targets. This is just for safety purposes. Main branch will now target the clusters for testing. We would not want both branches running tests against the same clusters. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
