### PR TITLE
Fix testcases.json excluded test cases in dev branch

### DIFF
--- a/.github/config/testcases.json
+++ b/.github/config/testcases.json
@@ -7,7 +7,7 @@
 					"name": "dev-collector-ci-amd64-1-23",
 					"region": "us-west-2",
 					"excluded_tests": [
-						"containerinsight_eks_containerd"
+						"containerinsights_eks_containerd"
 					]
 				},
 				{
@@ -26,7 +26,7 @@
 					"name": "dev-collector-ci-arm64-1-23",
 					"region": "us-west-2",
 					"excluded_tests": [
-						"containerinsight_eks_containerd"
+						"containerinsights_eks_containerd"
 					]
 				},
 				{


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Fix testcases.json excluded test cases in dev branch, causing failure [here](https://github.com/aws-observability/aws-otel-collector/actions/runs/5833077090/job/15827065582#step:6:32)

Note: It seems the naming of eks containerinsights testcases in test-framework need refactoring -  they cause massive confusion, and also (especially) the part where the templates are [duplicated](https://github.com/aws-observability/aws-otel-test-framework/tree/terraform/validator/src/main/resources/expected-data-template/container-insight/eks). 

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
