### PR TITLE
Bump Upload/download artifacts to v4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -193,7 +193,7 @@ jobs:
 
     # upload the binaries to artifact as well because cache@v3 hasn't support windows
     - name: Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: binary_artifacts
         path: build
@@ -206,7 +206,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download built artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: binary_artifacts
           path: build
@@ -262,7 +262,7 @@ jobs:
           }
           Write-Output "Valid signature found from the package"
       - name: Upload the msi
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: msi_artifacts
           path: "${{ env.PACKAGING_ROOT }}"
@@ -354,7 +354,7 @@ jobs:
         run: |
           ARCH=amd64 DEST=$PACKAGING_ROOT/debian/amd64 tools/packaging/debian/create_deb.sh
           ARCH=arm64 DEST=$PACKAGING_ROOT/debian/arm64 tools/packaging/debian/create_deb.sh
-      
+
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.COLLECTOR_PROD_PKG_SIGNER_ROLE_ARN }}
@@ -433,7 +433,7 @@ jobs:
 
       - name: Download built artifacts
         if: steps.cached_ssm.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: msi_artifacts
           path: "${{ env.PACKAGING_ROOT }}"
@@ -479,7 +479,7 @@ jobs:
 
       - name: Download built artifacts
         if: steps.cached_packages.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: msi_artifacts
           path: "${{ env.PACKAGING_ROOT }}"
@@ -593,7 +593,7 @@ jobs:
           platforms : linux/amd64, linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
 
-  get-testing-suites: 
+  get-testing-suites:
     runs-on: ubuntu-latest
     needs: [create-test-ref]
     outputs:
@@ -658,7 +658,7 @@ jobs:
           aws-region: us-west-2
           # 6 hours
           role-duration-seconds: 21600
-      
+
       - name: Checkout testing framework
         uses: actions/checkout@v4
         with:
@@ -695,11 +695,11 @@ jobs:
           export TF_VAR_aoc_version=${{ needs.e2etest-preparation.outputs.version }}
           cd testing-framework/terraform
           make checkCacheHits
-      
+
       # This is here just in case workflow cancel
       # We first kill terraform processes to ensure that no state
       # file locks are being held from SIGTERMS dispatched in previous
-      # steps. 
+      # steps.
       - name: Destroy resources
         if: ${{ cancelled() }}
         shell: bash {0}
@@ -801,7 +801,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -23,7 +23,7 @@ on:
 
 env:
   IMAGE_NAME: aws-otel-collector
-  PACKAGING_ROOT: build/packages 
+  PACKAGING_ROOT: build/packages
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   GO_VERSION: ~1.22.7
 
@@ -60,7 +60,7 @@ jobs:
             ${{ env.MDS }} \
             || { echo "Check that anchor links are lowercase"; exit 1; }
         if: ${{ env.MDS }}
-  
+
   create-test-ref:
     runs-on: ubuntu-latest
     outputs:
@@ -109,7 +109,7 @@ jobs:
       if: ${{ needs.changes.outputs.changed == 'true' }}
       run: make apply-patches
 
-    # Set up building environment, patch the dev repo code on dispatch events.  
+    # Set up building environment, patch the dev repo code on dispatch events.
     - name: Set up Go 1.x
       if: ${{ needs.changes.outputs.changed == 'true' }}
       uses: actions/setup-go@v5
@@ -119,12 +119,12 @@ jobs:
     - name: install tools
       if: ${{ needs.changes.outputs.changed == 'true' }}
       run: make install-tools
-        
+
     - name: Lint
       if: ${{ needs.changes.outputs.changed == 'true'}}
       run: make golint
-     
-    # only run unit tests on windows. The unix build job will lint, test, and build. 
+
+    # only run unit tests on windows. The unix build job will lint, test, and build.
     - name: Unit test
       if: ${{ needs.changes.outputs.changed == 'true'}}
       run: make gotest
@@ -145,7 +145,7 @@ jobs:
       if: ${{ needs.changes.outputs.changed == 'true' }}
       run: make apply-patches
 
-    # Set up building environment, patch the dev repo code on dispatch events.  
+    # Set up building environment, patch the dev repo code on dispatch events.
     - name: Set up Go 1.x
       if: ${{ needs.changes.outputs.changed == 'true' }}
       uses: actions/setup-go@v5
@@ -179,7 +179,7 @@ jobs:
     # upload the binaries to artifact as well because cache@v2 hasn't support windows
     - name: Upload
       if: ${{ needs.changes.outputs.changed == 'true' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: binary_artifacts
         path: build
@@ -195,7 +195,7 @@ jobs:
 
       - name: Download built artifacts
         if: ${{ needs.changes.outputs.changed == 'true' }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: binary_artifacts
           path: build
@@ -302,11 +302,11 @@ jobs:
         run: | 
           matrix=$(python e2etest/get-testcases.py local_matrix)
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
-          
+
       - name: List testing suites
         run: |
           echo ${{ steps.set-matrix.outputs.matrix }}
-          
+
   run-test-case:
     runs-on: ubuntu-latest
     needs: [changes, get-test-cases, build, create-test-ref]
@@ -364,7 +364,7 @@ jobs:
           registry: public.ecr.aws
         env:
           AWS_REGION: us-east-1
-          
+
       - name: Run test
         if: ${{ needs.changes.outputs.changed == 'true' }}
         uses: nick-invision/retry@v2

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -190,7 +190,7 @@ jobs:
           cd testing-framework/terraform/performance && terraform init && terraform apply -auto-approve -lock=false -var="data_rate=${{ matrix.data_rate }}" -var="commit_id=${{ needs.get-testing-version.outputs.commit_id }}" $opts -var="aoc_version=${{ needs.get-testing-version.outputs.testing_version }}" -var="testcase=../testcases/${{ matrix.testcase }}" -var="testing_ami=${{ matrix.testing_ami }}" -var="ssh_key_name=aoc-ssh-key-2022-09-13" -var="sshkey_s3_bucket=aoc-ssh-key" -var="sshkey_s3_private_key=aoc-ssh-key-2022-09-13.txt"
 
       - name: Upload the performance model as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "performance-model-${{ matrix.testcase }}-${{ matrix.data_rate }}-${{ matrix.testing_ami }}"
           path: testing-framework/terraform/performance/output/performance.json
@@ -216,7 +216,7 @@ jobs:
         run: pip install Jinja2
 
       - name: get all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -174,7 +174,7 @@ jobs:
             fi
           done
       - name: Upload versions artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.type }}-versions
           path: ${{ env.SSM_ARTIFACT_ROOT }}
@@ -322,7 +322,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.RELEASE_CN_SECRET }}
           aws-region: cn-north-1
       - name: Download versions artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.type }}-versions
           path: ${{ env.SSM_ARTIFACT_ROOT }}


### PR DESCRIPTION
**Description:**Bump Upload artifacts to v4, `v3` is going to be deprecated on november 30, 2024

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
