### PR TITLE
Use Gradle command to build wrapper

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -748,6 +748,7 @@ jobs:
         run: |
           export TEST_IMAGE=public.ecr.aws/${{ env.ECR_REPO }}:${{ needs.e2etest-preparation.outputs.version }}
           cd testing-framework/adot-testbed
+          gradle wrapper
           ./gradlew test --rerun-tasks --info
 
   clean-ssm-package:


### PR DESCRIPTION
**Description:** 

PR to fix the [error](https://github.com/aws-observability/aws-otel-collector/actions/runs/6522691900/job/17712660925#step:7:35) , `gradle wrapper` is used to get the gradle version build.



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
