### PR TITLE
use dockerhub OAT

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -70,8 +70,8 @@ jobs:
       - name: Login Dockerhub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_OAT_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_OAT_SECRET }}
 
       - name: Download candidate
         run: aws s3 cp "s3://aws-otel-collector-release-candidate/${{ steps.set-input-vars.outputs.sha }}.tar.gz" candidate.tar.gz
@@ -177,8 +177,8 @@ jobs:
         if: steps.release-version-image.outputs.cache-hit != 'true'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_OAT_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_OAT_SECRET }}
 
       - name: Pull image from integration test ECR and Upload to public release ECR and Dockerhub
         if: steps.release-version-image.outputs.cache-hit != 'true'

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -197,8 +197,8 @@ jobs:
       - name: Login to Dockerhub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_OAT_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_OAT_SECRET }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Switched the DockerHub authentication in `CD.yml` and `rollback.yml` to use new OAT-based credentials `DOCKERHUB_OAT_USERNAME / DOCKERHUB_OAT_SECRET` in place of the previously referenced credentials.

**Link to tracking Issue:** 
NA

**Testing:**
No code logic changed

**Documentation:**
None required — internal workflow credential update with no user-facing impact.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
