### PR TITLE
Use reusable workflows to trigger perf workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -808,11 +808,8 @@ jobs:
           aws s3 cp $GITHUB_SHA.tar.gz s3://aws-otel-collector-release-candidate/$GITHUB_SHA.tar.gz
 
       - name: Trigger performance test
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: "${{ secrets.REPO_WRITE_ACCESS_TOKEN }}"
-          event-type: trigger-perf
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+        uses: ./.github/workflows/perf.yml
+        secrets: inherit
 
   publish-ci-status:
     runs-on: ubuntu-latest

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -13,8 +13,7 @@
 
 name: 'Performance test'
 on:
-  repository_dispatch:
-    types: [trigger-perf]
+  workflow_call:
   workflow_dispatch:
     inputs:
       sha:
@@ -66,8 +65,8 @@ jobs:
           aws-region: us-west-2
 
       - name: Download candidate based on dispatch payload
-        if: github.event_name == 'repository_dispatch'
-        run: aws s3 cp "s3://aws-otel-collector-release-candidate/${{ github.event.client_payload.sha }}.tar.gz" ./candidate.tar.gz
+        if: github.event_name == 'workflow_call'
+        run: aws s3 cp "s3://aws-otel-collector-release-candidate/${{ github.sha }}.tar.gz" ./candidate.tar.gz
 
       - name: Download candidate based on workflow dispatch input
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
**Description:**  Use reusable workflows to trigger perf workflow

This is so that we don't need to rely on `peter-evans/repository-dispatch@v2` and have the extra `REPO_WRITE_ACCESS_TOKEN`

References: https://docs.github.com/en/actions/using-workflows/reusing-workflows

> When a reusable workflow is triggered by a caller workflow, the github context is always associated with the caller workflow. The called workflow is automatically granted access to github.token and secrets.GITHUB_TOKEN. For more information about the github context, see "[Contexts](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)."

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
