### PR TITLE
Adding ECS_Observer_Test_Case

### DIFF
--- a/.github/config/testcases.json
+++ b/.github/config/testcases.json
@@ -557,6 +557,12 @@
 			"platforms": [
 				"ECS"
 			]
+		},
+		{
+			"case_name": "containerinsight_ecs_prometheus",
+			"platforms": [
+				"ECS"
+			]
 		}
 	]
 }


### PR DESCRIPTION
**Description:** 

Adding TestCase: containerinsight_ecs_prometheus to testcases.json, as the `ecs_observer` fix has been merged. 

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/aws-observability/aws-otel-collector/issues/2039
https://github.com/aws-observability/aws-otel-collector/issues/1636
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5373
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21509


**Testing:** <Describe what testing was performed and which tests were added.>
TestCase: containerinsight_ecs_prometheus passed on local box. 
<img width="1674" alt="Screenshot 2023-07-31 at 10 57 30 PM" src="https://github.com/aws-observability/aws-otel-collector/assets/62579325/a41bbfac-0f01-4197-b17c-993453602803">



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
