### PR TITLE
[FIX] Enable remote sampling support in App Runner config

### DIFF
--- a/config/apprunner/apprunner-default-config.yaml
+++ b/config/apprunner/apprunner-default-config.yaml
@@ -1,5 +1,6 @@
 extensions:
   health_check:
+  awsproxy:
 
 receivers:
   otlp:
@@ -30,4 +31,4 @@ service:
       processors: [memory_limiter, resourcedetection, batch]
       exporters: [awsxray]
 
-  extensions: [health_check]
+  extensions: [health_check, awsproxy]


### PR DESCRIPTION
**Description:** Add `awsproxy` extension to App Runner default config to enable X-Ray remote sampling support. 

  **Link to tracking Issue:** #3154

  **Testing:** Verified locally:
  - Old config: Port 2000 closed, remote sampling fails
  - New config: Port 2000 open, `GetSamplingRules` API returns rules successfully

  **Documentation:** N/A

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
