### PR TITLE
Fix ownership of the home directory in Dockerfile

### DIFF
--- a/cmd/awscollector/Dockerfile
+++ b/cmd/awscollector/Dockerfile
@@ -87,7 +87,7 @@ ARG USERNAME=aoc
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=base /etc/passwd /etc/passwd
 COPY --from=base /etc/group /etc/group
-COPY --from=base --chown=aoc:aoc /home/$USERNAME/ /home/$USERNAME
+COPY --from=base --chown=$USERNAME:$USERNAME /home/$USERNAME/ /home/$USERNAME
 COPY --from=package /workspace/awscollector /awscollector
 COPY --from=package /workspace/config/ /etc/
 COPY --from=package /workspace/healthcheck /healthcheck


### PR DESCRIPTION
**Description:**

The collector runs as "aoc" user, but it doesn't have access to it's own home directory.

So, because of this, there is no way to write anything to file system from the collector extensions without running it as a superuser.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
