### PR TITLE
ECS configs changes: from BASH-style environment variables to ${}

### DIFF
--- a/config/ecs/ecs-amp-prometheus.yaml
+++ b/config/ecs/ecs-amp-prometheus.yaml
@@ -1,7 +1,7 @@
 extensions:
   health_check:
   sigv4auth:
-    region: $AWS_REGION
+    region: ${AWS_REGION}
 
 receivers:
   awsecscontainermetrics:
@@ -41,7 +41,7 @@ processors:
 
 exporters:
   prometheusremotewrite:
-    endpoint: $AWS_PROMETHEUS_ENDPOINT
+    endpoint: ${AWS_PROMETHEUS_ENDPOINT}
     auth:
       authenticator: sigv4auth
     resource_to_telemetry_conversion:

--- a/config/ecs/ecs-amp-xray-prometheus.yaml
+++ b/config/ecs/ecs-amp-xray-prometheus.yaml
@@ -1,7 +1,7 @@
 extensions:
   health_check:
   sigv4auth:
-    region: $AWS_REGION
+    region: ${AWS_REGION}
 
 receivers:
   otlp:
@@ -51,7 +51,7 @@ processors:
 exporters:
   awsxray:
   prometheusremotewrite:
-    endpoint: $AWS_PROMETHEUS_ENDPOINT
+    endpoint: ${AWS_PROMETHEUS_ENDPOINT}
     auth:
       authenticator: sigv4auth
     resource_to_telemetry_conversion:

--- a/config/ecs/ecs-amp-xray.yaml
+++ b/config/ecs/ecs-amp-xray.yaml
@@ -1,7 +1,7 @@
 extensions:
   health_check:
   sigv4auth:
-    region: $AWS_REGION
+    region: ${AWS_REGION}
 
 receivers:
   otlp:
@@ -42,7 +42,7 @@ processors:
 exporters:
   awsxray:
   prometheusremotewrite:
-    endpoint: $AWS_PROMETHEUS_ENDPOINT
+    endpoint: ${AWS_PROMETHEUS_ENDPOINT}
     auth:
       authenticator: sigv4auth
     resource_to_telemetry_conversion:

--- a/config/ecs/ecs-amp.yaml
+++ b/config/ecs/ecs-amp.yaml
@@ -1,7 +1,7 @@
 extensions:
   health_check:
   sigv4auth:
-    region: $AWS_REGION
+    region: ${AWS_REGION}
 
 receivers:
   otlp:
@@ -38,7 +38,7 @@ processors:
 
 exporters:
   prometheusremotewrite:
-    endpoint: $AWS_PROMETHEUS_ENDPOINT
+    endpoint: ${AWS_PROMETHEUS_ENDPOINT}
     auth:
       authenticator: sigv4auth
     resource_to_telemetry_conversion:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

v0.41.0 fails to start

This issue was because I used default configuration.

            "command": [
                "--config=/etc/ecs/ecs-amp.yaml"
            ],
ecs-amp.yaml file still uses BASH-style environment variables just like below

```
....
exporters:
  prometheusremotewrite:
    endpoint: $AWS_PROMETHEUS_ENDPOINT
    auth:
      authenticator: sigv4auth
....
```
I solved this by changing that environment from **$AWS_PROMETHEUS_ENDPOINT** to **${AWS_PROMETHEUS_ENDPOINT}**



**Link to tracking Issue:** <Issue number if applicable>

v0.41.0 failed to build pipelines in ECS Fargate #2863 

**Testing:** <Describe what testing was performed and which tests were added.>
I changed sample file, `ecs-amp.yaml` and launched it on ECS Fargate
```
extensions:
  health_check:
  sigv4auth:
    region: ${AWS_REGION}

....

exporters:
  prometheusremotewrite:
    endpoint: ${AWS_PROMETHEUS_ENDPOINT}
    auth:
      authenticator: sigv4auth
    resource_to_telemetry_conversion:
      enabled: true

....
```

**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
