### PR TITLE
Fix/remove unused gh action in CD workflow

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -241,10 +241,3 @@ jobs:
              --draft \
              --pre-release \
              ${{ needs.release-checking.outputs.version }}
-        with:
-          tag_name: ${{ needs.release-checking.outputs.version }}
-          commitish: ${{ needs.release-checking.outputs.sha }}
-          release_name: ${{ needs.release-checking.outputs.version }}
-          body_path: release-note
-          draft: true
-          prerelease: true

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -241,7 +241,6 @@ jobs:
              --draft \
              --pre-release \
              ${{ needs.release-checking.outputs.version }}
-
         with:
           tag_name: ${{ needs.release-checking.outputs.version }}
           commitish: ${{ needs.release-checking.outputs.sha }}


### PR DESCRIPTION
**Description:** 

This PR fixes the indentation/removes the unused [gh action part of previously one](https://github.com/actions/create-release#inputs) in CD workflow

<img width="808" alt="image" src="https://github.com/aws-observability/aws-otel-collector/assets/41936996/29073911-8918-4b3a-b70b-0bae0432bf90">


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
