### PR TITLE
Update windows permissions in logs and configuration

### DIFF
--- a/tools/packaging/windows/aws-otel-collector.wxs
+++ b/tools/packaging/windows/aws-otel-collector.wxs
@@ -100,9 +100,9 @@ Wait="yes" />
          The subsequent ACE strings with the format "ace_type;ace_flags;rights;object_guid;inherit_object_guid;account_sid;(resource_attribute)" do the following:
          - Allow access (ace_type A) to the local system (account_sid SY) and administrators (account_sid BA)
          - ace_flags "OI" + "CI": inherit ACE permissions for the SIDs
-         - Rights "FR" + "FW": gives permissions to read and write files.
+         - Rights "FA": gives permissions to read, write and delete files.
       -->
-      <PermissionEx Sddl="D:PAI(A;OICI;FRFW;;;SY)(A;OICI;FRFW;;;BA)"/>
+      <PermissionEx Sddl="D:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"/>
     </CreateFolder>
     <File Source='./config.yaml' KeyPath='yes'/>
     </Component>


### PR DESCRIPTION

**Description:** Update windows permissions in logs and configuration so that it is possible to delete the configuration folder. This has to be done so operators can delete the folder after the msi is uninstalled.

If we don't use "FA", even the admin will need to first change the permission on the folder before performing a delete operation.

**Testing:** manually created an installer.

Permissions in the directory.
```
$handler = Get-Acl 'C:\ProgramData\Amazon\AWSOTelCollector'
$handler.Access


FileSystemRights  : FullControl
AccessControlType : Allow
IdentityReference : NT AUTHORITY\SYSTEM
IsInherited       : False
InheritanceFlags  : ContainerInherit, ObjectInherit
PropagationFlags  : None

FileSystemRights  : FullControl
AccessControlType : Allow
IdentityReference : BUILTIN\Administrators
IsInherited       : False
InheritanceFlags  : ContainerInherit, ObjectInherit
PropagationFlags  : None
```

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
