### PR TITLE
Add Lambda Layer Version cleaner

### DIFF
--- a/tools/workflow/cleaner/lambda/clean.go
+++ b/tools/workflow/cleaner/lambda/clean.go
@@ -122,10 +122,14 @@ func cleanLayers(sess *session.Session, expirationDate time.Time) error {
 	} else {
 		for _, id := range deleteLayerVersionsIDs {
 			fmt.Println("Trying to delete the layer in the list that is acquired", *id.Key)
-			//deleteLayerVersionInput := &lambda.DeleteLayerVersionInput{LayerName: id.Key, VersionNumber: id.Value}
-			//if _, err := lambdaClient.DeleteLayerVersion(deleteLayerVersionInput); err != nil {
-			//	return fmt.Errorf("unable to delete layer version: %w", err)
-			//}
+			for *id.Value > 0 {
+				deleteLayerVersionInput := &lambda.DeleteLayerVersionInput{LayerName: id.Key, VersionNumber: id.Value}
+				if _, err := lambdaClient.DeleteLayerVersion(deleteLayerVersionInput); err != nil {
+					return fmt.Errorf("unable to delete layer version: %w", err)
+				}
+				*id.Value--
+			}
+
 		}
 		logger.Printf("Deleted %d Lambda layer versions", len(deleteLayerVersionsIDs))
 	}

--- a/tools/workflow/cleaner/lambda/clean.go
+++ b/tools/workflow/cleaner/lambda/clean.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
 )
@@ -17,46 +18,114 @@ var logger = log.New(os.Stdout, fmt.Sprintf("[%s] ", Type), log.LstdFlags)
 
 func Clean(sess *session.Session, expirationDate time.Time) error {
 	logger.Printf("Begin to clean Lambda functions")
+	if err := cleanFunctions(sess, expirationDate); err != nil {
+		return err
+	}
 
-	lambdaclient := lambda.New(sess)
+	logger.Printf("Begin to clean Lambda layers")
+	if err := cleanLayers(sess, expirationDate); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func cleanFunctions(sess *session.Session, expirationDate time.Time) error {
+	lambdaClient := lambda.New(sess)
 	var deleteFunctionIDs []*string
 	var nextToken *string
+
 	for {
-		ListFunctionsInput := &lambda.ListFunctionsInput{Marker: nextToken}
-		ListFunctionsOutput, err := lambdaclient.ListFunctions(ListFunctionsInput)
+		listFunctionsInput := &lambda.ListFunctionsInput{Marker: nextToken}
+		listFunctionsOutput, err := lambdaClient.ListFunctions(listFunctionsInput)
 		if err != nil {
-			return fmt.Errorf("unable to retrieve APIs: %w", err)
+			return fmt.Errorf("unable to retrieve functions: %w", err)
 		}
-		for _, lf := range ListFunctionsOutput.Functions {
+
+		for _, lf := range listFunctionsOutput.Functions {
 			doesNameMatch, err := shouldDelete(lf)
 			if err != nil {
 				return fmt.Errorf("error during pattern match: %w", err)
 			}
 			created, err := time.Parse("2006-01-02T15:04:05Z0700", *lf.LastModified)
 			if err != nil {
-				return fmt.Errorf("error parting last modified time: %w", err)
+				return fmt.Errorf("error parsing last modified time: %w", err)
 			}
 			if expirationDate.After(created) && doesNameMatch {
 				logger.Printf("Try to delete function %s created-at %s", *lf.FunctionArn, *lf.LastModified)
 				deleteFunctionIDs = append(deleteFunctionIDs, lf.FunctionArn)
 			}
 		}
-		if ListFunctionsOutput.NextMarker == nil {
+		if listFunctionsOutput.NextMarker == nil {
 			break
 		}
-		nextToken = ListFunctionsOutput.NextMarker
+		nextToken = listFunctionsOutput.NextMarker
 	}
 	if len(deleteFunctionIDs) < 1 {
 		logger.Printf("No Lambda functions to delete")
-		return nil
+	} else {
+		for _, id := range deleteFunctionIDs {
+			terminateFunctionInput := &lambda.DeleteFunctionInput{FunctionName: id}
+			if _, err := lambdaClient.DeleteFunction(terminateFunctionInput); err != nil {
+				return fmt.Errorf("unable to delete function: %w", err)
+			}
+		}
+		logger.Printf("Deleted %d Lambda functions", len(deleteFunctionIDs))
 	}
 
-	for _, id := range deleteFunctionIDs {
-		terminateFunctionInput := &lambda.DeleteFunctionInput{FunctionName: id}
-		if _, err := lambdaclient.DeleteFunction(terminateFunctionInput); err != nil {
-			return fmt.Errorf("unable to delete function: %w", err)
+	return nil
+}
+
+func cleanLayers(sess *session.Session, expirationDate time.Time) error {
+	lambdaClient := lambda.New(sess)
+	var deleteLayerVersionsIDs []*string
+	var nextToken *string
+
+	for {
+		listLayerVersionsInput := &lambda.ListLayerVersionsInput{
+			LayerName: aws.String("Java_wrapper"),
+			Marker:    nextToken,
 		}
+		listLayerVersionsOutput, err := lambdaClient.ListLayerVersions(listLayerVersionsInput)
+		if err != nil {
+			return fmt.Errorf("unable to retrieve layer versions: %w", err)
+		}
+
+		for _, layer := range listLayerVersionsOutput.LayerVersions {
+			/*			doesNameMatch, err := shouldDeleteLayer(layer)
+						if err != nil {
+							return fmt.Errorf("error during layer pattern match: %w", err)
+						}*/
+
+			created, err := time.Parse("2006-01-02T15:04:05Z0700", *layer.CreatedDate)
+			if err != nil {
+				return fmt.Errorf("error parsing layer created time: %w", err)
+			}
+
+			if expirationDate.After(created) {
+				logger.Printf("Try to delete layer version %s created-at %s", *layer.LayerVersionArn, *layer.CreatedDate)
+				deleteLayerVersionsIDs = append(deleteLayerVersionsIDs, layer.LayerVersionArn)
+			}
+		}
+
+		if listLayerVersionsOutput.NextMarker == nil {
+			break
+		}
+		nextToken = listLayerVersionsOutput.NextMarker
 	}
+
+	if len(deleteLayerVersionsIDs) < 1 {
+		logger.Printf("No Lambda layers to delete")
+	} else {
+		for _, id := range deleteLayerVersionsIDs {
+			deleteLayerVersionInput := &lambda.DeleteLayerVersionInput{LayerName: id}
+			if _, err := lambdaClient.DeleteLayerVersion(deleteLayerVersionInput); err != nil {
+				return fmt.Errorf("unable to delete layer version: %w", err)
+			}
+		}
+		logger.Printf("Deleted %d Lambda layer versions", len(deleteLayerVersionsIDs))
+	}
+
 	return nil
 }
 
@@ -72,6 +141,26 @@ func shouldDelete(lf *lambda.FunctionConfiguration) (bool, error) {
 		matches, err := regexp.MatchString(rx, *lfName)
 		if err != nil {
 			return false, fmt.Errorf("error during regex match: %w", err)
+		}
+		if matches {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func shouldDeleteLayer(layerList *lambda.LayersListItem) (bool, error) {
+	layerName := layerList.LayerArn
+	regexList := []string{
+		"\\Alambda-[a-z]+-aws-sdk-.*$",
+		"\\Ahello-lambda-[a-z]+-okhttp-.*",
+		"\\Alambda-[a-z]+-okhttp-wrapper-.*$",
+	}
+
+	for _, rx := range regexList {
+		matches, err := regexp.MatchString(rx, *layerName)
+		if err != nil {
+			return false, fmt.Errorf("error during layer regex match: %w", err)
 		}
 		if matches {
 			return true, nil


### PR DESCRIPTION
**Description:**

Add cleaner to delete lambda layers



**Testing:** <Describe what testing was performed and which tests were added.>

This contains extra print statements that i have used for testing purposes.

```
It has matched the regexlist arn:aws:lambda:us-east-1:629274716306:layer:custom-config-layer
[lambda] 2024/02/02 15:32:48 Try to delete layer version arn:aws:lambda:us-east-1:629274716306:layer:custom-config-layer created-at 2023-12-04 18:40:10.624 +0000 +0000
arn:aws:lambda:us-east-1:629274716306:layer:opentelemetry-python-39
true
It has matched the regexlist arn:aws:lambda:us-east-1:629274716306:layer:opentelemetry-python-39
[lambda] 2024/02/02 15:32:48 Try to delete layer version arn:aws:lambda:us-east-1:629274716306:layer:opentelemetry-python-39 created-at 2022-02-16 17:46:01.346 +0000 +0000
arn:aws:lambda:us-east-1:629274716306:layer:sdk-layer
true
It has matched the regexlist arn:aws:lambda:us-east-1:629274716306:layer:sdk-layer
[lambda] 2024/02/02 15:32:48 Try to delete layer version arn:aws:lambda:us-east-1:629274716306:layer:sdk-layer created-at 2023-12-04 18:40:05.361 +0000 +0000
[lambda] 2024/02/02 15:33:13 Deleted 29 Lambda layer versions
2024/02/02 15:33:13 Finished cleaning AWS resources

```


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
