### PR TITLE
Update EKS Cluster targets to 1.24 - 1.27

### DIFF
--- a/.github/config/testcases.json
+++ b/.github/config/testcases.json
@@ -63,9 +63,7 @@
 					"excluded_tests": [
 						"containerinsight_eks"
 					]
-				},
-				
-				
+				}
 			]
 		},
 		{

--- a/.github/config/testcases.json
+++ b/.github/config/testcases.json
@@ -4,20 +4,6 @@
 			"type": "EKS",
 			"targets": [
 				{
-					"name": "collector-ci-amd64-1-22",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsights_eks_containerd"
-					]
-				},
-				{
-					"name": "collector-ci-amd64-1-23",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsights_eks_containerd"
-					]
-				},
-				{
 					"name": "collector-ci-amd64-1-24",
 					"region": "us-west-2",
 					"excluded_tests": [
@@ -37,26 +23,19 @@
 					"excluded_tests": [
 						"containerinsight_eks"
 					]
+				},
+				{
+					"name": "collector-ci-amd64-1-27",
+					"region": "us-west-2",
+					"excluded_tests": [
+						"containerinsight_eks"
+					]
 				}
 			]
 		},
 		{
 			"type": "EKS_ARM64",
 			"targets": [
-				{
-					"name": "collector-ci-arm64-1-22",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsights_eks_containerd"
-					]
-				},
-				{
-					"name": "collector-ci-arm64-1-23",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsights_eks_containerd"
-					]
-				},
 				{
 					"name": "collector-ci-arm64-1-24",
 					"region": "us-west-2",
@@ -77,7 +56,16 @@
 					"excluded_tests": [
 						"containerinsight_eks"
 					]
-				}
+				},
+				{
+					"name": "collector-ci-arm64-1-27",
+					"region": "us-west-2",
+					"excluded_tests": [
+						"containerinsight_eks"
+					]
+				},
+				
+				
 			]
 		},
 		{
@@ -110,11 +98,19 @@
 			"type": "EKS_FARGATE",
 			"targets": [
 				{
-					"name": "collector-ci-fargate-1-22",
+					"name": "collector-ci-fargate-1-24",
 					"region": "us-west-2"
 				},
 				{
-					"name": "collector-ci-fargate-1-23",
+					"name": "collector-ci-fargate-1-25",
+					"region": "us-west-2"
+				},
+				{
+					"name": "collector-ci-fargate-1-26",
+					"region": "us-west-2"
+				},
+				{
+					"name": "collector-ci-fargate-1-27",
 					"region": "us-west-2"
 				}
 			]


### PR DESCRIPTION
**Description:** 

Update EKS Cluster targets to 1.24 - 1.27

**Link to tracking Issue:** https://github.com/aws-observability/aws-otel-collector/issues/2427




<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
