### PR TITLE
Fix control script to avoid sed special characters

### DIFF
--- a/.github/scripts/test-collector-ctl.sh
+++ b/.github/scripts/test-collector-ctl.sh
@@ -49,7 +49,7 @@ test_collector_ctl_with_sed_special_chars() {
 
     expected_string="^config=\"--config '${cfg}'\"$"
 
-    if ! grep -q "${expected_string}" "$CONFIG_FILE";  then
+    if ! grep -q "${expected_string}" "$ENV_FILE";  then
         echo "Configuration is incorrect"
         exit 1
     fi
@@ -58,7 +58,7 @@ test_collector_ctl_with_sed_special_chars() {
     $ADOT_CTL -a start -c "$cfg"
 
     expected_string="^config=\"--config /opt/aws/aws-otel-collector/etc/config.yaml\"$"
-    if ! grep -q "${expected_string}" "$CONFIG_FILE";  then
+    if ! grep -q "${expected_string}" "$ENV_FILE";  then
         echo "Configuration is incorrect"
         exit 1
     fi

--- a/.github/scripts/test-collector-ctl.sh
+++ b/.github/scripts/test-collector-ctl.sh
@@ -42,8 +42,33 @@ test_collector_ctl_does_not_overwrite_env() {
     echo "${FUNCNAME[0]} ... OK"
 }
 
+test_collector_ctl_with_sed_special_chars() {
+    # ampersand is a special character in sed
+    cfg="https://example.com?test=1&test=2"
+    $ADOT_CTL -a start -c "$cfg"
+
+    expected_string="^config=\"--config '${cfg}'\"$"
+
+    if ! grep -q "${expected_string}" "$CONFIG_FILE";  then
+        echo "Configuration is incorrect"
+        exit 1
+    fi
+
+    cfg="./config.yaml"
+    $ADOT_CTL -a start -c "$cfg"
+
+    expected_string="^config=\"--config /opt/aws/aws-otel-collector/etc/config.yaml\"$"
+    if ! grep -q "${expected_string}" "$CONFIG_FILE";  then
+        echo "Configuration is incorrect"
+        exit 1
+    fi
+
+    echo "${FUNCNAME[0]} ... OK"
+}
+
 
 setup
 
 ## Tests
 test_collector_ctl_does_not_overwrite_env
+test_collector_ctl_with_sed_special_chars

--- a/tools/ctl/linux/aws-otel-collector-ctl.sh
+++ b/tools/ctl/linux/aws-otel-collector-ctl.sh
@@ -53,7 +53,8 @@ UsageString="
 aoc_config_remote_uri() {
     config="${1:-}"
 
-    sed -i 's#^config=.*$#config="--config '"${config}"'"#' $ENV_FILE
+    sed -i '/^config=.*$/d' $ENV_FILE
+    echo "config=\"--config '${config}'\"" >> $ENV_FILE
 }
 
 
@@ -63,7 +64,9 @@ aoc_config_local_uri() {
     # Strip the file scheme in case it is present
     config="${config#file:}"
 
-    sed -i 's#^config=.*$#config="--config /opt/aws/aws-otel-collector/etc/config.yaml"#' $ENV_FILE
+    sed -i '/^config=.*$/d' $ENV_FILE
+    echo "config=\"--config /opt/aws/aws-otel-collector/etc/config.yaml\"" >> $ENV_FILE
+
 
     if [ -n "$config" ] && [ -f "$config" ]; then
         cp "$config" $CONFDIR/config.yaml


### PR DESCRIPTION
**Description:** Fix control script to avoid sed special characters

Before the control script was using sed to do string replacement of the configuration. However urls can contain characters that have special meaning in the sed replacement part. Therefore we are removing the line and creating a new one instead of changing in place.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
