### PR TITLE
[chore]Fix ref name CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -581,7 +581,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: aws-otel-collector
-          ref: ${{ needs.create-test-ref.outputs.testRef }}
+          ref: ${{ github.ref_name }}
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v4


### PR DESCRIPTION
**Description:** Oops, `outputs.testRef` is the ref for the testing-framework repo and should not have been used for the collector repository. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
