### PR TITLE
Fix invocation of the perf workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -807,9 +807,10 @@ jobs:
           tar czvf $GITHUB_SHA.tar.gz build
           aws s3 cp $GITHUB_SHA.tar.gz s3://aws-otel-collector-release-candidate/$GITHUB_SHA.tar.gz
 
-      - name: Trigger performance test
-        uses: ./.github/workflows/perf.yml
-        secrets: inherit
+  perf-workflow:
+    needs: [release-candidate]
+    uses: ./.github/workflows/perf.yml
+    secrets: inherit
 
   publish-ci-status:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description:** Fix invocation of the perf workflow

The [documentation](https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow) was not clear that inherit would only work in the job level.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
