### PR TITLE
Update linux ctl script to handle same file path issue

### DIFF
--- a/tools/ctl/linux/aws-otel-collector-ctl.sh
+++ b/tools/ctl/linux/aws-otel-collector-ctl.sh
@@ -70,6 +70,8 @@ aoc_config_local_uri() {
 
     if [ -n "$config" ] && [ -f "$config" ]; then
         cp "$config" $CONFDIR/config.yaml
+    elif [ "$config" == "$CONFDIR/config.yaml" ]; then
+        echo "Source and destination files are the same. No need to copy."
     else
         echo "File $config does not exist"
         exit 1

--- a/tools/ctl/linux/aws-otel-collector-ctl.sh
+++ b/tools/ctl/linux/aws-otel-collector-ctl.sh
@@ -70,7 +70,7 @@ aoc_config_local_uri() {
 
     if [ -n "$config" ] && [ -f "$config" ]; then
         cp "$config" $CONFDIR/config.yaml
-    elif [ "$config" == "$CONFDIR/config.yaml" ]; then
+    elif [ "$config" = "$CONFDIR/config.yaml" ]; then
         echo "Source and destination files are the same. No need to copy."
     else
         echo "File $config does not exist"


### PR DESCRIPTION
**Description:** 

When we run `/opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -c file:/opt/aws/aws-otel-collector/etc/config.yaml -a start` on an EC2 instance to start up the ADOT collector, we get the error:

`cp: ‘/opt/aws/aws-otel-collector/etc/config.yaml’ and ‘/opt/aws/aws-otel-collector/etc/config.yaml’ are the same file`

The issue seems to be that we are trying to pass the default config path (`file:/opt/aws/aws-otel-collector/etc/config.yaml)` again with a `-c` flag which is to be used to pass custom config. This causes the cp command to fail as the same file is trying to overwrite itself

The fix is to add an additional conditional logic to check if both the file paths are same before we run the `cp` command



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
