### PR TITLE
chore: Update GitHub Actions workflow to use Ubuntu 22.04 runner

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -13,7 +13,7 @@
 
 name: C/D
 
-on:     
+on:
   workflow_dispatch:
     inputs:
       version:
@@ -21,11 +21,11 @@ on:
         required: true
       sha:
         description: 'the github sha to release'
-        required: true   
+        required: true
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
-    
+
 env:
   IMAGE_NAME: aws-otel-collector
   IMAGE_NAMESPACE: amazon
@@ -42,14 +42,14 @@ permissions:
   contents: write
 
 jobs:
-  release-checking: 
-    runs-on: ubuntu-latest
+  release-checking:
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.set-input-vars.outputs.version }}
       testing_version: ${{ steps.checking_sha_version.outputs.testing_version }}
       latest-or-newer: ${{ steps.version.outputs.latest-or-newer }}
       sha: ${{ steps.set-input-vars.outputs.sha }}
-    steps: 
+    steps:
       - uses: actions/checkout@v4
       - name: Set Input Variables
         id: set-input-vars
@@ -96,7 +96,7 @@ jobs:
           fi
 
           echo "testing_version=$version_in_release_candidate" >> $GITHUB_OUTPUT
-          
+
       - name: Compare version with Dockerhub latest
         id: version
         run: |
@@ -110,7 +110,7 @@ jobs:
           path: ${{ env.PACKAGING_ROOT }}
 
   release-to-s3:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [release-checking]
     steps:
       - uses: actions/checkout@v4
@@ -143,9 +143,9 @@ jobs:
       - name: Release binaries to s3 with latest version
         if: ${{ needs.release-checking.outputs.latest-or-newer == 'true' && steps.release-to-s3.outputs.cache-hit != 'true' }}
         run: s3_bucket_name=${{ env.RELEASE_S3_BUCKET }} upload_to_latest=1 bash tools/release/image-binary-release/s3-release.sh
-          
+
   release-version-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [release-checking]
     steps:
       - uses: actions/checkout@v4
@@ -199,7 +199,7 @@ jobs:
             ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
 
   release-ssm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:  [release-version-image,release-to-s3, release-checking]
     steps:
       - name: Cache if success
@@ -218,7 +218,7 @@ jobs:
           inputs: '{ "version": "${{ needs.release-checking.outputs.version }}", "sha": "${{ needs.release-checking.outputs.sha }}", "public": "true", "pkgname": "${{ env.SSM_RELEASE_PACKAGE_NAME }}", "latest": "${{ needs.release-checking.outputs.latest-or-newer }}" }'
 
   release-to-github:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ release-ssm, release-to-s3, release-version-image, release-checking]
     steps:
       - name: Checkout

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,7 +63,7 @@ permissions:
 
 jobs:
   validate-markdown:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
           || { echo "Check that anchor links are lowercase"; exit 1; } 
 
   create-test-ref:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: validate-markdown
     outputs:
       testRef: ${{ steps.setRef.outputs.ref }}
@@ -102,7 +102,7 @@ jobs:
           fi
 
   build-aotutil:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: create-test-ref
     steps:
       - name: Check out testing framework
@@ -127,7 +127,7 @@ jobs:
   build:
     needs:
       - create-test-ref
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Remove cache
@@ -269,7 +269,7 @@ jobs:
           retention-days: 1
 
   packaging-rpm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     steps:
       # Build and archive rpms into cache.
@@ -329,7 +329,7 @@ jobs:
           gpg --fingerprint --with-colons aws-otel-collector@amazon.com grep "^fpr" | sed -n 's/^fpr:::::::::\([[:alnum:]]\+\):/\1/p' | xargs gpg --batch --yes --delete-secret-keys
           gpg --list-secret-keys
   packaging-deb:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     steps:
       # Build and archive debs into cache.
@@ -384,7 +384,7 @@ jobs:
           gpg --list-secret-keys
 
   test-control-stript:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [packaging-deb]
     steps:
       - name: Checkout
@@ -404,7 +404,7 @@ jobs:
           sudo ./.github/scripts/test-collector-ctl.sh $PACKAGING_ROOT/debian/amd64/aws-otel-collector.deb ./config.yaml
 
   packaging-ssm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [packaging-rpm, packaging-deb, packaging-msi]
     steps:
       # Build and archive SSM package into cache.
@@ -448,7 +448,7 @@ jobs:
           rm -rf $PACKAGING_ROOT/ssm
           python3 tools/ssm/ssm_manifest.py ${ssm_pkg_version}
   e2etest-preparation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [packaging-rpm, packaging-deb, packaging-msi, packaging-ssm]
     outputs:
       version: ${{ steps.versioning.outputs.version }}
@@ -506,7 +506,7 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
   e2etest-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [e2etest-preparation]
     steps:
       - uses: actions/checkout@v4
@@ -594,7 +594,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   get-testing-suites:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [create-test-ref]
     outputs:
       test-case-batch-key: ${{ steps.set-batches.outputs.batch-keys }}
@@ -632,7 +632,7 @@ jobs:
           echo ${{ steps.set-batches.outputs.batch-values }}
 
   run-batch-job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref, build-aotutil]
     strategy:
       fail-fast: false
@@ -709,7 +709,7 @@ jobs:
           make terraformCleanup
 
   run-collector-testbed:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ e2etest-preparation, e2etest-release, create-test-ref]
 
     steps:
@@ -751,7 +751,7 @@ jobs:
           ./gradlew test --rerun-tasks --info
 
   clean-ssm-package:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ always() && needs.e2etest-preparation.result == 'success' }}
     needs: [run-batch-job,e2etest-preparation]
     steps:
@@ -786,7 +786,7 @@ jobs:
             aws ssm delete-document --name ${{ env.SSM_PACKAGE_NAME }} --version-name ${{ steps.versioning.outputs.ssm_pkg_version }}
 
   validate-all-tests-pass:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [run-batch-job,e2etest-preparation,create-test-ref,get-testing-suites]
     if: always()
     steps:
@@ -823,7 +823,7 @@ jobs:
           make checkCacheHits
 
   release-candidate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ always() && needs.validate-all-tests-pass.result == 'success'
             && needs.run-collector-testbed.result == 'success'
             && (startsWith(github.ref_name, 'release/v') || github.ref_name == 'main') }}
@@ -862,7 +862,7 @@ jobs:
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
 
   publish-ci-status:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [release-candidate]
     if: always()
     steps:

--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   validate-markdown:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -62,7 +62,7 @@ jobs:
         if: ${{ env.MDS }}
 
   create-test-ref:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       testRef: ${{ steps.setRef.outputs.ref }}
     steps:
@@ -76,7 +76,7 @@ jobs:
           fi
 
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
@@ -131,7 +131,7 @@ jobs:
 
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [changes]
     steps:
     - name: Remove cache
@@ -209,7 +209,7 @@ jobs:
         run: .\tools\packaging\windows\create_msi.ps1
 
   packaging-rpm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [changes, build]
     steps:
       # Build and archive RPMs into cache.
@@ -235,7 +235,7 @@ jobs:
           ARCH=aarch64 SOURCE_ARCH=arm64 DEST=build/packages/linux/arm64 tools/packaging/linux/create_rpm.sh
 
   packaging-deb:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [changes, build]
     steps:
       # Build and archive debs into cache.
@@ -264,7 +264,7 @@ jobs:
           ARCH=arm64 DEST=build/packages/debian/arm64 tools/packaging/debian/create_deb.sh
 
   test-control-stript:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [changes, packaging-deb]
     steps:
       - name: Checkout
@@ -285,7 +285,7 @@ jobs:
           sudo ./.github/scripts/test-collector-ctl.sh ./build/packages/debian/amd64/aws-otel-collector.deb ./config.yaml
 
   get-test-cases:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -308,7 +308,7 @@ jobs:
           echo ${{ steps.set-matrix.outputs.matrix }}
 
   run-test-case:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [changes, get-test-cases, build, create-test-ref]
     strategy:
       fail-fast: false

--- a/.github/workflows/aws-resources-clean.yml
+++ b/.github/workflows/aws-resources-clean.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   clean-resources:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -73,7 +73,7 @@ jobs:
   # API GW api has a limit of one delete request per 30 seconds. Thus it cannot be run in parallel
   # with the other tests
   clean-apigw:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   create-test-ref:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       testRef: ${{ steps.setRef.outputs.ref }}
     steps:
@@ -44,7 +44,7 @@ jobs:
           fi
 
   build-aotutil:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: create-test-ref
     steps:
       - name: Check out testing framework
@@ -68,7 +68,7 @@ jobs:
           path: testing-framework/cmd/aotutil/aotutil
 
   get-canary-test-cases:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - build-aotutil
     outputs:
@@ -88,7 +88,7 @@ jobs:
           echo "canary_matrix=$canary_matrix" >> $GITHUB_OUTPUT
 
   run-canary-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [get-canary-test-cases, create-test-ref]
     strategy:
       matrix: ${{ fromJson(needs.get-canary-test-cases.outputs.canary_matrix) }}
@@ -138,7 +138,7 @@ jobs:
             cd testing-framework/terraform/canary
             terraform init
             terraform apply -auto-approve -lock=false $opts -var="aoc_version=latest" -var="testcase=../testcases/${{ matrix.testcase }}" -var="testing_ami=${{ matrix.testing_ami }}"
-       
+
       - name: Destroy terraform resources
         if: ${{ always() }}
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   create-test-ref:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       testRef: ${{ steps.setRef.outputs.ref }}
     steps:
@@ -49,7 +49,7 @@ jobs:
           fi
 
   get-testing-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.get-testing-version.outputs.version }}
       testing_version: ${{ steps.get-testing-version.outputs.testing_version }}
@@ -98,7 +98,7 @@ jobs:
           fi
 
   get-perf-test-cases:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       perf_matrix: ${{ steps.get-test-cases.outputs.perf_matrix }}
     steps:
@@ -116,7 +116,7 @@ jobs:
           echo "perf_matrix=$perf_matrix" >> $GITHUB_OUTPUT
 
   build-aotutil:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: create-test-ref
     steps:
       - name: Check out testing framework
@@ -143,7 +143,7 @@ jobs:
 
 
   run-perf-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [get-perf-test-cases, get-testing-version, create-test-ref, build-aotutil]
     strategy:
       matrix: ${{ fromJson(needs.get-perf-test-cases.outputs.perf_matrix) }}
@@ -202,7 +202,7 @@ jobs:
           cd testing-framework/terraform/performance && terraform destroy -auto-approve
 
   upload-performance-model:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [get-testing-version, run-perf-test]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-body-validate.yml
+++ b/.github/workflows/pr-body-validate.yml
@@ -22,11 +22,11 @@ env:
 
 jobs:
     validate-pr-body:
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       steps:
         - name: Validade license content
-          if: ${{ github.actor != 'dependabot[bot]' }} 
-          env: 
+          if: ${{ github.actor != 'dependabot[bot]' }}
+          env:
             PRBODY: ${{ github.event.pull_request.body }}
             LICTEXT: ${{ env.LICENSE_TEXT }}
           run: | 

--- a/.github/workflows/prod-image-mirror.yml
+++ b/.github/workflows/prod-image-mirror.yml
@@ -20,9 +20,9 @@ permissions:
   id-token: write
   contents: read
 
-jobs:           
+jobs:
   release-latest-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/rollback-operator.yml
+++ b/.github/workflows/rollback-operator.yml
@@ -25,14 +25,14 @@ env:
 
 jobs:
   image-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check version exists on Release ECR/DockerHub repos
         run: |
           docker manifest inspect public.ecr.aws/$ECR_REPO:${{ github.event.inputs.rollback-version }} > /dev/null
 
   image-rollback:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [image-check]
     if: always() && needs.image-check.result == 'success'
     steps:

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -47,7 +47,7 @@ permissions:
 
 jobs:
   image-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.inputs.skip-image-rollback == 'false'
     steps:
       - name: Check version exists on Release ECR/DockerHub repos
@@ -55,7 +55,7 @@ jobs:
           docker manifest inspect public.ecr.aws/$ECR_REPO:${{ github.event.inputs.rollback-version }} > /dev/null
           docker manifest inspect $DOCKERHUB_REPO:${{ github.event.inputs.rollback-version }} > /dev/null
   s3-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.inputs.skip-s3-rollback == 'false'
     strategy:
       fail-fast: true
@@ -92,7 +92,7 @@ jobs:
           S3_KEY="${{ matrix.os }}/${{ matrix.arch }}/${{ github.event.inputs.rollback-version }}/aws-otel-collector.${{ matrix.type }}"
           aws s3api head-object --bucket ${S3_BUCKET} --key ${S3_KEY} > /dev/null
   ssm-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.inputs.skip-ssm-rollback == 'false'
     strategy:
       fail-fast: true
@@ -180,7 +180,7 @@ jobs:
           path: ${{ env.SSM_ARTIFACT_ROOT }}
           retention-days: 1
   all-checked:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [image-check, s3-check, ssm-check]
     if: |
       always() &&
@@ -190,7 +190,7 @@ jobs:
     steps:
       - run: echo "All checks passed."
   image-rollback:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [all-checked]
     if: always() && needs.all-checked.result == 'success' && github.event.inputs.skip-image-rollback == 'false'
     steps:
@@ -221,7 +221,7 @@ jobs:
           src: ${{ env.DOCKERHUB_REPO }}:${{ github.event.inputs.rollback-version }}
           dst: ${{ env.DOCKERHUB_REPO }}:latest
   s3-rollback:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [all-checked]
     if: always() && needs.all-checked.result == 'success' && github.event.inputs.skip-s3-rollback == 'false'
     strategy:
@@ -262,7 +262,7 @@ jobs:
           LATEST_URI="s3://${S3_BUCKET}/${LATEST_KEY}"
           aws s3 cp "${VERSION_URI}" "${LATEST_URI}" --acl public-read
   ssm-rollback:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [all-checked]
     if: always() && needs.all-checked.result == 'success' && github.event.inputs.skip-ssm-rollback == 'false'
     strategy:

--- a/.github/workflows/ssm-release.yml
+++ b/.github/workflows/ssm-release.yml
@@ -51,13 +51,13 @@ permissions:
 
 jobs:
   release-ssm-package:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout the sha
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.sha }}
-      
+
       - name: Set SSM make default env -var
         if: ${{ inputs.latest }}
         run: echo "SSM_ADDTL_ARGS=--make_default_version" >> $GITHUB_ENV

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   stale-close:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Mark the issues/pr
         uses: actions/stale@v9

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   update-gh-pages-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
**Description:** 

Use `ubuntu-22.04` instead of `ubuntu-latest` to avoid any breaking changes that comes with `latest`. ubuntu-22.04 is already used as part of ubuntu-latest, so this shall not break any existing workflows.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
