### PR TITLE
Add Log statement about statsd receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Use the community resources below for getting help with the ADOT Collector.
 * If you think you may have found a bug, open a [bug report](https://github.com/aws-observability/aws-otel-collector/issues/new?template=bug_report.md).
 * For contributing guidelines, refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 
-### Notice: ADOT Collector v0.32.0 Breaking Change
+### Notice: ADOT Collector v0.33.0 Breaking Change
 Users of the `statsd` receiver, please refer to GitHub Issue - [Warning: StatsD Receiver → EMF Exporter Metric Pipeline Breaking Change](https://github.com/aws-observability/aws-otel-collector/issues/2249)
 for information on an upcoming breaking change.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Use the community resources below for getting help with the ADOT Collector.
 * If you think you may have found a bug, open a [bug report](https://github.com/aws-observability/aws-otel-collector/issues/new?template=bug_report.md).
 * For contributing guidelines, refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 
+### Notice: ADOT Collector v0.32.0 Breaking Change
+Users of the `statsd` receiver, please refer to GitHub Issue - [Warning: StatsD Receiver → EMF Exporter Metric Pipeline Breaking Change](https://github.com/aws-observability/aws-otel-collector/issues/2249)
+for information on an upcoming breaking change.
+
 #### ADOT Collector Built-in Components
 
 This table represents the supported components of the ADOT Collector. The highlighted components below are developed by AWS in-house. The rest of the components in the table are the essential default components that the ADOT Collector will support.

--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -94,7 +94,7 @@ func buildAndParseFlagSet(featgate *featuregate.Registry) (*flag.FlagSet, error)
 	flagSet := config.Flags(featgate)
 
 	// TODO: remove after ADOT Collector v0.34.0 is released
-	log.Printf("attn: users of the statsd please refer to " +
+	log.Printf("attn: users of the statsd receiver please refer to " +
 		"https://github.com/aws-observability/aws-otel-collector/issues/2249 in regards to an ADOT Collector v0.33.0 " +
 		"breaking change")
 	if err := flagSet.Parse(os.Args[1:]); err != nil {

--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -94,9 +94,6 @@ func buildAndParseFlagSet(featgate *featuregate.Registry) (*flag.FlagSet, error)
 	flagSet := config.Flags(featgate)
 
 	// TODO: remove after ADOT Collector v0.34.0 is released
-	if err := featgate.Set("aws.statsd.instrumentationScope", false); err != nil {
-		return nil, err
-	}
 	log.Printf("attn: users of the statsd please refer to " +
 		"https://github.com/aws-observability/aws-otel-collector/issues/2249 in regards to an ADOT Collector v0.32.0 " +
 		"breaking change")

--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -93,6 +93,13 @@ func main() {
 func buildAndParseFlagSet(featgate *featuregate.Registry) (*flag.FlagSet, error) {
 	flagSet := config.Flags(featgate)
 
+	// TODO: remove after ADOT Collector v0.34.0 is released
+	if err := featgate.Set("aws.statsd.instrumentationScope", false); err != nil {
+		return nil, err
+	}
+	log.Printf("attn: users of the statsd please refer to " +
+		"https://github.com/aws-observability/aws-otel-collector/issues/2249 in regards to an ADOT Collector v0.32.0 " +
+		"breaking change")
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		return nil, err
 	}

--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -95,7 +95,7 @@ func buildAndParseFlagSet(featgate *featuregate.Registry) (*flag.FlagSet, error)
 
 	// TODO: remove after ADOT Collector v0.34.0 is released
 	log.Printf("attn: users of the statsd please refer to " +
-		"https://github.com/aws-observability/aws-otel-collector/issues/2249 in regards to an ADOT Collector v0.32.0 " +
+		"https://github.com/aws-observability/aws-otel-collector/issues/2249 in regards to an ADOT Collector v0.33.0 " +
 		"breaking change")
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		return nil, err

--- a/docs/developers/build-docker.md
+++ b/docs/developers/build-docker.md
@@ -7,4 +7,4 @@ aws-otel-collector is an open source project, we’re looking for the contributi
 2. Build your own docker image.  
 ```make docker-build ```
 3. Run AWSOTelCollector docker image with the default configuration file. By default, it will pull the latest image from ECR. Modify docker-compose.yaml to use your own image.  
-```cd examples; docker-compose up -d```
+```cd examples/docker; docker-compose up -d```


### PR DESCRIPTION
**Description:** 
This PR is created to add log statement regarding statsd receiver

Tested: 

```
2023/08/07 21:35:37 found no extra config, skip it, err: open /opt/aws/aws-otel-collector/etc/extracfg.txt: no such file or directory
2023/08/07 21:35:37 attn: users of the statsd please refer to https://github.com/aws-observability/aws-otel-collector/issues/2249 in regards to an ADOT Collector v0.32.0 breaking change
```

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
