### PR TITLE
[chore] Modify EKS cluster in test cases

### DIFF
--- a/.github/config/testcases.json
+++ b/.github/config/testcases.json
@@ -4,20 +4,6 @@
 			"type": "EKS",
 			"targets": [
 				{
-					"name": "collector-ci-amd64-1-24",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsight_eks"
-					]
-				},
-				{
-					"name": "collector-ci-amd64-1-25",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsight_eks"
-					]
-				},
-				{
 					"name": "collector-ci-amd64-1-26",
 					"region": "us-west-2",
 					"excluded_tests": [
@@ -26,6 +12,20 @@
 				},
 				{
 					"name": "collector-ci-amd64-1-27",
+					"region": "us-west-2",
+					"excluded_tests": [
+						"containerinsight_eks"
+					]
+				},
+				{
+					"name": "collector-ci-amd64-1-28",
+					"region": "us-west-2",
+					"excluded_tests": [
+						"containerinsight_eks"
+					]
+				},
+				{
+					"name": "collector-ci-amd64-1-29",
 					"region": "us-west-2",
 					"excluded_tests": [
 						"containerinsight_eks"
@@ -51,20 +51,6 @@
 			"type": "EKS_ARM64",
 			"targets": [
 				{
-					"name": "collector-ci-arm64-1-24",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsight_eks"
-					]
-				},
-				{
-					"name": "collector-ci-arm64-1-25",
-					"region": "us-west-2",
-					"excluded_tests": [
-						"containerinsight_eks"
-					]
-				},
-				{
 					"name": "collector-ci-arm64-1-26",
 					"region": "us-west-2",
 					"excluded_tests": [
@@ -73,6 +59,20 @@
 				},
 				{
 					"name": "collector-ci-arm64-1-27",
+					"region": "us-west-2",
+					"excluded_tests": [
+						"containerinsight_eks"
+					]
+				},
+				{
+					"name": "collector-ci-arm64-1-28",
+					"region": "us-west-2",
+					"excluded_tests": [
+						"containerinsight_eks"
+					]
+				},
+				{
+					"name": "collector-ci-arm64-1-29",
 					"region": "us-west-2",
 					"excluded_tests": [
 						"containerinsight_eks"
@@ -98,19 +98,19 @@
 			"type": "EKS_FARGATE",
 			"targets": [
 				{
-					"name": "collector-ci-fargate-1-24",
-					"region": "us-west-2"
-				},
-				{
-					"name": "collector-ci-fargate-1-25",
-					"region": "us-west-2"
-				},
-				{
 					"name": "collector-ci-fargate-1-26",
 					"region": "us-west-2"
 				},
 				{
 					"name": "collector-ci-fargate-1-27",
+					"region": "us-west-2"
+				},
+				{
+					"name": "collector-ci-fargate-1-28",
+					"region": "us-west-2"
+				},
+				{
+					"name": "collector-ci-fargate-1-29",
 					"region": "us-west-2"
 				},
 				{


### PR DESCRIPTION
**Description:**
Modify eks cluster versions in testcases by removing unsupported eks versions
 1.24, 1.25 and adding supported 1.28 and 1.29 k8s

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
