### PR TITLE
added spanmetrics connector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.93.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.93.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.93.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.93.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.93.0
@@ -50,6 +51,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/collector/component v0.93.0
 	go.opentelemetry.io/collector/confmap v0.93.0
+	go.opentelemetry.io/collector/connector v0.93.0
 	go.opentelemetry.io/collector/exporter v0.93.0
 	go.opentelemetry.io/collector/exporter/loggingexporter v0.93.0
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.93.0
@@ -325,6 +327,7 @@ require (
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tidwall/tinylru v1.1.0 // indirect
 	github.com/tidwall/wal v1.1.7 // indirect
+	github.com/tilinna/clock v1.1.0 // indirect
 	github.com/tinylib/msgp v1.1.9 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
@@ -349,7 +352,6 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.93.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.93.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.93.0 // indirect
-	go.opentelemetry.io/collector/connector v0.93.0 // indirect
 	go.opentelemetry.io/collector/consumer v0.93.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.93.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -727,6 +727,8 @@ github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
 github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.93.0 h1:oUZwT2VurXvflS7tP1pNQnBd54+xWDU9mCy7+SMVUPk=
 github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.93.0/go.mod h1:hoYsAqrCYWq6ClRzJW/RxJyqgH5UWj/NSojK6iyqQ9o=
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector v0.93.0 h1:iqrUmWMe4oVEBR99RnbbIASjOOlChqYyPFYvon5w+/k=
+github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.93.0 h1:NwUuRd6+iZwEPZQXEZzQ4CX9TfZnV9tT89Wp6HBclyQ=
+github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.93.0/go.mod h1:hIINFdrXGiZyykfuqisb+co0UaWbMDmUr5wU+t5+eVw=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.93.0 h1:rB2r33pURwmFgtnK1AmonpQ11Ih2UqE7sjRGMuPvm2Q=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.93.0/go.mod h1:W17nWjFCbWcb2YPXocPPown2856v2D9OnQd5V3j/U2I=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.93.0 h1:Q0RGGM8urjMLki0stX6R5VQ53kO89mHr5mvv6Cf5hkg=
@@ -1052,6 +1054,8 @@ github.com/tidwall/tinylru v1.1.0 h1:XY6IUfzVTU9rpwdhKUF6nQdChgCdGjkMfLzbWyiau6I
 github.com/tidwall/tinylru v1.1.0/go.mod h1:3+bX+TJ2baOLMWTnlyNWHh4QMnFyARg2TLTQ6OFbzw8=
 github.com/tidwall/wal v1.1.7 h1:emc1TRjIVsdKKSnpwGBAcsAGg0767SvUk8+ygx7Bb+4=
 github.com/tidwall/wal v1.1.7/go.mod h1:r6lR1j27W9EPalgHiB7zLJDYu3mzW5BQP5KrzBpYY/E=
+github.com/tilinna/clock v1.1.0 h1:6IQQQCo6KoBxVudv6gwtY8o4eDfhHo8ojA5dP0MfhSs=
+github.com/tilinna/clock v1.1.0/go.mod h1:ZsP7BcY7sEEz7ktc0IVy8Us6boDrK8VradlKRUGfOao=
 github.com/tinylib/msgp v1.1.9 h1:SHf3yoO2sGA0veCJeCBYLHuttAVFHGm2RHgNodW7wQU=
 github.com/tinylib/msgp v1.1.9/go.mod h1:BCXGB54lDD8qUEPmiG0cQQUANC4IUQyB2ItS2UDlO/k=
 github.com/tklauser/go-sysconf v0.3.11/go.mod h1:GqXfhXY3kiPa0nAXPDIQIWzJbMCB7AmcWpGR8lSZfqI=

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -16,6 +16,7 @@
 package defaultcomponents // import "aws-observability.io/collector/defaultcomponents
 
 import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter"
@@ -56,6 +57,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver"
+	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/loggingexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
@@ -87,6 +89,16 @@ func Components() (otelcol.Factories, error) {
 	}
 
 	extensions, err := extension.MakeFactoryMap(extensionsList...)
+
+	if err != nil {
+		errs = multierr.Append(errs, err)
+	}
+
+	connectorsList := []connector.Factory{
+		spanmetricsconnector.NewFactory(),
+	}
+
+	connectors, err := connector.MakeFactoryMap(connectorsList...)
 
 	if err != nil {
 		errs = multierr.Append(errs, err)
@@ -164,6 +176,7 @@ func Components() (otelcol.Factories, error) {
 		Receivers:  receivers,
 		Processors: processors,
 		Exporters:  exporters,
+		Connectors: connectors,
 	}
 
 	return factories, errs


### PR DESCRIPTION
**Description:** Added ability to use spanmetrics connector to be able to cast traces to metrics. We do not use storage for traces collection and want to be able to use Prometheus for both metrics and traces

**Link to tracking Issue:** #1166


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
