### PR TITLE
fix: incorrect AWS credentials extracfg field name

### DIFF
--- a/extracfg.txt
+++ b/extracfg.txt
@@ -5,4 +5,4 @@
 # awsProfile=default
 
 # set aws credential file path
-# awsCredsFile=~/.aws/credentials
+# awsCredentialFile=~/.aws/credentials


### PR DESCRIPTION
**Description:**
Fixes the example extracfg.txt file which had an incorrect field name for the AWS credentials file.

The [example file](https://github.com/aws-observability/aws-otel-collector/blob/main/extracfg.txt#L8) has this documented as `awsCredsFile` in the comments whereas the [parser expects](https://github.com/aws-observability/aws-otel-collector/blob/main/pkg/extraconfig/extraconfig.go#L78) `awsCredentialsFile`

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
