### PR TITLE
[chore]: fix incorrect AWS credentials extracfg field name

### DIFF
--- a/extracfg.txt
+++ b/extracfg.txt
@@ -5,4 +5,4 @@
 # awsProfile=default
 
 # set aws credential file path
-# awsCredsFile=~/.aws/credentials
+# awsCredentialFile=~/.aws/credentials


### PR DESCRIPTION
Fixes the example extracfg.txt file which had an incorrect field name for the AWS credentials file. this file is probably missed during the implementation, [Unit tests were present for this usage](https://github.com/aws-observability/aws-otel-collector/blob/main/pkg/extraconfig/testdata/extraconfig.txt#L9-L10)



as referenced in #2901 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
