### PR TITLE
Add support for loki exporter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -202,6 +202,7 @@ require (
 	github.com/gophercloud/gophercloud v1.5.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/grafana/loki/pkg/push v0.0.0-20230127072203-4e8cc8d71928 // indirect
 	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.1 // indirect
 	github.com/hashicorp/consul/api v1.25.1 // indirect
@@ -262,6 +263,7 @@ require (
 	github.com/mrunalp/fileutils v0.5.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs v0.89.0 // indirect
@@ -287,6 +289,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.89.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/signalfx v0.89.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -490,6 +490,8 @@ github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/z
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/grafana/loki/pkg/push v0.0.0-20230127072203-4e8cc8d71928 h1:KCbGfs9SGr3lL3RWc+c+njCYyWUOa++Oas6McnwdQ2I=
+github.com/grafana/loki/pkg/push v0.0.0-20230127072203-4e8cc8d71928/go.mod h1:DhJMrd2QInI/1CNtTN43BZuTmkccdizW1jZ+F6aHkhY=
 github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd h1:PpuIBO5P3e9hpqBD0O/HjhShYuM6XE0i/lbE6J94kww=
 github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -764,6 +766,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancing
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.89.0/go.mod h1:qgny2qt3cij+lcPH6r+YJz7FqJUiKQKkzYIgOE5JUJs=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter v0.89.0 h1:FxU4MCINH0d+AAIVF5a7j1zE1Ol42Yg5rhXlim6SL4U=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter v0.89.0/go.mod h1:C0i2+Q2IyNyHiuZuac9FF/GeT+0F+yFw6+4fgtaDYE4=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v0.89.0 h1:/TMbPPItbmHgu7IXT+q87zP5Wrtu/vfONWwOFAuQe3E=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v0.89.0/go.mod h1:5+x6H9r6hEWKQfGUHamloAZHKBPYWj0WSDEqP35AQOw=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.89.0 h1:Y+GbWnFyQgnwdo8TD5MA49ilPezCAklXR1yOIRjWmKI=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.89.0/go.mod h1:WFck1rdCuRJ16wu5uqUfp9T0n5FNOlWuHaHrooyhMNk=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.89.0 h1:31Nbeod7i+wYzDb6n16tVqkeA37MoQUN9Wgh4MxAaX8=
@@ -838,6 +842,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.89.0 h1:
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.89.0/go.mod h1:7uCHpcHoawJsqoyPLxaFROWsZXPSF6/op3Hmw4pV4WE=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.89.0 h1:KLCkJzSvqMTEQXadbPBq/IGX4112QSE9b1RrnnyvQTA=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.89.0/go.mod h1:lZaeA7rW0m9Hz9W70LOEbjDr1SQr4FE7FeOObyleHHE=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.89.0 h1:LgdE857D7il5QSOVlIIXC/0AhrniNH9aXfm3prf4+7c=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.89.0/go.mod h1:BPLszD40ABbZMhhyhvxU/PC0wA0pxCVNOyNxNiDem0U=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.89.0 h1:YK17XegxPxT5sZJIx2iqAen8G7LIIOlHjGrwr7Uka7E=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.89.0/go.mod h1:HXv8nyJ+RUHGLZMPbaPFnWKonYWNTJfZ9ZUudqtwudw=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.89.0 h1:Lu16kQylQWaI217RMA3E3mPos2RUEN7oybg+7YzCbzM=

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -25,6 +25,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter"
@@ -148,6 +149,7 @@ func Components() (otelcol.Factories, error) {
 		datadogexporter.NewFactory(),
 		logzioexporter.NewFactory(),
 		loggingexporter.NewFactory(),
+		lokiexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),
 		awsxrayexporter.NewFactory(),

--- a/pkg/defaultcomponents/defaults_test.go
+++ b/pkg/defaultcomponents/defaults_test.go
@@ -49,6 +49,7 @@ func TestComponents(t *testing.T) {
 	assert.NotNil(t, exporters["sapm"])
 	assert.NotNil(t, exporters["signalfx"])
 	assert.NotNil(t, exporters["logzio"])
+	assert.NotNil(t, exporters["loki"])
 	assert.NotNil(t, exporters["prometheusremotewrite"])
 	assert.NotNil(t, exporters["kafka"])
 	assert.NotNil(t, exporters["loadbalancing"])

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -139,6 +139,7 @@ require (
 	github.com/gophercloud/gophercloud v1.5.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/grafana/loki/pkg/push v0.0.0-20230127072203-4e8cc8d71928 // indirect
 	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.1 // indirect
 	github.com/hashicorp/consul/api v1.25.1 // indirect
@@ -209,6 +210,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter v0.89.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.89.0 // indirect
@@ -248,6 +250,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.89.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.89.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.89.0 // indirect

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -494,6 +494,8 @@ github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/z
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/grafana/loki/pkg/push v0.0.0-20230127072203-4e8cc8d71928 h1:KCbGfs9SGr3lL3RWc+c+njCYyWUOa++Oas6McnwdQ2I=
+github.com/grafana/loki/pkg/push v0.0.0-20230127072203-4e8cc8d71928/go.mod h1:DhJMrd2QInI/1CNtTN43BZuTmkccdizW1jZ+F6aHkhY=
 github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd h1:PpuIBO5P3e9hpqBD0O/HjhShYuM6XE0i/lbE6J94kww=
 github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -768,6 +770,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancing
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.89.0/go.mod h1:qgny2qt3cij+lcPH6r+YJz7FqJUiKQKkzYIgOE5JUJs=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter v0.89.0 h1:FxU4MCINH0d+AAIVF5a7j1zE1Ol42Yg5rhXlim6SL4U=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter v0.89.0/go.mod h1:C0i2+Q2IyNyHiuZuac9FF/GeT+0F+yFw6+4fgtaDYE4=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v0.89.0 h1:/TMbPPItbmHgu7IXT+q87zP5Wrtu/vfONWwOFAuQe3E=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v0.89.0/go.mod h1:5+x6H9r6hEWKQfGUHamloAZHKBPYWj0WSDEqP35AQOw=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter v0.89.0 h1:kdkpG9i//zro7++cOsej9c8a8UY3BrFOAbXycOFJGzs=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter v0.89.0/go.mod h1:W8Rr325PuIE0PWxpv38oHTWt9tqY4HXeVV63qcq1HTY=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.89.0 h1:Y+GbWnFyQgnwdo8TD5MA49ilPezCAklXR1yOIRjWmKI=
@@ -850,6 +854,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.89.0 h1:
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.89.0/go.mod h1:7uCHpcHoawJsqoyPLxaFROWsZXPSF6/op3Hmw4pV4WE=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.89.0 h1:KLCkJzSvqMTEQXadbPBq/IGX4112QSE9b1RrnnyvQTA=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.89.0/go.mod h1:lZaeA7rW0m9Hz9W70LOEbjDr1SQr4FE7FeOObyleHHE=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.89.0 h1:LgdE857D7il5QSOVlIIXC/0AhrniNH9aXfm3prf4+7c=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.89.0/go.mod h1:BPLszD40ABbZMhhyhvxU/PC0wA0pxCVNOyNxNiDem0U=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.89.0 h1:ZY3gmVjRuB1z8f2WHFKlFbe9bxRZKq+LctMLP5ZRtT8=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.89.0/go.mod h1:IJm8iyL2FTuxbivR0WOlKPVAEQPSlhU3AbAHXmcPoKo=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.89.0 h1:YK17XegxPxT5sZJIx2iqAen8G7LIIOlHjGrwr7Uka7E=


### PR DESCRIPTION
**Description:** Add support for loki exporter for logs

AWS recently announced support for logs in ADOT: https://aws.amazon.com/about-aws/whats-new/2023/11/logs-support-aws-distro-opentelemetry/

This PR allows exporting logs via OTLP protocol to Grafana Loki.

**Link to tracking Issue:** https://github.com/aws-observability/aws-otel-collector/issues/1776

**Testing:** `make docker-build` passes, tested docker image with loki exporter enabled, logs delivered 

**Documentation:** None so far

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
