### PR TITLE
Remove 1.23 cluster targets

### DIFF
--- a/.github/config/testcases.json
+++ b/.github/config/testcases.json
@@ -4,13 +4,6 @@
 			"type": "EKS",
 			"targets": [
 				{
-					"name": "collector-ci-amd64-1-23",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsights_eks_containerd"
-					]
-				},
-				{
 					"name": "collector-ci-amd64-1-24",
 					"region": "us-west-2",
 					"excluded_tests": [
@@ -44,13 +37,6 @@
 			"type": "EKS_ARM64",
 			"targets": [
 				{
-					"name": "collector-ci-arm64-1-23",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsights_eks_containerd"
-					]
-				},
-				{
 					"name": "collector-ci-arm64-1-24",
 					"region": "us-west-2",
 					"excluded_tests": [
@@ -83,10 +69,6 @@
 		{
 			"type": "EKS_FARGATE",
 			"targets": [
-				{
-					"name": "collector-ci-fargate-1-23",
-					"region": "us-west-2"
-				},
 				{
 					"name": "collector-ci-fargate-1-24",
 					"region": "us-west-2"


### PR DESCRIPTION
**Description:** Remove 1.23 cluster targets 
Issue #2428 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
