### PR TITLE
[release/v0.35.x] Only run otlp_logs on ecs

### DIFF
--- a/.github/config/testcases.json
+++ b/.github/config/testcases.json
@@ -204,11 +204,7 @@
 		{
 			"case_name": "otlp_logs",
 			"platforms": [
-				"EC2",
-				"ECS",
-				"EKS",
-				"EKS_ARM64",
-				"CANARY"
+				"ECS"
 			]
 		},
 		{


### PR DESCRIPTION
**Description:** Remove platforms other than ecs


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
