### PR TITLE
[release/v0.41.x] cherry-pick:pin markdown lint due to 3.12.2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install markdown-link-check
-        run: npm install -g markdown-link-check
+        run: npm install -g markdown-link-check@3.12.2
 
       - name: Run markdown-link-check in the developers docs
         run: |

--- a/docs/developers/linux-rpm-demo.md
+++ b/docs/developers/linux-rpm-demo.md
@@ -7,7 +7,7 @@ See [AWS Distro for OpenTelemetry documentation](https://aws-otel.github.io/docs
 ### Install ADOT Collector on ECS EC2
 See [AWS Distro for OpenTelemetry documentation](https://aws-otel.github.io/docs/setup/ecs) for detailed information on installing ADOT Collector on ECS.
 
-#### enable debugging log
+#### Enable debugging log
 
 add a key value pair into `/opt/aws/aws-otel-collector/etc/extracfg.txt` and restart collector
 


### PR DESCRIPTION
**Description:**

cherry-picking https://github.com/aws-observability/aws-otel-collector/pull/2896

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
