### PR TITLE
Remove prometheus normalization feature gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ Use the community resources below for getting help with the ADOT Collector.
 * If you think you may have found a bug, open a [bug report](https://github.com/aws-observability/aws-otel-collector/issues/new?template=bug_report.md).
 * For contributing guidelines, refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 
-### Notice: ADOT Collector v0.31.0 Breaking Change
-Users of the `prometheus` receiver, `prometheus` exporter or `prometheusremotewrite` exporter please reference GitHub Issue [Warning: ADOT Collector v0.31.0 breaking change](https://github.com/aws-observability/aws-otel-collector/issues/2043)
-for information on an upcoming breaking change. 
-
 #### ADOT Collector Built-in Components
 
 This table represents the supported components of the ADOT Collector. The highlighted components below are developed by AWS in-house. The rest of the components in the table are the essential default components that the ADOT Collector will support.

--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -93,14 +93,6 @@ func main() {
 func buildAndParseFlagSet(featgate *featuregate.Registry) (*flag.FlagSet, error) {
 	flagSet := config.Flags(featgate)
 
-	// TODO: remove after ADOT Collector v0.30.0 is released
-	if err := featgate.Set("pkg.translator.prometheus.NormalizeName", false); err != nil {
-		return nil, err
-	}
-	log.Printf("attn: users of the prometheus receiver, prometheus exporter or prometheusremotewrite exporter please refer to " +
-		"https://github.com/aws-observability/aws-otel-collector/issues/2043 in regards to an ADOT Collector v0.31.0 " +
-		"breaking change")
-
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Description:** Closes #2043 

Removes prometheus normalization feature gates as they were reverted back to alpha status upstream. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
