### PR TITLE
[FIX] Add cAdvisor filesystem plugin packages and fix patch

### DIFF
--- a/patches/awscontainerinsightreceiver-cadvisor-fs.patch
+++ b/patches/awscontainerinsightreceiver-cadvisor-fs.patch
@@ -13,18 +13,3 @@ index 72ba3e62b..da7b71057 100644
  	cInfo "github.com/google/cadvisor/info/v1"
  	"github.com/google/cadvisor/manager"
  	"github.com/google/cadvisor/utils/sysfs"
-diff --git a/testbed/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go b/testbed/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
-index 72ba3e62b..da7b71057 100644
---- a/testbed/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
-+++ b/testbed/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
-@@ -18,6 +18,10 @@ import (
- 	"github.com/google/cadvisor/container/crio"
- 	"github.com/google/cadvisor/container/docker"
- 	"github.com/google/cadvisor/container/systemd"
-+	// Register filesystem plugins via init() functions
-+	_ "github.com/google/cadvisor/fs/overlay/install"
-+	_ "github.com/google/cadvisor/fs/tmpfs/install"
-+	_ "github.com/google/cadvisor/fs/vfs/install"
- 	cInfo "github.com/google/cadvisor/info/v1"
- 	"github.com/google/cadvisor/manager"
- 	"github.com/google/cadvisor/utils/sysfs"

--- a/vendor/github.com/google/cadvisor/fs/overlay/install/install.go
+++ b/vendor/github.com/google/cadvisor/fs/overlay/install/install.go
@@ -1,0 +1,31 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package install
+
+import (
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/fs/overlay"
+
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	err := fs.RegisterPlugin("overlay", overlay.NewPlugin())
+	if err != nil {
+		klog.Fatalf("Failed to register overlay fs plugin: %v", err)
+	}
+}

--- a/vendor/github.com/google/cadvisor/fs/overlay/plugin.go
+++ b/vendor/github.com/google/cadvisor/fs/overlay/plugin.go
@@ -1,0 +1,76 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package overlay
+
+import (
+	"fmt"
+
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/fs/vfs"
+
+	mount "github.com/moby/sys/mountinfo"
+)
+
+type overlayPlugin struct{}
+
+// NewPlugin creates a new Overlay filesystem plugin.
+func NewPlugin() fs.FsPlugin {
+	return &overlayPlugin{}
+}
+
+func (p *overlayPlugin) Name() string {
+	return "overlay"
+}
+
+// CanHandle returns true if the filesystem type is overlay or overlay2.
+func (p *overlayPlugin) CanHandle(fsType string) bool {
+	return fsType == "overlay"
+}
+
+// Priority returns 100 - Overlay has higher priority than VFS.
+func (p *overlayPlugin) Priority() int {
+	return 100
+}
+
+// GetStats returns filesystem statistics for Overlay.
+// Overlay delegates to VFS for stats collection.
+func (p *overlayPlugin) GetStats(device string, partition fs.PartitionInfo) (*fs.FsStats, error) {
+	// Overlay uses VFS stats
+	capacity, free, avail, inodes, inodesFree, err := vfs.GetVfsStats(partition.Mountpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return &fs.FsStats{
+		Capacity:   capacity,
+		Free:       free,
+		Available:  avail,
+		Inodes:     &inodes,
+		InodesFree: &inodesFree,
+		Type:       fs.VFS,
+	}, nil
+}
+
+// ProcessMount handles Overlay mount processing.
+// Overlay fix: Making mount source unique for all overlay mounts, using the mount's major and minor ids.
+// This is needed because multiple overlay mounts can have the same source.
+func (p *overlayPlugin) ProcessMount(mnt *mount.Info) (bool, *mount.Info, error) {
+	// Create a copy with unique source
+	correctedMnt := *mnt
+	correctedMnt.Source = fmt.Sprintf("%s_%d-%d", mnt.Source, mnt.Major, mnt.Minor)
+	return true, &correctedMnt, nil
+}

--- a/vendor/github.com/google/cadvisor/fs/tmpfs/install/install.go
+++ b/vendor/github.com/google/cadvisor/fs/tmpfs/install/install.go
@@ -1,0 +1,31 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package install
+
+import (
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/fs/tmpfs"
+
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	err := fs.RegisterPlugin("tmpfs", tmpfs.NewPlugin())
+	if err != nil {
+		klog.Fatalf("Failed to register tmpfs fs plugin: %v", err)
+	}
+}

--- a/vendor/github.com/google/cadvisor/fs/tmpfs/plugin.go
+++ b/vendor/github.com/google/cadvisor/fs/tmpfs/plugin.go
@@ -1,0 +1,80 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package tmpfs
+
+import (
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/fs/vfs"
+
+	mount "github.com/moby/sys/mountinfo"
+)
+
+type tmpfsPlugin struct{}
+
+// NewPlugin creates a new tmpfs filesystem plugin.
+func NewPlugin() fs.FsPlugin {
+	return &tmpfsPlugin{}
+}
+
+func (p *tmpfsPlugin) Name() string {
+	return "tmpfs"
+}
+
+// CanHandle returns true if the filesystem type is tmpfs.
+func (p *tmpfsPlugin) CanHandle(fsType string) bool {
+	return fsType == "tmpfs"
+}
+
+// Priority returns 100 - tmpfs has higher priority than VFS.
+func (p *tmpfsPlugin) Priority() int {
+	return 100
+}
+
+// GetStats returns filesystem statistics for tmpfs.
+// tmpfs delegates to VFS for stats collection.
+func (p *tmpfsPlugin) GetStats(device string, partition fs.PartitionInfo) (*fs.FsStats, error) {
+	// tmpfs uses VFS stats
+	capacity, free, avail, inodes, inodesFree, err := vfs.GetVfsStats(partition.Mountpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return &fs.FsStats{
+		Capacity:   capacity,
+		Free:       free,
+		Available:  avail,
+		Inodes:     &inodes,
+		InodesFree: &inodesFree,
+		Type:       fs.VFS,
+	}, nil
+}
+
+// ProcessMount handles tmpfs mount processing.
+// For tmpfs, we use the mountpoint as the source to make each mount unique.
+// This allows multiple tmpfs mounts with the same "tmpfs" source to coexist.
+func (p *tmpfsPlugin) ProcessMount(mnt *mount.Info) (bool, *mount.Info, error) {
+	// Use mountpoint as source to make each tmpfs mount unique
+	correctedMnt := *mnt
+	correctedMnt.Source = mnt.Mountpoint
+	return true, &correctedMnt, nil
+}
+
+// AllowDuplicateSource returns true for tmpfs since multiple tmpfs mounts
+// should be tracked separately even if they appear to have the same source.
+func (p *tmpfsPlugin) AllowDuplicateSource() bool {
+	return true
+}

--- a/vendor/github.com/google/cadvisor/fs/vfs/install/install.go
+++ b/vendor/github.com/google/cadvisor/fs/vfs/install/install.go
@@ -1,0 +1,31 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package install
+
+import (
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/fs/vfs"
+
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	err := fs.RegisterPlugin("vfs", vfs.NewPlugin())
+	if err != nil {
+		klog.Fatalf("Failed to register vfs fs plugin: %v", err)
+	}
+}

--- a/vendor/github.com/google/cadvisor/fs/vfs/plugin.go
+++ b/vendor/github.com/google/cadvisor/fs/vfs/plugin.go
@@ -1,0 +1,97 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package vfs
+
+import (
+	"strings"
+
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/utils"
+
+	mount "github.com/moby/sys/mountinfo"
+	"k8s.io/klog/v2"
+)
+
+type vfsPlugin struct{}
+
+// NewPlugin creates a new VFS filesystem plugin.
+func NewPlugin() fs.FsPlugin {
+	return &vfsPlugin{}
+}
+
+func (p *vfsPlugin) Name() string {
+	return "vfs"
+}
+
+// CanHandle returns true for standard filesystems that use VFS stats.
+// This includes ext2/3/4, xfs, and similar block-based filesystems.
+// Virtual/pseudo filesystems (proc, sysfs, cgroup, etc.) are excluded.
+func (p *vfsPlugin) CanHandle(fsType string) bool {
+	// Exclude virtual/pseudo filesystems that don't have real disk backing
+	switch fsType {
+	case "cgroup", "cgroup2", "cpuset", "mqueue", "proc", "sysfs",
+		"devtmpfs", "devpts", "securityfs", "debugfs", "tracefs",
+		"pstore", "configfs", "fusectl", "hugetlbfs", "autofs",
+		"binfmt_misc", "efivarfs", "rpc_pipefs", "nsfs":
+		return false
+	}
+
+	// VFS can handle most standard Linux filesystems
+	if strings.HasPrefix(fsType, "ext") {
+		return true
+	}
+	switch fsType {
+	case "xfs", "squashfs", "f2fs", "jfs", "reiserfs", "hfs", "hfsplus",
+		"ntfs", "vfat", "fat", "msdos", "exfat", "udf", "iso9660":
+		return true
+	}
+	// Don't act as a general fallback - only handle known filesystem types
+	return false
+}
+
+// Priority returns 0 - VFS is the lowest priority fallback plugin.
+func (p *vfsPlugin) Priority() int {
+	return 0
+}
+
+// GetStats returns filesystem statistics using the statfs syscall.
+func (p *vfsPlugin) GetStats(device string, partition fs.PartitionInfo) (*fs.FsStats, error) {
+	if !utils.FileExists(partition.Mountpoint) {
+		klog.V(4).Infof("VFS: mountpoint does not exist: %v", partition.Mountpoint)
+		return nil, nil
+	}
+
+	capacity, free, avail, inodes, inodesFree, err := GetVfsStats(partition.Mountpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return &fs.FsStats{
+		Capacity:   capacity,
+		Free:       free,
+		Available:  avail,
+		Inodes:     &inodes,
+		InodesFree: &inodesFree,
+		Type:       fs.VFS,
+	}, nil
+}
+
+// ProcessMount handles standard mount processing.
+// For VFS, no special processing is needed.
+func (p *vfsPlugin) ProcessMount(mnt *mount.Info) (bool, *mount.Info, error) {
+	return true, mnt, nil
+}

--- a/vendor/github.com/google/cadvisor/fs/vfs/stats.go
+++ b/vendor/github.com/google/cadvisor/fs/vfs/stats.go
@@ -1,0 +1,63 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package vfs
+
+import (
+	"context"
+	"syscall"
+	"time"
+)
+
+// GetVfsStats returns filesystem statistics using the statfs syscall.
+// It has a timeout to prevent hanging on unresponsive filesystems.
+func GetVfsStats(path string) (total uint64, free uint64, avail uint64, inodes uint64, inodesFree uint64, err error) {
+	// timeout the context with, default is 2sec
+	timeout := 2
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	type result struct {
+		total      uint64
+		free       uint64
+		avail      uint64
+		inodes     uint64
+		inodesFree uint64
+		err        error
+	}
+
+	resultChan := make(chan result, 1)
+
+	go func() {
+		var s syscall.Statfs_t
+		if err = syscall.Statfs(path, &s); err != nil {
+			total, free, avail, inodes, inodesFree = 0, 0, 0, 0, 0
+		}
+		total = uint64(s.Frsize) * s.Blocks
+		free = uint64(s.Frsize) * s.Bfree
+		avail = uint64(s.Frsize) * s.Bavail
+		inodes = uint64(s.Files)
+		inodesFree = uint64(s.Ffree)
+		resultChan <- result{total: total, free: free, avail: avail, inodes: inodes, inodesFree: inodesFree, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return 0, 0, 0, 0, 0, ctx.Err()
+	case res := <-resultChan:
+		return res.total, res.free, res.avail, res.inodes, res.inodesFree, res.err
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1130,6 +1130,12 @@ github.com/google/cadvisor/container/systemd
 github.com/google/cadvisor/devicemapper
 github.com/google/cadvisor/events
 github.com/google/cadvisor/fs
+github.com/google/cadvisor/fs/overlay
+github.com/google/cadvisor/fs/overlay/install
+github.com/google/cadvisor/fs/tmpfs
+github.com/google/cadvisor/fs/tmpfs/install
+github.com/google/cadvisor/fs/vfs
+github.com/google/cadvisor/fs/vfs/install
 github.com/google/cadvisor/info/v1
 github.com/google/cadvisor/info/v2
 github.com/google/cadvisor/machine


### PR DESCRIPTION
**Description:** Fix cAdvisor filesystem plugin imports patch and add missing vendor packages.

- Remove testbed/vendor from patch (testbed/vendor is gitignored)
- Add cadvisor fs/overlay, fs/tmpfs, fs/vfs packages to vendor

**Link to tracking Issue:** Fixes CI failure from #3157

**Testing:** Patch applies cleanly via `make apply-patches`

**Documentation:** N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.