### PR TITLE
Preserve user and group when copying default config

### DIFF
--- a/tools/ctl/linux/aws-otel-collector-ctl.sh
+++ b/tools/ctl/linux/aws-otel-collector-ctl.sh
@@ -84,7 +84,7 @@ aoc_config_local_uri() {
 # Safe to run as this will not overwrite a file if one exists in default location already.
 aoc_ensure_default_config() {
     if [ ! -f $CONFDIR/config.yaml ]; then
-        cp $DFT_CONFDIR/.config.yaml $CONFDIR/config.yaml
+        cp -p $DFT_CONFDIR/.config.yaml $CONFDIR/config.yaml
     fi
 }
 


### PR DESCRIPTION
**Description:** Ensure that `aoc:aoc` user:group gets preserved when copying default config. Without this the collector `aoc` user will not be able to read the config file. 

Current behavior - `root:root` will become user and group. Service executes as `aoc:aoc`. Collector receives permission denied when trying to read config file. 

Permissions before copy
```
sudo ls -al /opt/aws/aws-otel-collector/var
total 4
drwxr-x--- 2 aoc  aoc   26 Oct 15 00:47 .
drwxr-xr-x 7 root root  97 Oct 15 00:47 ..
-rw-r----- 1 aoc  aoc  596 Oct 13 00:53 .config.yaml

```
permissions pre change post copy
```
$ sudo ls -l /opt/aws/aws-otel-collector/etc/
total 8
-rw-r----- 1 root root 413 Oct 15 00:14 config.yaml
-rw-r----- 1 aoc  aoc  144 Oct 14 00:22 extracfg.txt
```


permissions post change post copy
```
sudo ls -l /opt/aws/aws-otel-collector/etc/
total 8
-rw-r----- 1 aoc aoc 596 Oct 14 00:22 config.yaml
-rw-r----- 1 aoc aoc 144 Oct 14 00:22 extracfg.txt
```
<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
