### PR TITLE
Update ecs-ec2-adot-config.yaml -- env variable not being parsed

### DIFF
--- a/examples/ecs/aws-prometheus/ecs-ec2-adot-config.yaml
+++ b/examples/ecs/aws-prometheus/ecs-ec2-adot-config.yaml
@@ -7,7 +7,7 @@ receivers:
       scrape_configs:
       - job_name: "test-prometheus-sample-app"
         static_configs:
-        - targets: [ ${env:PROMETHEUS_SAMPLE_APP} ]
+        - targets: [ '${env:PROMETHEUS_SAMPLE_APP}' ]
   awsecscontainermetrics:
     collection_interval: 20s
 


### PR DESCRIPTION
Fix environment variable syntax so it can be parsed correctly.



**Description:** 

I found that the environment variable was not being parsed correctly, leading to this error:
Error: failed to get config: cannot resolve the configuration: retrieved value (type=string) cannot be used as a Conf

After adding the quotations, it is now working as expected.

**Link to tracking Issue:** No related issue number.
**Testing:** Manual testing in my environment.
**Documentation:** No documentation modified.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
