### PR TITLE
[aoc-collector non-root user]: Create and use a new user for the container image

### DIFF
--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -4,16 +4,30 @@
 ARG BUILDMODE=build
 
 ################################
-#	Certificate Stage      #
-#			       #
+#	       Base Stage          #
+#			                   #
 ################################
-FROM alpine:latest AS certs
+FROM alpine:latest AS base
+
+ARG USERNAME=aoc
+ARG USER_UID=4317
+
+RUN addgroup \
+    -g $USER_UID \
+    $USERNAME && \
+    adduser \
+    -D \
+    -g $USERNAME \
+    -h "/home/${USERNAME}"\
+    -G $USERNAME \
+    -u $USER_UID \
+    $USERNAME \
 
 RUN apk --update add ca-certificates
 
 ################################
-#	Build Stage            #
-#			       #
+#	       Build Stage         #
+#			                   #
 ################################
 FROM golang:1.20 AS prep-build
 
@@ -68,14 +82,21 @@ COPY config/ /workspace/config/
 ################################
 FROM scratch
 
-COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+ARG USERNAME=aoc
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=base /etc/passwd /etc/passwd
+COPY --from=base /etc/group /etc/group
+COPY --from=base /home/$USERNAME/ /home/$USERNAME
 COPY --from=package /workspace/awscollector /awscollector
 COPY --from=package /workspace/config/ /etc/
 COPY --from=package /workspace/healthcheck /healthcheck
 
 ENV RUN_IN_CONTAINER="True"
+
+USER $USERNAME
 # aws-sdk-go needs $HOME to look up shared credentials
-ENV HOME=/root
+ENV HOME=/home/$USERNAME
 ENTRYPOINT ["/awscollector"]
 CMD ["--config=/etc/otel-config.yaml"]
 EXPOSE 4317 55681 2000

--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -21,7 +21,7 @@ RUN addgroup \
     -h "/home/${USERNAME}"\
     -G $USERNAME \
     -u $USER_UID \
-    $USERNAME \
+    $USERNAME
 
 RUN apk --update add ca-certificates
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Adding `aoc` user to docker file for dev branch as done in [this](https://github.com/aws-observability/aws-otel-collector/pull/1549) PR.
Haven't removed [RUN_IN_CONTAINER](https://github.com/aws-observability/aws-otel-collector/blob/main/pkg/extraconfig/container.go#L21) environment variable as it is getting used at [this](https://github.com/aws-observability/aws-otel-collector/blob/8343b25181940ee656138f42986462500f623672/pkg/logger/logger.go#L41) place as well.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/aws-observability/aws-otel-collector/issues/2222

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
