### PR TITLE
added file log receiver, cwl exporter, and storage extension

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.80.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.80.0
@@ -20,6 +21,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.80.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor v0.80.0
@@ -35,6 +37,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.80.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.80.0
@@ -126,6 +129,7 @@ require (
 	github.com/aws/smithy-go v1.13.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/bmatcuk/doublestar/v4 v4.6.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
@@ -266,6 +270,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.80.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.80.0 // indirect
@@ -326,6 +331,7 @@ require (
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
+	go.etcd.io/bbolt v1.3.7 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.80.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v0.80.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -291,6 +291,7 @@ github.com/bkielbasa/cyclop v1.2.0/go.mod h1:qOI0yy6A7dYC4Zgsa72Ppm9kONl0RoIlPbz
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
+github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bombsimon/wsl/v3 v3.2.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
 github.com/bsm/sarama-cluster v2.1.13+incompatible/go.mod h1:r7ao+4tTNXvWm+VRpRJchr2kQhqxgmAp2iEX5W96gMM=
@@ -1246,6 +1247,7 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/observiq/ctimefmt v1.0.0 h1:r7vTJ+Slkrt9fZ67mkf+mA6zAdR5nGIJRMTzkUyvilk=
 github.com/observiq/ctimefmt v1.0.0/go.mod h1:mxi62//WbSpG/roCO1c6MqZ7zQTvjVtYheqHN3eOjvc=
+github.com/observiq/nanojack v0.0.0-20201106172433-343928847ebc h1:49ewVBwLcy+eYqI4R0ICilCI4dPjddpFXWv3liXzUxM=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
@@ -1284,6 +1286,8 @@ github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.80.0 h1:MFn4mWSeDFWuHeFTG4a+AMlxrrmpmpVIFndjixSq9eU=
 github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.80.0/go.mod h1:86BmUxPzvbwCMmlCYg+wE2RJkixq07EGv9X7ApJ4ssA=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.80.0 h1:obgvtZU3dG88muulCQrl5joo+1bU0AfRBQilcVLXoQw=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.80.0/go.mod h1:yLngeSbCks8ORYfwGDmoKa4AgPQyCAij3huFcG//qEM=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.80.0 h1:qap40x3P5hxtPaBtPner2fKMuZbCT+myO40xAOknkcQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.80.0/go.mod h1:pUjiByVP67csOHwtIRoGkYdzDPNR20Ru47z3erPVu4U=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.80.0 h1:n3jf7EQhHyupBULBtGCDkHWpvCVsf09rSkEPGzLA4R0=
@@ -1316,6 +1320,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextensi
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.80.0/go.mod h1:94k6OG2D6QsCM3UNGlSV61rWjNnmyej5pEusejrsxns=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.80.0 h1:bDOzezMdoK2m5Q7h/kzd5qBZRqX1B4hrIIzxKiDuFLE=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.80.0/go.mod h1:GvKtC20zbU1ldj6c8EnHcRFVQBJDrY0IwN0KzfsePYs=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.80.0 h1:J1lDmXPLcRPFSmuI9KthrxbxHx6or9e2Us2V8Q1mbEY=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.80.0/go.mod h1:0apoSNWoIjseuJ9WfPS1kgIIwPD6hy6wGAFLV4LkBtk=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.80.0 h1:1shm62b1ptUk2R9q9TeFRmLwxrObZwsByOCrCWF2cM4=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.80.0/go.mod h1:7hlMI9BZF3/O+2ru5xzOgw35V/2+pHRCQip7M5qPPx4=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight v0.80.0 h1:Bj0NvFJeeMQ5PtiTN/sZONEd+rczh1DvRPm9UX6nHHo=
@@ -1365,6 +1371,7 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.80.0/
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.80.0 h1:CqYgmPPPFTHMPNymMFM22A6R0GSUXfPzu8kwMHI6AmU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.80.0/go.mod h1:rGOF0E6vNjS/pdIBo43dgkLEAbabnGYuG3InxAs4mbI=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.80.0 h1:P519Jfw2dNW4FyepOUoN+EBGwhKZpDNGxfxBcbKm0pU=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.80.0/go.mod h1:rPhXh9uzzs0gU4i7iqVwzt8+eKjwiQSxVI3tkGBgnk0=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.52.0/go.mod h1:tU7s/ki/QePSIZ7ExYGWLMb9erCAt66brQHBEHxr8HU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.54.0/go.mod h1:uWFgO68sLEqWrQxL8rws1CkB8EUNQaedP3FWI1gMJOU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.57.2/go.mod h1:4rFuWKMbzM9H39RbDvPtJfAp/fxsHydhJhKns6skmK0=
@@ -1411,6 +1418,7 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontain
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.80.0 h1:vSAgqbMNK1DtFoFD6VesdjmqG7MW7HCDN6gWOCgdEpo=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.80.0/go.mod h1:lyOlrnDunXRb2GJMFBpHNb1Fb3E/cm/L90PBut4wLIo=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.80.0 h1:tjjq3Mwd0eNxAX1SX3ZKC852ylXP0hw3bzPbqcNudQg=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.80.0/go.mod h1:FWj/Kcv7TURpJjVfgLr/SAaWVczjFzjkHLYupHoA8KI=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.80.0 h1:Ipcw4LLyxuRDhF4iu3irByWrJ/ZhmOo1YP1JPI69GjY=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.80.0 h1:y7Q+273OjVQy3+jAEL6uXtDci3MZ2yCoEXe4VlRMo84=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.80.0/go.mod h1:oouhPXRhQHBfJAADTA0EVc/HwghFUA8lgBdd7TrzfNQ=
@@ -1841,6 +1849,8 @@ github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQ
 github.com/zorkian/go-datadog-api v2.30.0+incompatible h1:R4ryGocppDqZZbnNc5EDR8xGWF/z/MxzWnqTUijDQes=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.etcd.io/bbolt v1.3.7 h1:j+zJOnnEjF/kyHlDDgGnVL/AIqIJPq8UoB2GSNfkUfQ=
+go.etcd.io/bbolt v1.3.7/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/api/v3 v3.5.2/go.mod h1:5GB2vv4A4AOn3yk7MftYGHkUfGtDHnEraIjym4dYz5A=

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -16,6 +16,7 @@
 package defaultcomponents // import "aws-observability.io/collector/defaultcomponents
 
 import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter"
@@ -32,6 +33,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor"
@@ -47,6 +49,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
@@ -59,6 +62,7 @@ import (
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/extension/ballastextension"
 	"go.opentelemetry.io/collector/extension/zpagesextension"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/batchprocessor"
@@ -68,10 +72,21 @@ import (
 	"go.uber.org/multierr"
 )
 
+var fileLogReceiverFeatureGate = featuregate.GlobalRegistry().MustRegister("adot.filelog.receiver",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("Allows for the ADOT Collector to be configured and started with the File Log Receiver"))
+
+var cwlExporterFeatureGate = featuregate.GlobalRegistry().MustRegister("adot.awscloudwatchlogs.exporter",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("Allows for the ADOT Collector to be configured and started with the AWS CloudWatch Logs Exporter"))
+
+var fileStorageExtensionFeatureGate = featuregate.GlobalRegistry().MustRegister("adot.file_storage.extension",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("\"Allows for the ADOT Collector to be configured and started with the File Storage Extension"))
+
 // Components register OTel components for ADOT-collector distribution
 func Components() (otelcol.Factories, error) {
 	var errs error
-
 	extensionsList := []extension.Factory{
 		awsproxy.NewFactory(),
 		ecsobserver.NewFactory(),
@@ -80,6 +95,9 @@ func Components() (otelcol.Factories, error) {
 		sigv4authextension.NewFactory(),
 		zpagesextension.NewFactory(),
 		ballastextension.NewFactory(),
+	}
+	if fileStorageExtensionFeatureGate.IsEnabled() {
+		extensionsList = append(extensionsList, filestorage.NewFactory())
 	}
 	extensions, err := extension.MakeFactoryMap(extensionsList...)
 
@@ -98,7 +116,9 @@ func Components() (otelcol.Factories, error) {
 		zipkinreceiver.NewFactory(),
 		otlpreceiver.NewFactory(),
 	}
-
+	if fileLogReceiverFeatureGate.IsEnabled() {
+		receiverList = append(receiverList, filelogreceiver.NewFactory())
+	}
 	receivers, err := receiver.MakeFactoryMap(receiverList...)
 
 	if err != nil {
@@ -143,6 +163,9 @@ func Components() (otelcol.Factories, error) {
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),
 		awsxrayexporter.NewFactory(),
+	}
+	if cwlExporterFeatureGate.IsEnabled() {
+		exporterList = append(exporterList, awscloudwatchlogsexporter.NewFactory())
 	}
 	exporters, err := exporter.MakeFactoryMap(exporterList...)
 

--- a/pkg/defaultcomponents/defaults_test.go
+++ b/pkg/defaultcomponents/defaults_test.go
@@ -16,6 +16,7 @@
 package defaultcomponents
 
 import (
+	"go.opentelemetry.io/collector/featuregate"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,7 @@ const (
 	processorCount  = 14
 )
 
+// Assert that the components behind feature gate are not in the default
 func TestComponents(t *testing.T) {
 	factories, err := Components()
 	assert.NoError(t, err)
@@ -99,4 +101,42 @@ func TestComponents(t *testing.T) {
 	assert.NotNil(t, processors["deltatorate"])
 	assert.NotNil(t, processors["groupbytrace"])
 	assert.NotNil(t, processors["tail_sampling"])
+
+	// Ensure that the components behind feature gates aren't included
+	assert.Nil(t, receivers["filelog"])
+	assert.Nil(t, exporters["awscloudwatchlogs"])
+	assert.Nil(t, extensions["file_storage"])
+}
+
+func TestFileLogReceiverEnabled(t *testing.T) {
+	err := featuregate.GlobalRegistry().Set("adot.filelog.receiver", true)
+	assert.NoError(t, err)
+	factories, err := Components()
+	assert.NoError(t, err)
+	receivers := factories.Receivers
+	assert.Len(t, receivers, receiversCount+1)
+	// File Log Receiver
+	assert.NotNil(t, receivers["filelog"])
+}
+
+func TestCWLExporterEnabled(t *testing.T) {
+	err := featuregate.GlobalRegistry().Set("adot.awscloudwatchlogs.exporter", true)
+	assert.NoError(t, err)
+	factories, err := Components()
+	assert.NoError(t, err)
+	exporters := factories.Exporters
+	assert.Len(t, exporters, exportersCount+1)
+	//CloudWatch Logs Exporter
+	assert.NotNil(t, exporters["awscloudwatchlogs"])
+}
+
+func TestFileStorageExtensionEnabled(t *testing.T) {
+	err := featuregate.GlobalRegistry().Set("adot.file_storage.extension", true)
+	assert.NoError(t, err)
+	factories, err := Components()
+	assert.NoError(t, err)
+	extensions := factories.Extensions
+	assert.Len(t, extensions, extensionsCount+1)
+	//File Storage Extension
+	assert.NotNil(t, extensions["file_storage"])
 }

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/aws/smithy-go v1.13.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/bmatcuk/doublestar/v4 v4.6.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
@@ -186,6 +187,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/observiq/ctimefmt v1.0.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter v0.80.0 // indirect
@@ -206,6 +208,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.80.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs v0.80.0 // indirect
@@ -228,6 +231,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.80.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.80.0 // indirect
@@ -251,6 +255,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.80.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.80.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver v0.80.0 // indirect
@@ -321,6 +326,7 @@ require (
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
+	go.etcd.io/bbolt v1.3.7 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.80.0 // indirect
 	go.opentelemetry.io/collector/component v0.80.0 // indirect

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -284,6 +284,7 @@ github.com/bkielbasa/cyclop v1.2.0/go.mod h1:qOI0yy6A7dYC4Zgsa72Ppm9kONl0RoIlPbz
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
+github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bombsimon/wsl/v3 v3.2.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
@@ -1247,6 +1248,7 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/observiq/ctimefmt v1.0.0 h1:r7vTJ+Slkrt9fZ67mkf+mA6zAdR5nGIJRMTzkUyvilk=
 github.com/observiq/ctimefmt v1.0.0/go.mod h1:mxi62//WbSpG/roCO1c6MqZ7zQTvjVtYheqHN3eOjvc=
+github.com/observiq/nanojack v0.0.0-20201106172433-343928847ebc h1:49ewVBwLcy+eYqI4R0ICilCI4dPjddpFXWv3liXzUxM=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
@@ -1283,6 +1285,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
 github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.80.0 h1:obgvtZU3dG88muulCQrl5joo+1bU0AfRBQilcVLXoQw=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.80.0/go.mod h1:yLngeSbCks8ORYfwGDmoKa4AgPQyCAij3huFcG//qEM=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.80.0 h1:qap40x3P5hxtPaBtPner2fKMuZbCT+myO40xAOknkcQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.80.0/go.mod h1:pUjiByVP67csOHwtIRoGkYdzDPNR20Ru47z3erPVu4U=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.80.0 h1:n3jf7EQhHyupBULBtGCDkHWpvCVsf09rSkEPGzLA4R0=
@@ -1324,6 +1328,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextensi
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.80.0/go.mod h1:94k6OG2D6QsCM3UNGlSV61rWjNnmyej5pEusejrsxns=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.80.0 h1:bDOzezMdoK2m5Q7h/kzd5qBZRqX1B4hrIIzxKiDuFLE=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.80.0/go.mod h1:GvKtC20zbU1ldj6c8EnHcRFVQBJDrY0IwN0KzfsePYs=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.80.0 h1:J1lDmXPLcRPFSmuI9KthrxbxHx6or9e2Us2V8Q1mbEY=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.80.0/go.mod h1:0apoSNWoIjseuJ9WfPS1kgIIwPD6hy6wGAFLV4LkBtk=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.80.0 h1:1shm62b1ptUk2R9q9TeFRmLwxrObZwsByOCrCWF2cM4=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.80.0/go.mod h1:7hlMI9BZF3/O+2ru5xzOgw35V/2+pHRCQip7M5qPPx4=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight v0.80.0 h1:Bj0NvFJeeMQ5PtiTN/sZONEd+rczh1DvRPm9UX6nHHo=
@@ -1373,6 +1379,7 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.80.0/
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.80.0 h1:CqYgmPPPFTHMPNymMFM22A6R0GSUXfPzu8kwMHI6AmU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.80.0/go.mod h1:rGOF0E6vNjS/pdIBo43dgkLEAbabnGYuG3InxAs4mbI=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.80.0 h1:P519Jfw2dNW4FyepOUoN+EBGwhKZpDNGxfxBcbKm0pU=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.80.0/go.mod h1:rPhXh9uzzs0gU4i7iqVwzt8+eKjwiQSxVI3tkGBgnk0=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.52.0/go.mod h1:tU7s/ki/QePSIZ7ExYGWLMb9erCAt66brQHBEHxr8HU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.54.0/go.mod h1:uWFgO68sLEqWrQxL8rws1CkB8EUNQaedP3FWI1gMJOU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.57.2/go.mod h1:4rFuWKMbzM9H39RbDvPtJfAp/fxsHydhJhKns6skmK0=
@@ -1424,6 +1431,7 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceive
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.80.0 h1:elIzVG3DclrZRHyfyxcGEDosNrym9ftdtoL34zHwUVU=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver v0.80.0/go.mod h1:8CxDuktIzjhS7uDHcWuDRSsqEopTlxYQRei2BN1sKng=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.80.0 h1:tjjq3Mwd0eNxAX1SX3ZKC852ylXP0hw3bzPbqcNudQg=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.80.0/go.mod h1:FWj/Kcv7TURpJjVfgLr/SAaWVczjFzjkHLYupHoA8KI=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.80.0 h1:Ipcw4LLyxuRDhF4iu3irByWrJ/ZhmOo1YP1JPI69GjY=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.80.0 h1:y7Q+273OjVQy3+jAEL6uXtDci3MZ2yCoEXe4VlRMo84=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.80.0/go.mod h1:oouhPXRhQHBfJAADTA0EVc/HwghFUA8lgBdd7TrzfNQ=
@@ -1873,6 +1881,8 @@ github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQ
 github.com/zorkian/go-datadog-api v2.30.0+incompatible h1:R4ryGocppDqZZbnNc5EDR8xGWF/z/MxzWnqTUijDQes=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.etcd.io/bbolt v1.3.7 h1:j+zJOnnEjF/kyHlDDgGnVL/AIqIJPq8UoB2GSNfkUfQ=
+go.etcd.io/bbolt v1.3.7/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/api/v3 v3.5.2/go.mod h1:5GB2vv4A4AOn3yk7MftYGHkUfGtDHnEraIjym4dYz5A=


### PR DESCRIPTION
**Description:** Added [File Log Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver), [AWS CloudWatch Logs Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awscloudwatchlogsexporter), and [File Storage Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage) to the ADOT Collector. These components are behind a feature gate that is disabled by default (i.e. Stage Alpha).

**Link to tracking Issue:**

**Testing:** Added on to one of the unit tests to make sure all these components are not included by default. Separate unit tests were created to ensure each component was added to the ADOT Collector when their corresponding feature gate is enabled. These unit tests are located pkg/defaultcomponents/defaults_test.go

**Documentation:** No documentation was added since these components are still being tested.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
