### PR TITLE
Add the platforms back for otlp_logs testcase

### DIFF
--- a/.github/config/testcases.json
+++ b/.github/config/testcases.json
@@ -204,7 +204,11 @@
 		{
 			"case_name": "otlp_logs",
 			"platforms": [
-				"ECS"
+				"EC2",
+				"ECS",
+				"EKS",
+				"EKS_ARM64",
+				"CANARY"
 			]
 		},
 		{


### PR DESCRIPTION
**Description:** 
After Sample App fix, added the platforms back to the otlp_logs testcase

**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
