### PR TITLE
fix: reduce CI concurrency to prevent subnet IP exhaustion

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ env:
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   GITHB_RUN_ID: ${{ github.run_id }}
   DDB_TABLE_NAME: BatchTestCache
-  MAX_JOBS: 110
+  MAX_JOBS: 50
   BATCH_INCLUDED_SERVICES: EKS,ECS,EC2,EKS_ARM64,EKS_FARGATE
   GO_VERSION: ~1.26.2
 


### PR DESCRIPTION
Reduce MAX_JOBS from 110 to 50 to prevent `InsufficientFreeAddressesInSubnet` errors during CI.

With 110 concurrent batch jobs, EC2 and ECS tests exhaust all 3 public subnets' IP addresses simultaneously. Each EC2 test creates 2 instances, and ECS tests create load balancers and EFS mounts — all consuming subnet IPs. Reducing to 50 batches keeps concurrency within subnet capacity.

Tradeoff: each batch contains more test cases, so the CI run takes longer but completes reliably.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.