### PR TITLE
[FIX] Add cAdvisor filesystem plugin imports patch for awscontainerinsightreceiver

### DIFF
--- a/patches/awscontainerinsightreceiver-cadvisor-fs.patch
+++ b/patches/awscontainerinsightreceiver-cadvisor-fs.patch
@@ -1,0 +1,30 @@
+diff --git a/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go b/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
+index 72ba3e62b..da7b71057 100644
+--- a/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
++++ b/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
+@@ -18,6 +18,10 @@ import (
+ 	"github.com/google/cadvisor/container/crio"
+ 	"github.com/google/cadvisor/container/docker"
+ 	"github.com/google/cadvisor/container/systemd"
++	// Register filesystem plugins via init() functions
++	_ "github.com/google/cadvisor/fs/overlay/install"
++	_ "github.com/google/cadvisor/fs/tmpfs/install"
++	_ "github.com/google/cadvisor/fs/vfs/install"
+ 	cInfo "github.com/google/cadvisor/info/v1"
+ 	"github.com/google/cadvisor/manager"
+ 	"github.com/google/cadvisor/utils/sysfs"
+diff --git a/testbed/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go b/testbed/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
+index 72ba3e62b..da7b71057 100644
+--- a/testbed/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
++++ b/testbed/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
+@@ -18,6 +18,10 @@ import (
+ 	"github.com/google/cadvisor/container/crio"
+ 	"github.com/google/cadvisor/container/docker"
+ 	"github.com/google/cadvisor/container/systemd"
++	// Register filesystem plugins via init() functions
++	_ "github.com/google/cadvisor/fs/overlay/install"
++	_ "github.com/google/cadvisor/fs/tmpfs/install"
++	_ "github.com/google/cadvisor/fs/vfs/install"
+ 	cInfo "github.com/google/cadvisor/info/v1"
+ 	"github.com/google/cadvisor/manager"
+ 	"github.com/google/cadvisor/utils/sysfs"


### PR DESCRIPTION
**Description:** Add patch to register cAdvisor filesystem plugins (vfs, overlay, tmpfs) required for NodeFS/InstanceFS metrics collection.

cAdvisor v0.55.0 introduced a pluggable filesystem architecture (PR google/cadvisor#3794) that requires explicit plugin registration via blank imports. Without these imports, `fs.GetPluginForFsType()` returns nil for all filesystem types and NodeFS/InstanceFS metrics are not emitted.

**Link to tracking Issue:** Upstream PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/45535

**Testing:** Patch applies cleanly via `make apply-patches`

**Documentation:** N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.