### PR TITLE
Handle prometheus normalization breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Use the community resources below for getting help with the ADOT Collector.
 Users of the `statsd` receiver, please refer to GitHub Issue - [Warning: StatsD Receiver → EMF Exporter Metric Pipeline Breaking Change](https://github.com/aws-observability/aws-otel-collector/issues/2249)
 for information on an upcoming breaking change.
 
-### Notice: ADOT Collector v0.35.0 Breaking Change
-Users of the 'awscontainerinsightreceiver', please refer to the GitHub Issue - [Warning: Container Image Default User Change → Important consideration for AWSContainerInsightReceiver](https://github.com/aws-observability/aws-otel-collector/issues/2317) for more information on an upcoming breaking change.
+### Notices: ADOT Collector v0.35.0 Breaking Changes
+* Users of the 'awscontainerinsightreceiver', please refer to the GitHub Issue - [Warning: Container Image Default User Change → Important consideration for AWSContainerInsightReceiver](https://github.com/aws-observability/aws-otel-collector/issues/2317) for more information on an upcoming breaking change.
+* Users of the `prometheus` or `prometheusremotewrite` exporters please refer to the GitHub Issue [Warning: ADOT Collector v0.35.0 breaking change](https://github.com/aws-observability/aws-otel-collector/issues/xxx)
+for information on an upcoming breaking change.
 
 #### ADOT Collector Built-in Components
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ for information on an upcoming breaking change.
 
 ### Notices: ADOT Collector v0.35.0 Breaking Changes
 * Users of the 'awscontainerinsightreceiver', please refer to the GitHub Issue - [Warning: Container Image Default User Change → Important consideration for AWSContainerInsightReceiver](https://github.com/aws-observability/aws-otel-collector/issues/2317) for more information on an upcoming breaking change.
-* Users of the `prometheus` or `prometheusremotewrite` exporters please refer to the GitHub Issue [Warning: ADOT Collector v0.35.0 breaking change](https://github.com/aws-observability/aws-otel-collector/issues/xxx)
+* Users of the `prometheus` or `prometheusremotewrite` exporters please refer to the GitHub Issue [Warning: ADOT Collector v0.35.0 breaking change](https://github.com/aws-observability/aws-otel-collector/issues/2367)
 for information on an upcoming breaking change.
 
 #### ADOT Collector Built-in Components

--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -88,10 +88,16 @@ func main() {
 	}
 }
 
-// We parse the flags manually here so that we can use feature gates when constructing
-// our default component list. Flags also need to be parsed before creating the config provider.
-func buildAndParseFlagSet(featgate *featuregate.Registry) (*flag.FlagSet, error) {
-	flagSet := config.Flags(featgate)
+// Override upstream feature gates and print warning messages
+func handleBreakingChanges(featgate *featuregate.Registry) error {
+	// TODO: remove after ADOT Collector v0.34.0 is released
+	if err := featgate.Set("pkg.translator.prometheus.NormalizeName", false); err != nil {
+		return err
+	}
+
+	log.Printf("attn: users of the prometheus or prometheusremotewrite exporter please refer to " +
+		"https://github.com/aws-observability/aws-otel-collector/issues/xxx in regards to an ADOT Collector v0.35.0 " +
+		"breaking change")
 
 	// TODO: remove after ADOT Collector v0.34.0 is released
 	log.Printf("attn: users of the statsd receiver please refer to " +
@@ -101,6 +107,19 @@ func buildAndParseFlagSet(featgate *featuregate.Registry) (*flag.FlagSet, error)
 	log.Printf("attn: users of the awscontainerinsightreceiver please refer to " +
 		"https://github.com/aws-observability/aws-otel-collector/issues/2317 in regards to an ADOT Collector v0.35.0 " +
 		"breaking change")
+
+	return nil
+}
+
+// We parse the flags manually here so that we can use feature gates when constructing
+// our default component list. Flags also need to be parsed before creating the config provider.
+func buildAndParseFlagSet(featgate *featuregate.Registry) (*flag.FlagSet, error) {
+	if err := handleBreakingChanges(featgate); err != nil {
+		return nil, err
+	}
+
+	flagSet := config.Flags(featgate)
+
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		return nil, err
 	}

--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -96,7 +96,7 @@ func handleBreakingChanges(featgate *featuregate.Registry) error {
 	}
 
 	log.Printf("attn: users of the prometheus or prometheusremotewrite exporter please refer to " +
-		"https://github.com/aws-observability/aws-otel-collector/issues/xxx in regards to an ADOT Collector v0.35.0 " +
+		"https://github.com/aws-observability/aws-otel-collector/issues/2367 in regards to an ADOT Collector v0.35.0 " +
 		"breaking change")
 
 	// TODO: remove after ADOT Collector v0.34.0 is released


### PR DESCRIPTION
**Description:** Handle prometheus normalization breaking change

This PR will give users one more release of time to absorb the changes in the behaviour of the normalization of prometheus exporters, as a result of [this change](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/26489) being merged upstream.

**Link to tracking Issue:** #2367

**Testing:** I will use the CI to validate this change.

**Documentation:** In #2367


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
