### PR TITLE
Chore: Update day in which dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       - Skip Changelog
     schedule:
       interval: weekly
-      day: sunday
+      day: tuesday
   - package-ecosystem: docker
     directory: /cmd/awscollector
     labels:
@@ -18,7 +18,7 @@ updates:
       - Skip Changelog
     schedule:
       interval: weekly
-      day: sunday
+      day: tuesday
   - package-ecosystem: gomod
     directory: /
     labels:
@@ -27,7 +27,16 @@ updates:
       - Skip Changelog
     schedule:
       interval: weekly
-      day: sunday
+      day: tuesday
+  - package-ecosystem: gomod
+    directory: /testbed
+    labels:
+      - dependencies
+      - go
+      - Skip Changelog
+    schedule:
+      interval: weekly
+      day: tuesday
   - package-ecosystem: gomod
     directory: /tools/release/image-mirror
     labels:
@@ -36,7 +45,7 @@ updates:
       - Skip Changelog
     schedule:
       interval: weekly
-      day: sunday
+      day: tuesday
   - package-ecosystem: gomod
     directory: /tools/workflow/cleaner
     labels:
@@ -45,7 +54,7 @@ updates:
       - Skip Changelog
     schedule:
       interval: weekly
-      day: sunday
+      day: tuesday
   - package-ecosystem: gomod
     directory: /tools/workflow/linters
     labels:
@@ -54,4 +63,4 @@ updates:
       - Skip Changelog
     schedule:
       interval: weekly
-      day: sunday
+      day: tuesday


### PR DESCRIPTION
**Description:** Update day in which dependabot updates

I used the following command:
```
 ~/go/bin/dbotconf generate .github/dependabot.yml | sed  's/day\: sunday/day\: tuesday/g' > ./.github/dependabot.yml
```

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
