### PR TITLE
Add ECS Fargate ephemeral storage metrics from Task Metadata Endpoint V4

### DIFF
--- a/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil/metadata.go
+++ b/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil/metadata.go
@@ -5,18 +5,25 @@ package ecsutil // import "github.com/open-telemetry/opentelemetry-collector-con
 
 // TaskMetadata defines task metadata for a task
 type TaskMetadata struct {
-	AvailabilityZone string              `json:"AvailabilityZone,omitempty"`
-	Cluster          string              `json:"Cluster,omitempty"`
-	Containers       []ContainerMetadata `json:"Containers,omitempty"`
-	Family           string              `json:"Family,omitempty"`
-	KnownStatus      string              `json:"KnownStatus,omitempty"`
-	LaunchType       string              `json:"LaunchType,omitempty"`
-	Limits           Limits              `json:"Limits,omitzero"`
-	PullStartedAt    string              `json:"PullStartedAt,omitempty"`
-	PullStoppedAt    string              `json:"PullStoppedAt,omitempty"`
-	Revision         string              `json:"Revision,omitempty"`
-	ServiceName      string              `json:"ServiceName,omitempty"`
-	TaskARN          string              `json:"TaskARN,omitempty"`
+	AvailabilityZone        string                   `json:"AvailabilityZone,omitempty"`
+	Cluster                 string                   `json:"Cluster,omitempty"`
+	Containers              []ContainerMetadata      `json:"Containers,omitempty"`
+	EphemeralStorageMetrics *EphemeralStorageMetrics `json:"EphemeralStorageMetrics,omitempty"`
+	Family                  string                   `json:"Family,omitempty"`
+	KnownStatus             string                   `json:"KnownStatus,omitempty"`
+	LaunchType              string                   `json:"LaunchType,omitempty"`
+	Limits                  Limits                   `json:"Limits,omitzero"`
+	PullStartedAt           string                   `json:"PullStartedAt,omitempty"`
+	PullStoppedAt           string                   `json:"PullStoppedAt,omitempty"`
+	Revision                string                   `json:"Revision,omitempty"`
+	ServiceName             string                   `json:"ServiceName,omitempty"`
+	TaskARN                 string                   `json:"TaskARN,omitempty"`
+}
+
+// EphemeralStorageMetrics defines ephemeral storage usage metrics for a Fargate task
+type EphemeralStorageMetrics struct {
+	Utilized int64 `json:"Utilized,omitempty"`
+	Reserved int64 `json:"Reserved,omitempty"`
 }
 
 // ContainerMetadata defines container metadata for a container

--- a/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/accumulator.go
+++ b/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/accumulator.go
@@ -47,6 +47,10 @@ func (acc *metricDataAccumulator) getMetricsData(containerStatsMap map[string]*C
 		}
 	}
 	overrideWithTaskLevelLimit(&taskMetrics, metadata)
+	if metadata.EphemeralStorageMetrics != nil {
+		taskMetrics.EphemeralStorageUtilized = metadata.EphemeralStorageMetrics.Utilized
+		taskMetrics.EphemeralStorageReserved = metadata.EphemeralStorageMetrics.Reserved
+	}
 	acc.accumulate(convertToOTLPMetrics(taskPrefix, taskMetrics, taskResource, timestamp))
 }
 

--- a/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/constant.go
+++ b/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/constant.go
@@ -58,10 +58,13 @@ const (
 	attributeStorageRead  = "storage.read_bytes"
 	attributeStorageWrite = "storage.write_bytes"
 
+	attributeEphemeralStorageUtilized = "ephemeral_storage.utilized"
+	attributeEphemeralStorageReserved = "ephemeral_storage.reserved"
+
 	attributeDuration = "duration"
 
 	unitBytes       = "Bytes"
-	unitMegaBytes   = "Megabytes"
+	unitMiB         = "MiB"
 	unitNanoSecond  = "Nanoseconds"
 	unitBytesPerSec = "Bytes/Second"
 	unitCount       = "Count"

--- a/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/ecs_metrics.go
+++ b/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/ecs_metrics.go
@@ -35,4 +35,7 @@ type ECSMetrics struct {
 
 	StorageReadBytes  uint64
 	StorageWriteBytes uint64
+
+	EphemeralStorageUtilized int64
+	EphemeralStorageReserved int64
 }

--- a/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/translator.go
+++ b/vendor/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/translator.go
@@ -20,8 +20,8 @@ func convertToOTLPMetrics(prefix string, m ECSMetrics, r pcommon.Resource, times
 	appendIntGauge(prefix+attributeMemoryUsage, unitBytes, int64(m.MemoryUsage), timestamp, ilms.AppendEmpty())
 	appendIntGauge(prefix+attributeMemoryMaxUsage, unitBytes, int64(m.MemoryMaxUsage), timestamp, ilms.AppendEmpty())
 	appendIntGauge(prefix+attributeMemoryLimit, unitBytes, int64(m.MemoryLimit), timestamp, ilms.AppendEmpty())
-	appendIntGauge(prefix+attributeMemoryUtilized, unitMegaBytes, int64(m.MemoryUtilized), timestamp, ilms.AppendEmpty())
-	appendIntGauge(prefix+attributeMemoryReserved, unitMegaBytes, int64(m.MemoryReserved), timestamp, ilms.AppendEmpty())
+	appendIntGauge(prefix+attributeMemoryUtilized, unitMiB, int64(m.MemoryUtilized), timestamp, ilms.AppendEmpty())
+	appendIntGauge(prefix+attributeMemoryReserved, unitMiB, int64(m.MemoryReserved), timestamp, ilms.AppendEmpty())
 
 	appendIntSum(prefix+attributeCPUTotalUsage, unitNanoSecond, int64(m.CPUTotalUsage), timestamp, ilms.AppendEmpty())
 	appendIntSum(prefix+attributeCPUKernelModeUsage, unitNanoSecond, int64(m.CPUUsageInKernelmode), timestamp, ilms.AppendEmpty())
@@ -47,6 +47,13 @@ func convertToOTLPMetrics(prefix string, m ECSMetrics, r pcommon.Resource, times
 
 	appendIntSum(prefix+attributeStorageRead, unitBytes, int64(m.StorageReadBytes), timestamp, ilms.AppendEmpty())
 	appendIntSum(prefix+attributeStorageWrite, unitBytes, int64(m.StorageWriteBytes), timestamp, ilms.AppendEmpty())
+
+	// Ephemeral storage metrics are only available at the task level.
+	// They represent the shared ephemeral storage for the entire Fargate task.
+	if prefix == taskPrefix {
+		appendIntGauge(prefix+attributeEphemeralStorageUtilized, unitMiB, m.EphemeralStorageUtilized, timestamp, ilms.AppendEmpty())
+		appendIntGauge(prefix+attributeEphemeralStorageReserved, unitMiB, m.EphemeralStorageReserved, timestamp, ilms.AppendEmpty())
+	}
 
 	return md
 }


### PR DESCRIPTION
## Summary

Vendor patch to add support for **EphemeralStorageMetrics** from the [ECS Task Metadata Endpoint V4](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4-fargate.html).

This is based on upstream commit [`0cf514fa0ab3`](https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/0cf514fa0ab3e7908fcda525be579250c6bd9c1b) (open-telemetry/opentelemetry-collector-contrib#46414).

## Changes

Patched the following files in `vendor/`:

- `internal/aws/ecsutil/metadata.go` — Added `EphemeralStorageMetrics` struct and field to `TaskMetadata`
- `receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/ecs_metrics.go` — Added `EphemeralStorageUtilized` and `EphemeralStorageReserved` fields to `ECSMetrics`
- `receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/accumulator.go` — Populate ephemeral storage metrics from task metadata
- `receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/constant.go` — Added metric attribute constants; fixed memory unit from `Megabytes` to `MiB`
- `receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/translator.go` — Emit ephemeral storage metrics at task level; applied `MiB` unit fix for memory metrics

## New Metrics

| Metric Name | Unit | Description |
|---|---|---|
| `container.ephemeral_storage.utilized` | MiB | Ephemeral storage used by the Fargate task |
| `container.ephemeral_storage.reserved` | MiB | Ephemeral storage reserved for the Fargate task |

> These metrics are only available at the **task level** and only for **Fargate** launch type.

## Testing

- Built and verified locally (`go build ./cmd/awscollector`)
- Docker image built and published: `ghcr.io/neilkuan/aws-otel-collector/aws-otel-collector:fixed`
