### PR TITLE
fix: CI stability — restore concurrency, fix EKS/ECS/EC2 test infra

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -700,6 +700,10 @@ jobs:
 
       - name: run tests
         run: |
+          echo "## Batch ${{ matrix.BatchKey }} Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Service | Testcase | Status | Duration |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|----------|--------|----------|" >> $GITHUB_STEP_SUMMARY
           export TTL_DATE=${{ steps.date.outputs.ttldate }}
           export TF_VAR_aoc_version=${{ needs.e2etest-preparation.outputs.version }}
           cd testing-framework/terraform

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -553,6 +553,21 @@ jobs:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2
 
+      - name: ensure security group ports
+        run: |
+          SG_ID="sg-0bb18e38fc7a9285b"
+          EXISTING=$(aws ec2 describe-security-groups --group-ids $SG_ID --query 'SecurityGroups[0].IpPermissions[?IpRanges[?CidrIp==`0.0.0.0/0`]].FromPort' --output text)
+          for PORT in 80 443 4317 4567 5985 8080 9411 55671; do
+            if ! echo "$EXISTING" | grep -qw $PORT; then
+              echo "Adding TCP $PORT to $SG_ID"
+              aws ec2 authorize-security-group-ingress --group-id $SG_ID --protocol tcp --port $PORT --cidr 0.0.0.0/0
+            fi
+          done
+          if ! echo "$EXISTING" | grep -qw 55690; then
+            echo "Adding UDP 55690 to $SG_ID"
+            aws ec2 authorize-security-group-ingress --group-id $SG_ID --protocol udp --port 55690 --cidr 0.0.0.0/0 || true
+          fi
+
       - name: Login to Public Integration Test ECR
         if: steps.e2etest-release.outputs.cache-hit != 'true'
         uses: docker/login-action@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,11 +95,8 @@ jobs:
       - name: Set testRef output
         id: setRef
         run: |
-          if [[ ${{ github.ref_name }} == release/v* ]]; then 
-            echo "ref=${{github.ref_name}}" >> $GITHUB_OUTPUT
-          else
-            echo "ref=terraform" >> $GITHUB_OUTPUT
-          fi
+          # TODO: revert before merging to release/v0.48.x
+          echo "ref=fix/vpc-tf-version" >> $GITHUB_OUTPUT
 
   build-aotutil:
     runs-on: ubuntu-22.04

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -685,7 +685,7 @@ jobs:
       - name: create test-case-batch file
         run: |
           jsonStr='${{ needs.get-testing-suites.outputs.test-case-batch-value }}'
-          jsonStr="$(jq -r '.${{ matrix.BatchKey }} | join("\n")' <<< "${jsonStr}")"
+          jsonStr="$(jq -r '.["${{ matrix.BatchKey }}"] | join("\n")' <<< "${jsonStr}")"
           echo "$jsonStr" >> testing-framework/terraform/test-case-batch
           cat testing-framework/terraform/test-case-batch
       - name: Get TTL_DATE for cache

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ env:
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   GITHB_RUN_ID: ${{ github.run_id }}
   DDB_TABLE_NAME: BatchTestCache
-  MAX_JOBS: 50
+  MAX_JOBS: 110
   BATCH_INCLUDED_SERVICES: EKS,ECS,EC2,EKS_ARM64,EKS_FARGATE
   GO_VERSION: ~1.26.2
 
@@ -651,6 +651,7 @@ jobs:
 
   run-batch-job:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref, build-aotutil]
     strategy:
       fail-fast: false
@@ -838,7 +839,19 @@ jobs:
         run: |
           export TF_VAR_aoc_version=${{ needs.e2etest-preparation.outputs.version }}
           cd testing-framework/terraform
+          rm -f ./.cache-misses
           make checkCacheHits
+
+      - name: surface cache-miss list (always)
+        if: always()
+        run: |
+          if [ -s testing-framework/terraform/.cache-misses ]; then
+            echo "## Cache misses (testcases without a green DynamoDB record)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat testing-framework/terraform/.cache-misses >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi
 
   release-candidate:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary
- Restore `MAX_JOBS` to 110 (instance leaks fixed in test-framework PR)
- Add `timeout-minutes: 120` on batch jobs
- Add SG port drift pre-check (prevents silent failures from missing ports)
- Platform-grouped batch generation (`EC2/0`, `EKS/3`, `ECS/7`)
- Per-testcase step summary table with pass/fail/duration
- Surface cache-miss list on validate-all-tests-pass
- Quote batch keys for jq compatibility
- Hardcode test-framework ref to `fix/vpc-tf-version` (**revert before merge**)

## Companion test-framework PR
Branch: `fix/vpc-tf-version` on `aws-observability/aws-otel-test-framework`

Key changes:
- Docker compose v1 → v2 (with plugin install on EC2 sidecar)
- EKS exec-based auth (fixes 15-min token expiry)
- NLB annotation (36s provisioning vs 15-20min Classic ELB)
- Validator kubeconfig fresh token (fixes Fargate)
- Subnet dedup for ALB/EFS (fixes ECS same-AZ error)
- 4th public subnet for EC2 IP capacity
- Signal trap to prevent instance leaks on cancel
- terraform init before destroy in cleanup
- Parallel EC2 wait-patch
- Platform-grouped batch generator (no mixed-platform batches)
- X-Ray trace retry 5 → 10
- RetryHelper logs exception reason
- Apply timeout 45m → 30m, retries 2 → 1
- Collapsible log groups + timestamps

## Test results (run 25816284079)
- **EC2**: Passing across all AMIs (x86 + ARM)
- **ECS**: Fix pushed (subnet dedup), not in that run
- **EKS**: Fix pushed (exec auth + NLB + node scaling), not in that run
- **Next run**: Expected ~90%+ pass rate

## Test plan
- [ ] EC2 tests pass (confirmed)
- [ ] ECS tests pass (subnet dedup fix)
- [ ] EKS tests pass (exec auth + NLB + scaled nodes)
- [ ] EKS_FARGATE passes (fresh token kubeconfig)
- [ ] SG pre-check adds missing ports
- [ ] Step summary visible on batch jobs
- [ ] Revert hardcoded ref before final merge

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.