### PR TITLE
Update prometheus-daemonset.yaml

### DIFF
--- a/examples/eks/aws-prometheus/prometheus-daemonset.yaml
+++ b/examples/eks/aws-prometheus/prometheus-daemonset.yaml
@@ -53,6 +53,7 @@ data:
 
     extensions:
       health_check:
+        endpoint: :13133
       pprof:
         endpoint: :1888
       zpages:


### PR DESCRIPTION
Added the endpoint section at line 56 for healthcheck extension to point port 13133 in Adot collector configmap. Without this modification the Adot collector Daemonset Pods will fail with "CrashLoopBackOff" due to connection refused error on liveness and readiness probes.

Available in opentelemetry public doc

https://opentelemetry.io/docs/collector/configuration/#:~:text=endpoint:%200.0.0.0:13133

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
