### PR TITLE
Use kube-rbac-proxy image from Quay.io

### DIFF
--- a/tools/release/image-mirror/config.yaml
+++ b/tools/release/image-mirror/config.yaml
@@ -5,11 +5,6 @@ sourceRepos:
     host: quay.io
     allowed_tags:
       - v0.14.2
-      - v0.14.1
-      - v0.13.0
-      - v0.11.0
-      - v0.8.0
-      - v0.5.0
 
 targetRepos:
   - registry: public.ecr.aws/aws-observability

--- a/tools/release/image-mirror/config.yaml
+++ b/tools/release/image-mirror/config.yaml
@@ -1,8 +1,8 @@
 ## The source repositories and target repositories are one-to-one correspondence.
 sourceRepos:
-  - registry: kubebuilder
+  - registry: brancz
     name: kube-rbac-proxy
-    host: gcr.io
+    host: quay.io
     allowed_tags:
       - v0.14.2
       - v0.14.1

--- a/tools/release/image-mirror/mirror.go
+++ b/tools/release/image-mirror/mirror.go
@@ -15,6 +15,8 @@ import (
 )
 
 const (
+	ghcr                 = "ghcr.io"
+	gcr                  = "gcr.io"
 	quay				 = "quay.io"
 	defaultSleepDuration = 60 * time.Second
 )
@@ -22,6 +24,21 @@ const (
 var (
 	httpClient = &http.Client{Timeout: 10 * time.Second}
 )
+
+// GHCRTagsResponse contains the tags' information of the HTTP get response from ghcr.io.
+type GHCRTagsResponse struct {
+	Tags []string `json:"tags"`
+}
+
+// GCRTagsResponse contains the tags' information of the HTTP get response from gcr.io.
+type GCRTagsResponse struct {
+	Tags []string `json:"tags"`
+}
+
+// GHCRToken contains the necessary token information to get an HTTP response from ghcr.io
+type GHCRToken struct {
+	Token string
+}
 
 // QuayTagsResponse contains the tags' information of the HTTP get response from quay.io.
 type QuayTagsResponse struct {
@@ -71,6 +88,10 @@ func (m *mirror) work() {
 func (m *mirror) getRemoteTags() {
 	var url string
 	switch m.sourceRepo.Host {
+	case ghcr:
+		url = fmt.Sprintf("https://ghcr.io/v2/%s/tags/list", m.sourceRepositoryName())
+	case gcr:
+		url = fmt.Sprintf("https://gcr.io/v2/%s/tags/list", m.sourceRepositoryName())
 	case quay:
 		url = fmt.Sprintf("https://quay.io/api/v1/repository/%s/tag", m.sourceRepositoryName())
 	}
@@ -99,6 +120,28 @@ func (m *mirror) getTagResponse(url string) error {
 	if err != nil {
 		return err
 	}
+
+	// Sets the authorization header necessary for accessing ghcr.io
+	if m.sourceRepo.Host == ghcr {
+		tokenURL := fmt.Sprintf("https://ghcr.io/token?scope=repository:%s:pull", m.sourceRepositoryName())
+		// G107: Potential HTTP request made with variable url
+		// #nosec G107
+		tokenRes, err := http.Get(tokenURL)
+		if err != nil {
+			return err
+		}
+		defer tokenRes.Body.Close()
+
+		token := new(GHCRToken)
+		err = json.NewDecoder(tokenRes.Body).Decode(token)
+		if err != nil {
+			return err
+		}
+
+		authToken := "Bearer " + token.Token
+		req.Header.Set("Authorization", authToken)
+	}
+
 	res, err := httpClient.Do(req)
 	if err != nil {
 		log.Printf("Failed to get %s, retrying", url)
@@ -118,6 +161,32 @@ func (m *mirror) getTagResponse(url string) error {
 		dc := json.NewDecoder(res.Body)
 
 		switch m.sourceRepo.Host {
+		case ghcr:
+			var tags GHCRTagsResponse
+			if err := dc.Decode(&tags); err != nil {
+				return err
+			}
+			for _, tag := range tags.Tags {
+				// Check if the ghcr image is on allowlist
+				if tagInAllowlist(tag, m.sourceRepo.AllowedTags) {
+					allTags = append(allTags, RepositoryTag{
+						Name: tag,
+					})
+				}
+			}
+		case gcr:
+			var tags GCRTagsResponse
+			if err := dc.Decode(&tags); err != nil {
+				return err
+			}
+			for _, tag := range tags.Tags {
+				// Check if kube-rbac-proxy image is on allowlist
+				if tagInAllowlist(tag, m.sourceRepo.AllowedTags) {
+					allTags = append(allTags, RepositoryTag{
+						Name: tag,
+					})
+				}
+			}
 		case quay:
 			var tags QuayTagsResponse
 			if err := dc.Decode(&tags); err != nil {

--- a/tools/release/image-mirror/mirror.go
+++ b/tools/release/image-mirror/mirror.go
@@ -126,7 +126,7 @@ func (m *mirror) getTagResponse(url string) error {
 //			allTags = append(allTags, tags.Tags...)
 			for _, tag := range tags.Tags {
 				// Check if the kube-rbac-proxy image is on allowlist
-				if tagInAllowlist(tag, m.sourceRepo.AllowedTags) {
+				if tagInAllowlist(tag.Name, m.sourceRepo.AllowedTags) {
 					allTags = append(allTags, RepositoryTag{
 						Name: tag.Name,
 					})
@@ -163,9 +163,9 @@ func getSleepTime(rateLimitReset string, now time.Time) time.Duration {
 	return calculatedSleepTime
 }
 
-func tagInAllowlist(tag RepositoryTag, allowlist []string) bool {
+func tagInAllowlist(tag string, allowlist []string) bool {
 	for _, allowed := range allowlist {
-		if allowed == tag.Name {
+		if allowed == tag {
 			return true
 		}
 	}


### PR DESCRIPTION
**Description:** 
Uses Kube-rbac-proxy image from [quay.io](https://quay.io/repository/brancz/kube-rbac-proxy?tab=tags), modifies the mirroring accordingly to mirror the image from [quay api](https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_api_guide/index#listrepotags)

**Testing**
![image](https://github.com/aws-observability/aws-otel-collector/assets/41936996/6eda0713-004f-40af-bcbb-768b7da2f4e9)


Tested Locally.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
