### PR TITLE
remove EKS 1.24, 1.25, 1.26, 1.27 from CI tests

### DIFF
--- a/.github/config/testcases.json
+++ b/.github/config/testcases.json
@@ -4,34 +4,6 @@
 			"type": "EKS",
 			"targets": [
 				{
-					"name": "collector-ci-amd64-1-24",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsight_eks"
-					]
-				},
-				{
-					"name": "collector-ci-amd64-1-25",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsight_eks"
-					]
-				},
-				{
-					"name": "collector-ci-amd64-1-26",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsight_eks"
-					]
-				},
-				{
-					"name": "collector-ci-amd64-1-27",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsight_eks"
-					]
-				},
-				{
 					"name": "collector-ci-amd64-1-30",
 					"region": "us-west-2",
 					"excluded_tests": [
@@ -51,34 +23,6 @@
 			"type": "EKS_ARM64",
 			"targets": [
 				{
-					"name": "collector-ci-arm64-1-24",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsight_eks"
-					]
-				},
-				{
-					"name": "collector-ci-arm64-1-25",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsight_eks"
-					]
-				},
-				{
-					"name": "collector-ci-arm64-1-26",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsight_eks"
-					]
-				},
-				{
-					"name": "collector-ci-arm64-1-27",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsight_eks"
-					]
-				},
-				{
 					"name": "collector-ci-arm64-1-30",
 					"region": "us-west-2",
 					"excluded_tests": [
@@ -97,22 +41,6 @@
 		{
 			"type": "EKS_FARGATE",
 			"targets": [
-				{
-					"name": "collector-ci-fargate-1-24",
-					"region": "us-west-2"
-				},
-				{
-					"name": "collector-ci-fargate-1-25",
-					"region": "us-west-2"
-				},
-				{
-					"name": "collector-ci-fargate-1-26",
-					"region": "us-west-2"
-				},
-				{
-					"name": "collector-ci-fargate-1-27",
-					"region": "us-west-2"
-				},
 				{
 					"name": "collector-ci-fargate-1-30",
 					"region": "us-west-2"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
* Remove EKS versions that's on extended support from CI tests

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
