### PR TITLE
Fix prometheus-sample-app deployment with build instructions

### DIFF
--- a/examples/eks/aws-prometheus/prometheus-sample-app.yaml
+++ b/examples/eks/aws-prometheus/prometheus-sample-app.yaml
@@ -26,7 +26,15 @@ spec:
     spec:
       containers:
       - name: prometheus-sample-app
-        image: "" # change to your local image
+        # To build the image, clone and build from the sample app source:
+        # https://github.com/aws-observability/aws-otel-community/tree/master/sample-apps/prometheus-sample-app
+        # 
+        # Quick build command:
+        # docker build -t prometheus-sample-app:latest https://github.com/aws-observability/aws-otel-community.git#master:sample-apps/prometheus-sample-app
+        #
+        # Then update the image field below with your built image name
+        image: "prometheus-sample-app:latest"  # Replace with your registry/image:tag
+        imagePullPolicy: IfNotPresent
         command: ["/bin/main", "-listen_address=0.0.0.0:8080", "-metric_count=10"]
         ports:
         - name: web


### PR DESCRIPTION
## Problem
The prometheus-sample-app deployment YAML had an empty `image: ""` field, which prevented users from successfully deploying the sample application. This caused confusion as there were no instructions on how to obtain or build the required image.

## Solution
- Replaced empty image field with example image name: `prometheus-sample-app:latest`
- Added detailed comments explaining how to build the image from source
- Included direct link to the sample app source code in aws-otel-community repository
- Provided a quick one-line Docker build command for convenience
- Added `imagePullPolicy: IfNotPresent` to prevent image pull errors when using locally built images

## Changes Made
- Updated `examples/eks/aws-prometheus/prometheus-sample-app.yaml`
- Added comprehensive inline documentation for building the sample app image

## Testing
The YAML structure remains valid and users now have clear instructions to:
1. Build the image from the provided source repository
2. Deploy the sample app successfully to their EKS cluster

## Related
This improves the developer experience for users testing ADOT with Prometheus metrics on EKS.
