### PR TITLE
Add dependency to build-aot-util in performance test job

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -139,7 +139,7 @@ jobs:
 
   run-perf-test:
     runs-on: ubuntu-latest
-    needs: [get-perf-test-cases, get-testing-version, create-test-ref]
+    needs: [get-perf-test-cases, get-testing-version, create-test-ref, build-aotutil]
     strategy:
       matrix: ${{ fromJson(needs.get-perf-test-cases.outputs.perf_matrix) }}
       max-parallel: 10

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -124,18 +124,22 @@ jobs:
           repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
           ref: ${{ needs.create-test-ref.outputs.testRef }}
+      - name: Cache aotutil
+        uses: actions/cache@v3
+        id: cache
+        with:
+          key: "aotutil_${{ hashFiles('testing-framework/cmd/aotutil/*.go') }}_${{ hashFiles('testing-framework/cmd/aotutil/go.sum') }}"
+          path: testing-framework/cmd/aotutil/aotutil
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
+        if: steps.cache.outputs.cache-hit != 'true'
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: testing-framework/cmd/aotutil/go.sum
       - name: Build aotutil
+        if: steps.cache.outputs.cache-hit != 'true'
         run: cd testing-framework/cmd/aotutil && make build
-      - name: Cache aotutil
-        uses: actions/cache@v3
-        with:
-          key: "aotutil_${{ hashFiles('testing-framework/cmd/aotutil/*.go') }}_${{ hashFiles('testing-framework/cmd/aotutil/go.sum') }}"
-          path: testing-framework/cmd/aotutil/aotutil
+
 
   run-perf-test:
     runs-on: ubuntu-latest
@@ -177,6 +181,7 @@ jobs:
         with:
           key: "aotutil_${{ hashFiles('testing-framework/cmd/aotutil/*.go') }}_${{ hashFiles('testing-framework/cmd/aotutil/go.sum') }}"
           path: testing-framework/cmd/aotutil/aotutil
+          fail-on-cache-miss: true
 
       - name: Run Performance test
         run: |


### PR DESCRIPTION
**Description:** AOT Util needs to be built first so the cache can be restored. Also avoid building if cache already exists. Add in option to fail on cache miss since AOTUtil is required to execute the job. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
