### PR TITLE
Fix disk space issue in prod-image-mirror workflow

### DIFF
--- a/.github/workflows/prod-image-mirror.yml
+++ b/.github/workflows/prod-image-mirror.yml
@@ -24,6 +24,20 @@ jobs:
   release-latest-image:
     runs-on: ubuntu-22.04
     steps:
+      - name: Free space
+        run: |
+          echo '===== Before ====='
+          df -h
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/lib/google-cloud-sdk
+          sudo rm -rf /usr/local/julia*
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/share/dotnet
+          sudo apt-get clean
+          echo '===== After ====='
+          df -h
+
       - uses: actions/checkout@v4
 
       - name: Set up Go 1.x


### PR DESCRIPTION
Description: 

Free space step to clean up unnecessary files on the GitHub runner before running the image mirror process

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
