### PR TITLE
[chore] Add missing cluster targets

### DIFF
--- a/.github/config/testcases.json
+++ b/.github/config/testcases.json
@@ -4,14 +4,21 @@
 			"type": "EKS",
 			"targets": [
 				{
-					"name": "collector-ci-amd64-1-25",
+					"name": "collector-ci-amd64-1-22",
 					"region": "us-west-2",
 					"excluded_tests": [
-						"containerinsight_eks"
+						"containerinsights_eks_containerd"
 					]
 				},
 				{
-					"name": "collector-ci-amd64-1-26",
+					"name": "collector-ci-amd64-1-23",
+					"region": "us-west-2",
+					"excluded_tests": [
+						"containerinsights_eks_containerd"
+					]
+				},
+				{
+					"name": "collector-ci-amd64-1-24",
 					"region": "us-west-2",
 					"excluded_tests": [
 						"containerinsight_eks"
@@ -37,14 +44,21 @@
 			"type": "EKS_ARM64",
 			"targets": [
 				{
-					"name": "collector-ci-arm64-1-25",
+					"name": "collector-ci-arm64-1-22",
 					"region": "us-west-2",
 					"excluded_tests": [
-						"containerinsight_eks"
+						"containerinsights_eks_containerd"
 					]
 				},
 				{
-					"name": "collector-ci-arm64-1-26",
+					"name": "collector-ci-arm64-1-23",
+					"region": "us-west-2",
+					"excluded_tests": [
+						"containerinsights_eks_containerd"
+					]
+				},
+				{
+					"name": "collector-ci-arm64-1-24",
 					"region": "us-west-2",
 					"excluded_tests": [
 						"containerinsight_eks"


### PR DESCRIPTION
**Description:** Test cases file should be targeting clusters 1.22 - 1.26 for eks and eks arm64


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
