### PR TITLE
[chore] Updated typo in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To build the ADOT Collector locally, you will need to have Golang installed. You
 
 The ADOT Collector is built with a [default configuration](https://github.com/aws-observability/aws-otel-collector/blob/main/config.yaml).
 The ADOT Collector configuration uses the same configuration syntax/design from [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector). For more information regarding OpenTelemetry Collector configuration please refer to the [upstream documentation](https://opentelemetry.io/docs/collector/configuration/). 
-so you can customize or port your OpenTelemetry Collector configuration files when running ADOT Collector. Please refer to the `Try out ADOT Collector` section on configuring ADOT Collector.
+so you can customize or port your OpenTelemetry Collector configuration files when running ADOT Collector. Please refer to the `Try out the ADOT Collector` section on configuring ADOT Collector.
 
 #### Try out the ADOT Collector
 


### PR DESCRIPTION
**Description:** 
Fixed typo in README. The README referenced `Try out ADOT Collector` when it should have referenced `Try out the ADOT Collector`. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
