### PR TITLE
fix: CI stability — restore concurrency, add timeouts and visibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -700,6 +700,10 @@ jobs:
 
       - name: run tests
         run: |
+          echo "## Batch ${{ matrix.BatchKey }} Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Service | Testcase | Status | Duration |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|----------|--------|----------|" >> $GITHUB_STEP_SUMMARY
           export TTL_DATE=${{ steps.date.outputs.ttldate }}
           export TF_VAR_aoc_version=${{ needs.e2etest-preparation.outputs.version }}
           cd testing-framework/terraform

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,11 +95,8 @@ jobs:
       - name: Set testRef output
         id: setRef
         run: |
-          if [[ ${{ github.ref_name }} == release/v* ]]; then 
-            echo "ref=${{github.ref_name}}" >> $GITHUB_OUTPUT
-          else
-            echo "ref=terraform" >> $GITHUB_OUTPUT
-          fi
+          # TODO: revert before merging to release/v0.48.x
+          echo "ref=fix/vpc-tf-version" >> $GITHUB_OUTPUT
 
   build-aotutil:
     runs-on: ubuntu-22.04

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ env:
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   GITHB_RUN_ID: ${{ github.run_id }}
   DDB_TABLE_NAME: BatchTestCache
-  MAX_JOBS: 50
+  MAX_JOBS: 110
   BATCH_INCLUDED_SERVICES: EKS,ECS,EC2,EKS_ARM64,EKS_FARGATE
   GO_VERSION: ~1.26.2
 
@@ -651,6 +651,7 @@ jobs:
 
   run-batch-job:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref, build-aotutil]
     strategy:
       fail-fast: false
@@ -838,7 +839,19 @@ jobs:
         run: |
           export TF_VAR_aoc_version=${{ needs.e2etest-preparation.outputs.version }}
           cd testing-framework/terraform
+          rm -f ./.cache-misses
           make checkCacheHits
+
+      - name: surface cache-miss list (always)
+        if: always()
+        run: |
+          if [ -s testing-framework/terraform/.cache-misses ]; then
+            echo "## Cache misses (testcases without a green DynamoDB record)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat testing-framework/terraform/.cache-misses >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi
 
   release-candidate:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary
- Restore `MAX_JOBS` from 50 to 110 (leaked instances terminated; test-framework PR prevents recurrence)
- Add `timeout-minutes: 120` on `run-batch-job` to cap runaway batches
- Surface cache-miss list in GitHub step summary on `validate-all-tests-pass`
- Add per-testcase step summary table (service, testcase, pass/fail, duration)
- Hardcode test-framework ref to `fix/vpc-tf-version` for validation (revert before merge)

## Test plan
- [ ] CI run completes with 110 parallel batches without IP exhaustion
- [ ] Batches exceeding 2hr are killed
- [ ] Step summary shows testcase results table
- [ ] Cache-miss list appears on validate-all-tests-pass summary
- [ ] Revert hardcoded ref before final merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)