### PR TITLE
fix the Free space step in CI build stage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -134,7 +134,7 @@ jobs:
       run: rm -rf /opt/hostedtoolcache
 
     - name: Free space
-      run: rm -rf /usr/local/lib/android
+      run: sudo rm -rf /usr/local/lib/android
 
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
```
Run rm -rf /usr/local/lib/android
rm: cannot remove '/usr/local/lib/android/sdk': Permission denied
```

this should fix the issue

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
