### PR TITLE
Reduce permission in the folder that stores configuration and logs on Windows

### DIFF
--- a/tools/packaging/windows/aws-otel-collector.wxs
+++ b/tools/packaging/windows/aws-otel-collector.wxs
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"  xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
     <Product Id="EBBD8548-75D1-41D3-A402-ABE189F0C167"
 UpgradeCode="B7C263DD-95A5-436A-A025-DCA5200C2BE3"
 Name="ADOT Collector"
@@ -93,6 +93,17 @@ Wait="yes" />
 
     <DirectoryRef Id="Config">
     <Component Id='CommonConfigYML' Guid='293f73c5-1f51-4e65-86e3-97425ec75c94' Win64='yes' NeverOverwrite='yes' Permanent='yes'>
+    <CreateFolder>
+      <!-- Set permissions so that only admin and system can access this folder
+         Configures the permissions in the SDDL format: https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-string-format
+         DACL flags P + AI are used to not inherit permissions from parent folder and to propagate permissions to child elements.
+         The subsequent ACE strings with the format "ace_type;ace_flags;rights;object_guid;inherit_object_guid;account_sid;(resource_attribute)" do the following:
+         - Allow access (ace_type A) to the local system (account_sid SY) and administrators (account_sid BA)
+         - ace_flags "OI" + "CI": inherit ACE permissions for the the SIDs
+         - Rights "FA": gives permissions to write + read all files.
+      -->
+      <PermissionEx Sddl="D:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"/>
+    </CreateFolder>
     <File Source='./config.yaml' KeyPath='yes'/>
     </Component>
     </DirectoryRef>

--- a/tools/packaging/windows/aws-otel-collector.wxs
+++ b/tools/packaging/windows/aws-otel-collector.wxs
@@ -99,10 +99,10 @@ Wait="yes" />
          DACL flags P + AI are used to not inherit permissions from parent folder and to propagate permissions to child elements.
          The subsequent ACE strings with the format "ace_type;ace_flags;rights;object_guid;inherit_object_guid;account_sid;(resource_attribute)" do the following:
          - Allow access (ace_type A) to the local system (account_sid SY) and administrators (account_sid BA)
-         - ace_flags "OI" + "CI": inherit ACE permissions for the the SIDs
-         - Rights "FA": gives permissions to write + read all files.
+         - ace_flags "OI" + "CI": inherit ACE permissions for the SIDs
+         - Rights "FR" + "FW": gives permissions to read and write files.
       -->
-      <PermissionEx Sddl="D:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"/>
+      <PermissionEx Sddl="D:PAI(A;OICI;FRFW;;;SY)(A;OICI;FRFW;;;BA)"/>
     </CreateFolder>
     <File Source='./config.yaml' KeyPath='yes'/>
     </Component>


### PR DESCRIPTION
**Description:**  Reduce permission in the folder that stores configuration and logs on Windows

**Testing:** Tested locally by manually creating an installer.

I used powershell to verify the permissions of the directory:
```
$handler = Get-Acl 'C:\ProgramData\Amazon\AWSOTelCollector\Logs\'
$handler.access


FileSystemRights  : Write, Read, Synchronize
AccessControlType : Allow
IdentityReference : NT AUTHORITY\SYSTEM
IsInherited       : True
InheritanceFlags  : ContainerInherit, ObjectInherit
PropagationFlags  : None

FileSystemRights  : Write, Read, Synchronize
AccessControlType : Allow
IdentityReference : BUILTIN\Administrators
IsInherited       : True
InheritanceFlags  : ContainerInherit, ObjectInherit
PropagationFlags  : None
```

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
