### PR TITLE
Remove Deprecated dynatrace exporter

### DIFF
--- a/.github/config/testcases.json
+++ b/.github/config/testcases.json
@@ -379,17 +379,6 @@
 			]
 		},
 		{
-			"case_name": "dynatrace_exporter_metric_mock",
-			"platforms": [
-				"EC2",
-				"ECS",
-				"EKS",
-				"EKS_ARM64",
-				"LOCAL",
-				"PERF"
-			]
-		},
-		{
 			"case_name": "datadog_exporter_metric_mock",
 			"platforms": [
 				"EC2",

--- a/e2etest/testcases.json
+++ b/e2etest/testcases.json
@@ -88,10 +88,6 @@
 		"platforms": ["EC2", "ECS", "EKS", "EKS_ARM64", "LOCAL", "PERF"]
 	},
 	{
-		"case_name": "dynatrace_exporter_metric_mock",
-		"platforms": ["EC2", "ECS", "EKS", "EKS_ARM64", "LOCAL", "PERF"]
-	},
-	{
 		"case_name": "datadog_exporter_metric_mock",
 		"platforms": ["EC2", "ECS", "EKS", "EKS_ARM64", "LOCAL", "PERF"]
 	},

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.91.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.91.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.91.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter v0.91.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.91.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.91.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.91.0
@@ -152,7 +151,6 @@ require (
 	github.com/docker/go-connections v0.4.1-0.20210727194412-58542c764a11 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/dynatrace-oss/dynatrace-metric-utils-go v0.5.0 // indirect
 	github.com/eapache/go-resiliency v1.4.0 // indirect
 	github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 // indirect
 	github.com/eapache/queue v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -264,8 +264,6 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/dynatrace-oss/dynatrace-metric-utils-go v0.5.0 h1:wHGPJSXvwKQVf/XfhjUPyrhpcPKWNy8F3ikH+eiwoBg=
-github.com/dynatrace-oss/dynatrace-metric-utils-go v0.5.0/go.mod h1:PseHFo8Leko7J4A/TfZ6kkHdkzKBLUta6hRZR/OEbbc=
 github.com/eapache/go-resiliency v1.4.0 h1:3OK9bWpPk5q6pbFAaYSEwD9CLUSHG8bnZuqX2yMt3B0=
 github.com/eapache/go-resiliency v1.4.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=
 github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 h1:Oy0F4ALJ04o5Qqpdz8XLIpNA3WM/iSIXqxtqo7UGVws=
@@ -741,8 +739,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexport
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.91.0/go.mod h1:7LFN/WcxZXYitGcBWXPr5CssIeAmsQrELnbyvQJur/g=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.91.0 h1:SPRKiLoYdV0IIyJhofGdPm+QJ3JEVjAp8h7tdvlRoe4=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.91.0/go.mod h1:PHCePSoXQsHntygLOKieFf5TqPRsrDSK5sd9XdmdG3M=
-github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter v0.91.0 h1:9r68up6NyKMEE4j/BQzSa3Z4EXmaSwaLdluA6w7E2/c=
-github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter v0.91.0/go.mod h1:kWwPBXGJOr5/YwOmWa7L5dqnqx1rUISUxiNL8nXDFyY=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.91.0 h1:p8gP126reF8nK4HvgpQ+6R3+CVxnYohjInD67uKqfDw=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.91.0/go.mod h1:j26btuTJfz02X+urX9Qk73I13BdfuJoyjLm+edN1G94=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.91.0 h1:iU2St2YduQzbuXu68gjFB0CpPoQmo7kvl97IThw4aRE=

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -20,7 +20,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
@@ -142,7 +141,6 @@ func Components() (otelcol.Factories, error) {
 		prometheusexporter.NewFactory(),
 		fileexporter.NewFactory(),
 		kafkaexporter.NewFactory(),
-		dynatraceexporter.NewFactory(),
 		sapmexporter.NewFactory(),
 		signalfxexporter.NewFactory(),
 		datadogexporter.NewFactory(),

--- a/pkg/defaultcomponents/defaults_test.go
+++ b/pkg/defaultcomponents/defaults_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	exportersCount  = 16
+	exportersCount  = 15
 	receiversCount  = 10
 	extensionsCount = 8
 	processorCount  = 15
@@ -44,7 +44,6 @@ func TestComponents(t *testing.T) {
 	// other exporters
 	assert.NotNil(t, exporters["file"])
 	assert.NotNil(t, exporters["datadog"])
-	assert.NotNil(t, exporters["dynatrace"])
 	assert.NotNil(t, exporters["prometheus"])
 	assert.NotNil(t, exporters["sapm"])
 	assert.NotNil(t, exporters["signalfx"])

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -87,7 +87,6 @@ require (
 	github.com/docker/go-connections v0.4.1-0.20210727194412-58542c764a11 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/dynatrace-oss/dynatrace-metric-utils-go v0.5.0 // indirect
 	github.com/eapache/go-resiliency v1.4.0 // indirect
 	github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
@@ -197,7 +196,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.91.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter v0.91.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.91.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter v0.91.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.91.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.91.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter v0.91.0 // indirect

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -267,8 +267,6 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/dynatrace-oss/dynatrace-metric-utils-go v0.5.0 h1:wHGPJSXvwKQVf/XfhjUPyrhpcPKWNy8F3ikH+eiwoBg=
-github.com/dynatrace-oss/dynatrace-metric-utils-go v0.5.0/go.mod h1:PseHFo8Leko7J4A/TfZ6kkHdkzKBLUta6hRZR/OEbbc=
 github.com/eapache/go-resiliency v1.4.0 h1:3OK9bWpPk5q6pbFAaYSEwD9CLUSHG8bnZuqX2yMt3B0=
 github.com/eapache/go-resiliency v1.4.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=
 github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 h1:Oy0F4ALJ04o5Qqpdz8XLIpNA3WM/iSIXqxtqo7UGVws=
@@ -747,8 +745,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporte
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter v0.91.0/go.mod h1:aETj/Uzwkf3RBNiniHl7QygjHfBaW/xjubXCHn/MgT8=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.91.0 h1:SPRKiLoYdV0IIyJhofGdPm+QJ3JEVjAp8h7tdvlRoe4=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.91.0/go.mod h1:PHCePSoXQsHntygLOKieFf5TqPRsrDSK5sd9XdmdG3M=
-github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter v0.91.0 h1:9r68up6NyKMEE4j/BQzSa3Z4EXmaSwaLdluA6w7E2/c=
-github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter v0.91.0/go.mod h1:kWwPBXGJOr5/YwOmWa7L5dqnqx1rUISUxiNL8nXDFyY=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.91.0 h1:p8gP126reF8nK4HvgpQ+6R3+CVxnYohjInD67uKqfDw=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.91.0/go.mod h1:j26btuTJfz02X+urX9Qk73I13BdfuJoyjLm+edN1G94=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.91.0 h1:iU2St2YduQzbuXu68gjFB0CpPoQmo7kvl97IThw4aRE=


### PR DESCRIPTION
**Description:** 

Remove Deprecated dynatrace exporter

Notice - https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/dynatraceexporter#dynatrace-metrics-exporter


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
