### PR TITLE
Ignore OTEL Collector updates from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,9 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
+    ignore:
+      - dependency-name: "github.com/open-telemetry/opentelemetry-collector-contrib*"
+      - dependency-name: "go.opentelemetry.io/collector*"
   - package-ecosystem: gomod
     directory: /testbed
     labels:
@@ -37,6 +40,9 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
+    ignore:
+      - dependency-name: "github.com/open-telemetry/opentelemetry-collector-contrib*"
+      - dependency-name: "go.opentelemetry.io/collector*"
   - package-ecosystem: gomod
     directory: /tools/release/image-mirror
     labels:
@@ -46,6 +52,9 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
+    ignore:
+      - dependency-name: "github.com/open-telemetry/opentelemetry-collector-contrib*"
+      - dependency-name: "go.opentelemetry.io/collector*"
   - package-ecosystem: gomod
     directory: /tools/workflow/cleaner
     labels:
@@ -55,6 +64,9 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
+    ignore:
+      - dependency-name: "github.com/open-telemetry/opentelemetry-collector-contrib*"
+      - dependency-name: "go.opentelemetry.io/collector*"
   - package-ecosystem: gomod
     directory: /tools/workflow/linters
     labels:
@@ -64,3 +76,6 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
+    ignore:
+      - dependency-name: "github.com/open-telemetry/opentelemetry-collector-contrib*"
+      - dependency-name: "go.opentelemetry.io/collector*"


### PR DESCRIPTION
**Description:** These have never really worked in the first place and they create a lot of noise. The dependabot update script works well for all other dependencies. The OTEL Collector updates can be completed easier with a search and replace. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
