### PR TITLE
[Release/v0.39.x] - Add third Party components behind featuregateBeta

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use the community resources below for getting help with the ADOT Collector.
 * For contributing guidelines, refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Notice: ADOT Collector v0.41.0 Breaking Changes
-* users of the `datadog`, `logzio`, `sapm`, `signalfx`, `splunkh_rec` exporter components. please refer to [Attention: ADOT Collector v0.41.0 breaking changes - third party exporters deprecation](https://github.com/aws-observability/aws-otel-collector/issues/2367) 
+* Users of the `datadog`, `logzio`, `sapm`, `signalfx`, `splunkh_rec` exporter components. please refer to [Attention: ADOT Collector v0.41.0 breaking changes - third party exporters deprecation](https://github.com/aws-observability/aws-otel-collector/issues/2734) 
   for more information on an upcoming breaking change .
 
 #### ADOT Collector Built-in Components

--- a/README.md
+++ b/README.md
@@ -18,14 +18,9 @@ Use the community resources below for getting help with the ADOT Collector.
 * If you think you may have found a bug, open a [bug report](https://github.com/aws-observability/aws-otel-collector/issues/new?template=bug_report.md).
 * For contributing guidelines, refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 
-### Notice: ADOT Collector v0.35.0 Breaking Change
-Users of the `statsd` receiver, please refer to GitHub Issue - [Warning: StatsD Receiver → EMF Exporter Metric Pipeline Breaking Change](https://github.com/aws-observability/aws-otel-collector/issues/2249)
-for information on a breaking change.
-
-### Notices: ADOT Collector v0.35.0 Breaking Changes
-* Users of the 'awscontainerinsightreceiver', please refer to the GitHub Issue - [Warning: Container Image Default User Change → Important consideration for AWSContainerInsightReceiver](https://github.com/aws-observability/aws-otel-collector/issues/2317) for more information on an upcoming breaking change.
-* Users of the `prometheus` or `prometheusremotewrite` exporters please refer to the GitHub Issue [Warning: ADOT Collector v0.35.0 breaking change](https://github.com/aws-observability/aws-otel-collector/issues/2367)
-for information on an upcoming breaking change.
+### Notice: ADOT Collector v0.41.0 Breaking Changes
+* users of the `datadog`, `logzio`, `sapm`, `signalfx`, `splunkh_rec` exporter components. please refer to [Attention: ADOT Collector v0.41.0 breaking changes - third party exporters deprecation](https://github.com/aws-observability/aws-otel-collector/issues/2367) 
+  for more information on an upcoming breaking change .
 
 #### ADOT Collector Built-in Components
 

--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -54,7 +54,7 @@ func main() {
 
 	// TODO : Remove after v0.41.0 release
 	log.Printf("attn: users of the `datadog`, `logzio`, `sapm`, `signalfx`, `splunkh_rec` exporter components. please refer to " +
-		"https://github.com/aws-observability/aws-otel-collector/issues/2367 in regards to an ADOT Collector v0.41.0 " +
+		"https://github.com/aws-observability/aws-otel-collector/issues/2734 in regards to an ADOT Collector v0.41.0 " +
 		"breaking change")
 
 	logger.SetupErrorLogger()

--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -52,8 +52,9 @@ func main() {
 		log.Printf("found no extra config, skip it, err: %v", err)
 	}
 
-	log.Printf("attn: users of the prometheus or prometheusremotewrite exporter please refer to " +
-		"https://github.com/aws-observability/aws-otel-collector/issues/2367 in regards to an ADOT Collector v0.35.0 " +
+	// TODO : Remove after v0.41.0 release
+	log.Printf("attn: users of the `datadog`, `logzio`, `sapm`, `signalfx`, `splunkh_rec` exporter components. please refer to " +
+		"https://github.com/aws-observability/aws-otel-collector/issues/2367 in regards to an ADOT Collector v0.41.0 " +
 		"breaking change")
 
 	logger.SetupErrorLogger()
@@ -75,10 +76,10 @@ func main() {
 	}
 
 	params := otelcol.CollectorSettings{
-		Factories:      defaultcomponents.Components,
-		BuildInfo:      info,
-		LoggingOptions: []zap.Option{logger.WrapCoreOpt()},
-		ConfigProvider: config.GetConfigProvider(flagSet),
+		Factories:              defaultcomponents.Components,
+		BuildInfo:              info,
+		LoggingOptions:         []zap.Option{logger.WrapCoreOpt()},
+		ConfigProviderSettings: config.GetConfigProvider(flagSet),
 	}
 
 	if err = run(params, flagSet); err != nil {

--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -79,7 +79,7 @@ func main() {
 		Factories:              defaultcomponents.Components,
 		BuildInfo:              info,
 		LoggingOptions:         []zap.Option{logger.WrapCoreOpt()},
-		ConfigProviderSettings: config.GetConfigProvider(flagSet),
+		ConfigProviderSettings: config.GetConfigProviderSettings(flagSet),
 	}
 
 	if err = run(params, flagSet); err != nil {

--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -52,6 +52,10 @@ func main() {
 		log.Printf("found no extra config, skip it, err: %v", err)
 	}
 
+	log.Printf("attn: users of the prometheus or prometheusremotewrite exporter please refer to " +
+		"https://github.com/aws-observability/aws-otel-collector/issues/2367 in regards to an ADOT Collector v0.35.0 " +
+		"breaking change")
+
 	logger.SetupErrorLogger()
 
 	// set the collector config from extracfg file

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.98.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.98.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.98.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.98.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy v0.98.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.98.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver v0.98.0

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
+dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
+dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.10.0 h1:n1DH8TPV4qqPTje2RcUBYwtrTWlabVp4n46+74X2pn4=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.10.0/go.mod h1:HDcZnuGbiyppErN6lB+idp4CKhjbc8gwjto6OPpyggM=
@@ -118,6 +120,8 @@ github.com/IBM/sarama v1.43.1/go.mod h1:GG5q1RURtDNPz8xxJs3mgX6Ytak8Z9eLhAkJPObe
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
+github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=
+github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
@@ -239,6 +243,8 @@ github.com/containerd/cgroups/v3 v3.0.3 h1:S5ByHZ/h9PMe5IOQoN7E+nMc2UcLEM/V48DGD
 github.com/containerd/cgroups/v3 v3.0.3/go.mod h1:8HBe7V3aWGLFPd/k03swSIsGjZhHI2WzJmticMgVuz0=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
+github.com/containerd/containerd v1.7.12 h1:+KQsnv4VnzyxWcfO9mlxxELaoztsDEjOuCMPAuPqgU0=
+github.com/containerd/containerd v1.7.12/go.mod h1:/5OMpE1p0ylxtEUGY8kuCYkDRzJm9NO1TFMWjUpdevk=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/ttrpc v1.2.2 h1:9vqZr0pxwOF5koz6N0N3kJ0zDHokrcPxIR/ZR2YFtOs=
@@ -249,6 +255,8 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
+github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
@@ -719,9 +727,15 @@ github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c/go.mod h1
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
+github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
 github.com/moby/sys/mountinfo v0.6.2/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
+github.com/moby/sys/sequential v0.5.0 h1:OPvI35Lzn9K04PBbCLW0g4LcFAJgHsvXsRyewg5lXtc=
+github.com/moby/sys/sequential v0.5.0/go.mod h1:tH2cOOs5V9MlPiXcQzRC+eEyab644PWKGRYaaV5ZZlo=
+github.com/moby/sys/user v0.1.0 h1:WmZ93f5Ux6het5iituh9x2zAG7NFY9Aqi49jjE1PaQg=
+github.com/moby/sys/user v0.1.0/go.mod h1:fKJhFOnsCN6xZ5gSfbM6zaHGgDJMrqt9/reuj4T7MmU=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -787,6 +801,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter 
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.98.0/go.mod h1:OVLmVtFMIEQjHMm1ygJ6dpGYhNxS6AEwhyc39Y0YPTU=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.98.0 h1:I1CrHkeifkWhGVZe7LMzM/sICHC193lbxd8J13ouXos=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.98.0/go.mod h1:rGIasss6gF8lmWZAmWhsKGcQeECTt7OomMeIopFzkO4=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.98.0 h1:+4AYRExNjrpfq1djZ/OkPcsNRiD2hyDnuWSSzNsF3yo=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.98.0/go.mod h1:LdFeUQT49BadOyeNa1akdDs3biaAxhqWdea0g4QuCyE=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy v0.98.0 h1:Ad9kF7wfdZWJacgtzguVEFvBcc8vthMzIlnMIqhOvKo=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy v0.98.0/go.mod h1:6bivBlhIFVflEYm4mMotqDJ54Z158LAActxNNd4KBGs=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.98.0 h1:GNDpMm6OqCTe7r1PFyDhm4CXQTqYPrnA3FEPt6ZkKzY=
@@ -1093,6 +1109,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/testcontainers/testcontainers-go v0.29.1 h1:z8kxdFlovA2y97RWx98v/TQ+tR+SXZm6p35M+xB92zk=
+github.com/testcontainers/testcontainers-go v0.29.1/go.mod h1:SnKnKQav8UcgtKqjp/AD8bE1MqZm+3TDb/B8crE3XnI=
 github.com/tidwall/gjson v1.10.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.12.1 h1:ikuZsLdhr8Ws0IdROXUS1Gi4v9Z4pGqpX/CvJkxvfpo=
 github.com/tidwall/gjson v1.12.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/pkg/config/config_factory.go
+++ b/pkg/config/config_factory.go
@@ -35,7 +35,7 @@ const (
 	envKey = "AOT_CONFIG_CONTENT"
 )
 
-func GetConfigProvider(flags *flag.FlagSet) otelcol.ConfigProvider {
+func GetConfigProviderSettings(flags *flag.FlagSet) otelcol.ConfigProviderSettings {
 	// aws-otel-collector supports loading yaml config from Env Var
 	// including SSM parameter store for ECS use case
 	loc := getConfigFlag(flags)
@@ -59,7 +59,7 @@ func GetConfigProvider(flags *flag.FlagSet) otelcol.ConfigProvider {
 	}
 
 	// create Config Provider Settings
-	settings := otelcol.ConfigProviderSettings{
+	configProviderSettings := otelcol.ConfigProviderSettings{
 		ResolverSettings: confmap.ResolverSettings{
 			URIs:       loc,
 			Providers:  mapProviders,
@@ -68,11 +68,11 @@ func GetConfigProvider(flags *flag.FlagSet) otelcol.ConfigProvider {
 	}
 
 	// get New config Provider
-	config_provider, err := otelcol.NewConfigProvider(settings)
+	_, err := otelcol.NewConfigProvider(configProviderSettings)
 
 	if err != nil {
 		log.Panicf("Err on creating Config Provider: %v\n", err)
 	}
 
-	return config_provider
+	return configProviderSettings
 }

--- a/pkg/defaultcomponents/defaults.go
+++ b/pkg/defaultcomponents/defaults.go
@@ -63,6 +63,7 @@ import (
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/extension/ballastextension"
 	"go.opentelemetry.io/collector/extension/zpagesextension"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/batchprocessor"
@@ -71,6 +72,30 @@ import (
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
 	"go.uber.org/multierr"
 )
+
+var jaegerReceiverFeatureGate = featuregate.GlobalRegistry().MustRegister("adot.receiver.jaegerreceiver",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("Allows for the ADOT Collector to be configured and started with the Jaeger Receiver"))
+
+var statsdReceiverFeatureGate = featuregate.GlobalRegistry().MustRegister("adot.receiver.statsdreceiver",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("Allows for the ADOT Collector to be configured and started with the Statsd Receiver"))
+
+var zipkinReceiverFeatureGate = featuregate.GlobalRegistry().MustRegister("adot.receiver.zipkinreceiver",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("Allows for the ADOT Collector to be configured and started with the Zipkin Receiver"))
+
+var datadogExporterFeatureGate = featuregate.GlobalRegistry().MustRegister("adot.exporter.datadogexporter",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("Allows for the ADOT Collector to be configured and started with the Data Dog Exporter"))
+
+var logzioExporterFeatureGate = featuregate.GlobalRegistry().MustRegister("adot.exporter.logzioexporter",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("Allows for the ADOT Collector to be configured and started with the Logzio Exporter"))
+
+var sapmexporterFeatureGate = featuregate.GlobalRegistry().MustRegister("adot.exporter.sapmexporter",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("Allows for the ADOT Collector to be configured and started with the sapm Exporter"))
 
 // Components register OTel components for ADOT-collector distribution
 func Components() (otelcol.Factories, error) {

--- a/pkg/defaultcomponents/defaults_test.go
+++ b/pkg/defaultcomponents/defaults_test.go
@@ -17,13 +17,14 @@ package defaultcomponents
 
 import (
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/featuregate"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 const (
-	exportersCount  = 15
+	exportersCount  = 16
 	receiversCount  = 10
 	extensionsCount = 8
 	processorCount  = 15
@@ -44,11 +45,7 @@ func TestComponents(t *testing.T) {
 	assert.NotNil(t, exporters[component.MustNewType("otlphttp")])
 	// other exporters
 	assert.NotNil(t, exporters[component.MustNewType("file")])
-	assert.NotNil(t, exporters[component.MustNewType("datadog")])
 	assert.NotNil(t, exporters[component.MustNewType("prometheus")])
-	assert.NotNil(t, exporters[component.MustNewType("sapm")])
-	assert.NotNil(t, exporters[component.MustNewType("signalfx")])
-	assert.NotNil(t, exporters[component.MustNewType("logzio")])
 	assert.NotNil(t, exporters[component.MustNewType("prometheusremotewrite")])
 	assert.NotNil(t, exporters[component.MustNewType("kafka")])
 	assert.NotNil(t, exporters[component.MustNewType("loadbalancing")])
@@ -105,4 +102,62 @@ func TestComponents(t *testing.T) {
 	assert.NotNil(t, processors[component.MustNewType("groupbytrace")])
 	assert.NotNil(t, processors[component.MustNewType("tail_sampling")])
 	assert.NotNil(t, processors[component.MustNewType("k8sattributes")])
+
+	// Ensure that the components behind feature gates are included
+	assert.NotNil(t, exporters[component.MustNewType("datadog")])
+	assert.NotNil(t, exporters[component.MustNewType("sapm")])
+	assert.NotNil(t, exporters[component.MustNewType("signalfx")])
+	assert.NotNil(t, exporters[component.MustNewType("logzio")])
+	assert.NotNil(t, exporters[component.MustNewType("splunk_hec")])
+}
+
+func TestDisableFeatureGate(t *testing.T) {
+
+	testCases := []struct {
+		desc        string
+		featureName string
+		component   component.Type
+	}{
+		{
+			desc:        "disable datadog exporter",
+			featureName: "adot.exporter.datadogexporter",
+			component:   component.MustNewType("datadog"),
+		},
+		{
+			desc:        "disable logzio exporter",
+			featureName: "adot.exporter.logzioexporter",
+			component:   component.MustNewType("logzio"),
+		},
+		{
+			desc:        "disable sapm exporter",
+			featureName: "adot.exporter.sapmexporter",
+			component:   component.MustNewType("sapm"),
+		},
+		{
+			desc:        "disable signalfx exporter",
+			featureName: "adot.exporter.signalfxexporter",
+			component:   component.MustNewType("signalfx"),
+		},
+		{
+			desc:        "disable splunk_hec exporter",
+			featureName: "adot.exporter.splunkhecexporter",
+			component:   component.MustNewType("splunk_hec"),
+		},
+	}
+	expectedLen := exportersCount
+
+	for _, tc := range testCases {
+		expectedLen--
+		t.Run(tc.desc, func(t *testing.T) {
+			err := featuregate.GlobalRegistry().Set(tc.featureName, false)
+			assert.NoError(t, err)
+
+			factories, err := Components()
+			assert.NoError(t, err)
+
+			exporters := factories.Exporters
+			assert.Len(t, exporters, expectedLen)
+			assert.Nil(t, exporters[tc.component])
+		})
+	}
 }

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -209,6 +209,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.98.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.98.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.98.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.98.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter v0.98.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter v0.98.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy v0.98.0 // indirect

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -34,6 +34,8 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
+dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
+dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.10.0 h1:n1DH8TPV4qqPTje2RcUBYwtrTWlabVp4n46+74X2pn4=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.10.0/go.mod h1:HDcZnuGbiyppErN6lB+idp4CKhjbc8gwjto6OPpyggM=
@@ -124,6 +126,8 @@ github.com/IBM/sarama v1.43.1/go.mod h1:GG5q1RURtDNPz8xxJs3mgX6Ytak8Z9eLhAkJPObe
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
+github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=
+github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -242,6 +246,8 @@ github.com/containerd/cgroups/v3 v3.0.3 h1:S5ByHZ/h9PMe5IOQoN7E+nMc2UcLEM/V48DGD
 github.com/containerd/cgroups/v3 v3.0.3/go.mod h1:8HBe7V3aWGLFPd/k03swSIsGjZhHI2WzJmticMgVuz0=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
+github.com/containerd/containerd v1.7.12 h1:+KQsnv4VnzyxWcfO9mlxxELaoztsDEjOuCMPAuPqgU0=
+github.com/containerd/containerd v1.7.12/go.mod h1:/5OMpE1p0ylxtEUGY8kuCYkDRzJm9NO1TFMWjUpdevk=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/ttrpc v1.2.2 h1:9vqZr0pxwOF5koz6N0N3kJ0zDHokrcPxIR/ZR2YFtOs=
@@ -252,6 +258,8 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
+github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
@@ -728,9 +736,15 @@ github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c/go.mod h1
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
+github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
 github.com/moby/sys/mountinfo v0.6.2/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
+github.com/moby/sys/sequential v0.5.0 h1:OPvI35Lzn9K04PBbCLW0g4LcFAJgHsvXsRyewg5lXtc=
+github.com/moby/sys/sequential v0.5.0/go.mod h1:tH2cOOs5V9MlPiXcQzRC+eEyab644PWKGRYaaV5ZZlo=
+github.com/moby/sys/user v0.1.0 h1:WmZ93f5Ux6het5iituh9x2zAG7NFY9Aqi49jjE1PaQg=
+github.com/moby/sys/user v0.1.0/go.mod h1:fKJhFOnsCN6xZ5gSfbM6zaHGgDJMrqt9/reuj4T7MmU=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -1135,6 +1149,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/testcontainers/testcontainers-go v0.29.1 h1:z8kxdFlovA2y97RWx98v/TQ+tR+SXZm6p35M+xB92zk=
+github.com/testcontainers/testcontainers-go v0.29.1/go.mod h1:SnKnKQav8UcgtKqjp/AD8bE1MqZm+3TDb/B8crE3XnI=
 github.com/tidwall/gjson v1.10.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.12.1 h1:ikuZsLdhr8Ws0IdROXUS1Gi4v9Z4pGqpX/CvJkxvfpo=
 github.com/tidwall/gjson v1.12.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=


### PR DESCRIPTION
**Description:** 

This PR adds third-party exporters behind the feature gate beta stage
Removes deprecated `configProvider` setting and use `configProviderSettings` .


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
