### PR TITLE
Use Appropriate command for gh release

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -236,7 +236,7 @@ jobs:
           gh release create --target ${{ needs.release-checking.outputs.sha }} \
              --title ${{ needs.release-checking.outputs.version }} \
              --notes-file release-note \
-             --discussion-category announcements \
              --verify-tag \
              --draft \
-             --prerelease
+             --prerelease \
+             ${{ needs.release-checking.outputs.version }}

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -239,5 +239,4 @@ jobs:
              --discussion-category announcements \
              --verify-tag \
              --draft \
-             --pre-release \
-             ${{ needs.release-checking.outputs.version }}
+             --prerelease


### PR DESCRIPTION
**Description:** 

Use Appropriate keyword `prerelease` for gh release command.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
