### PR TITLE
assume role using OIDC instead of long-term creds

### DIFF
--- a/.github/workflows/ssm-release.yml
+++ b/.github/workflows/ssm-release.yml
@@ -263,8 +263,8 @@ jobs:
       - name: Configure AWS Credentials for CN regions
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.RELEASE_CN_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.RELEASE_CN_SECRET }}
+          role-to-assume: ${{ secrets.COLLECTOR_PROD_RELEASE_CN_ROLE_ARN }}
+          audience: sts.amazonaws.com.cn
           aws-region: cn-north-1
 
       - name: Copy SSM package to S3 in CN regions


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

We can assume the CN release account role using ODIC. Let's do that instead of the static creds. 

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
