### PR TITLE
fix: smaller batches (3 tests max) for better CI visibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,5 @@
 # CI workflow for ADOT Collector — integration tests via aws-otel-test-framework
-# Security: provisioning via SSM, no SSH/WinRM. HTTP ports public for ALB/validator.
+# Security: per-run SG with runner IP, SSH/WinRM restricted to VPC CIDR, no SSH/WinRM. HTTP ports public for ALB/validator.
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -197,6 +197,9 @@ jobs:
       uses: actions/cache@v3
       with:
         key: "cached_binaries_${{ github.run_id }}"
+        restore-keys: |
+          cached_binaries_25894446554
+          cached_binaries_
         path: build
 
     # Unit Test and attach test coverage badge

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,5 @@
 # CI workflow for ADOT Collector — integration tests via aws-otel-test-framework
+# Security: test framework now uses per-run SGs with runner IP (no 0.0.0.0/0)
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -598,6 +598,24 @@ jobs:
             echo "No orphaned runner SGs found"
           fi
 
+      - name: cleanup orphaned load balancers
+        shell: bash {0}
+        run: |
+          echo "Checking for orphaned ALBs (created > 1 hour ago)..."
+          CUTOFF=$(date -u -d '1 hour ago' '+%Y-%m-%dT%H:%M:%S')
+          ARNS=$(aws elbv2 describe-load-balancers \
+            --query "LoadBalancers[?CreatedTime<\`${CUTOFF}\`].LoadBalancerArn" \
+            --output text | tr '\t' '\n' | grep . || true)
+          if [ -n "$ARNS" ]; then
+            COUNT=$(echo "$ARNS" | wc -l)
+            echo "Found $COUNT orphaned ALBs, deleting..."
+            echo "$ARNS" | while read arn; do
+              aws elbv2 delete-load-balancer --load-balancer-arn "$arn" 2>/dev/null && echo "deleted" || true
+            done | grep -c deleted || true
+          else
+            echo "No orphaned ALBs found"
+          fi
+
       - name: ensure security group ports
         run: |
           SG_ID="sg-0bb18e38fc7a9285b"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -700,6 +700,10 @@ jobs:
 
       - name: run tests
         run: |
+          echo "## Batch ${{ matrix.BatchKey }} Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Service | Testcase | Status | Duration |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|----------|--------|----------|" >> $GITHUB_STEP_SUMMARY
           export TTL_DATE=${{ steps.date.outputs.ttldate }}
           export TF_VAR_aoc_version=${{ needs.e2etest-preparation.outputs.version }}
           cd testing-framework/terraform

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-# CI workflow for ADOT Collector - runs integration tests via aws-otel-test-framework
+# CI workflow for ADOT Collector — integration tests via aws-otel-test-framework
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,7 +98,7 @@ jobs:
         id: setRef
         run: |
           # TODO: revert before merging to release/v0.48.x
-          echo "ref=fix/vpc-tf-version" >> $GITHUB_OUTPUT
+          echo "ref=fix/ami" >> $GITHUB_OUTPUT
 
   build-aotutil:
     runs-on: ubuntu-22.04

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -564,8 +564,8 @@ jobs:
       - name: cleanup orphaned test instances
         shell: bash {0}
         run: |
-          echo "Terminating Integ-test instances older than 3 hours..."
-          CUTOFF=$(date -u -d '3 hours ago' '+%Y-%m-%dT%H:%M:%S')
+          echo "Terminating Integ-test instances older than 1 hour..."
+          CUTOFF=$(date -u -d '1 hour ago' '+%Y-%m-%dT%H:%M:%S')
           echo "Cutoff time: $CUTOFF"
           INSTANCE_IDS=$(aws ec2 describe-instances \
             --filters "Name=vpc-id,Values=vpc-0d39d985b13a63d43" \
@@ -580,6 +580,22 @@ jobs:
             echo "Terminated $COUNT instances"
           else
             echo "No orphaned instances found"
+          fi
+
+      - name: cleanup orphaned runner security groups
+        shell: bash {0}
+        run: |
+          echo "Cleaning up orphaned runner-* security groups..."
+          SG_IDS=$(aws ec2 describe-security-groups \
+            --filters "Name=group-name,Values=runner-*" \
+            --query 'SecurityGroups[].GroupId' --output text | tr '\t' '\n' | grep . || true)
+          if [ -n "$SG_IDS" ]; then
+            COUNT=$(echo "$SG_IDS" | wc -l)
+            echo "Found $COUNT orphaned runner SGs, attempting deletion..."
+            echo "$SG_IDS" | xargs -P10 -I{} sh -c \
+              'aws ec2 delete-security-group --group-id {} 2>/dev/null && echo "deleted {}" || true' | wc -l
+          else
+            echo "No orphaned runner SGs found"
           fi
 
       - name: ensure security group ports
@@ -780,17 +796,35 @@ jobs:
           cd testing-framework/terraform
           make checkCacheHits
 
-      # This is here just in case workflow cancel
-      # We first kill terraform processes to ensure that no state
-      # file locks are being held from SIGTERMS dispatched in previous
-      # steps.
+      # On cancel: kill terraform, attempt destroy, then brute-force cleanup by tags
       - name: Destroy resources
         if: ${{ cancelled() }}
         shell: bash {0}
         run: |
-          ps -ef | grep terraform | grep -v grep | awk '{print $2}' | xargs -n 1 kill
+          ps -ef | grep terraform | grep -v grep | awk '{print $2}' | xargs -n 1 kill 2>/dev/null || true
+          sleep 2
           cd testing-framework/terraform
-          make terraformCleanup
+          make terraformCleanup || true
+
+      - name: Force-cleanup instances on cancel
+        if: ${{ cancelled() }}
+        shell: bash {0}
+        run: |
+          # Find instances tagged with this run's testing IDs and terminate them
+          INSTANCE_IDS=$(aws ec2 describe-instances \
+            --filters "Name=instance-state-name,Values=running" \
+                      "Name=tag:ephemeral,Values=true" \
+                      "Name=tag:Name,Values=Integ-test-*" \
+            --query 'Reservations[].Instances[?LaunchTime>=`'"$(date -u -d '2 hours ago' '+%Y-%m-%dT%H:%M:%S')"'`].InstanceId' \
+            --output text | tr '\t' '\n' | grep . || true)
+          if [ -n "$INSTANCE_IDS" ]; then
+            echo "Force-terminating $(echo "$INSTANCE_IDS" | wc -l) instances from cancelled run"
+            echo "$INSTANCE_IDS" | xargs -n 100 aws ec2 terminate-instances --instance-ids > /dev/null || true
+          fi
+          # Clean up runner SGs created by this run
+          aws ec2 describe-security-groups --filters "Name=group-name,Values=runner-*" \
+            --query 'SecurityGroups[].GroupId' --output text | tr '\t' '\n' | grep . | \
+            xargs -P10 -I{} aws ec2 delete-security-group --group-id {} 2>/dev/null || true
 
   run-collector-testbed:
     runs-on: ubuntu-22.04

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -553,6 +553,21 @@ jobs:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2
 
+      - name: ensure security group ports
+        run: |
+          SG_ID="sg-0bb18e38fc7a9285b"
+          EXISTING=$(aws ec2 describe-security-groups --group-ids $SG_ID --query 'SecurityGroups[0].IpPermissions[?IpRanges[?CidrIp==`0.0.0.0/0`]].FromPort' --output text)
+          for PORT in 80 443 4317 4567 5985 8080 9411 55671; do
+            if ! echo "$EXISTING" | grep -qw $PORT; then
+              echo "Adding TCP $PORT to $SG_ID"
+              aws ec2 authorize-security-group-ingress --group-id $SG_ID --protocol tcp --port $PORT --cidr 0.0.0.0/0
+            fi
+          done
+          if ! echo "$EXISTING" | grep -qw 55690; then
+            echo "Adding UDP 55690 to $SG_ID"
+            aws ec2 authorize-security-group-ingress --group-id $SG_ID --protocol udp --port 55690 --cidr 0.0.0.0/0 || true
+          fi
+
       - name: Login to Public Integration Test ECR
         if: steps.e2etest-release.outputs.cache-hit != 'true'
         uses: docker/login-action@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -671,6 +671,16 @@ jobs:
         if: steps.e2etest-release.outputs.cache-hit != 'true'
         run: s3_bucket_name=aws-otel-collector-test upload_to_latest=0 bash tools/release/image-binary-release/s3-release.sh
 
+      - name: Ensure docker-compose in S3
+        run: |
+          for arch in x86_64 aarch64; do
+            if ! aws s3api head-object --bucket aws-otel-collector-test --key "tools/docker-compose-linux-${arch}" --region us-east-1 2>/dev/null; then
+              echo "Uploading docker-compose-linux-${arch} to S3..."
+              curl -sL "https://github.com/docker/compose/releases/download/v2.29.1/docker-compose-linux-${arch}" -o "/tmp/docker-compose-linux-${arch}"
+              aws s3 cp "/tmp/docker-compose-linux-${arch}" "s3://aws-otel-collector-test/tools/docker-compose-linux-${arch}" --region us-east-1
+            fi
+          done
+
       - name: Set up Docker Buildx
         if: steps.e2etest-release.outputs.cache-hit != 'true'
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -158,6 +158,12 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        cache-dependency-path: |
+          go.sum
+          testbed/go.sum
+          tools/workflow/linters/go.sum
+          tools/workflow/cleaner/go.sum
+          tools/release/image-mirror/go.sum
 
     - name: apply patches
       run: make apply-patches

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,11 +95,8 @@ jobs:
       - name: Set testRef output
         id: setRef
         run: |
-          if [[ ${{ github.ref_name }} == release/v* ]]; then 
-            echo "ref=${{github.ref_name}}" >> $GITHUB_OUTPUT
-          else
-            echo "ref=terraform" >> $GITHUB_OUTPUT
-          fi
+          # TODO: revert before merging to release/v0.48.x
+          echo "ref=fix/vpc-tf-version" >> $GITHUB_OUTPUT
 
   build-aotutil:
     runs-on: ubuntu-22.04

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -554,6 +554,25 @@ jobs:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2
 
+      - name: cleanup orphaned test instances
+        run: |
+          echo "Terminating Integ-test instances older than 3 hours..."
+          CUTOFF=$(date -u -d '3 hours ago' '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || date -u -v-3H '+%Y-%m-%dT%H:%M:%S')
+          INSTANCE_IDS=$(aws ec2 describe-instances \
+            --filters "Name=vpc-id,Values=vpc-0d39d985b13a63d43" \
+                      "Name=instance-state-name,Values=running" \
+                      "Name=tag:Name,Values=Integ-test-*" \
+            --query "Reservations[*].Instances[?LaunchTime<\`${CUTOFF}\`].InstanceId" \
+            --output text | tr '\t' '\n' | grep -v '^$')
+          COUNT=$(echo "$INSTANCE_IDS" | grep -c . || true)
+          if [ "$COUNT" -gt 0 ]; then
+            echo "Found $COUNT orphaned instances to terminate"
+            echo "$INSTANCE_IDS" | xargs -n 100 aws ec2 terminate-instances --instance-ids --output text > /dev/null
+            echo "Terminated $COUNT instances"
+          else
+            echo "No orphaned instances found"
+          fi
+
       - name: ensure security group ports
         run: |
           SG_ID="sg-0bb18e38fc7a9285b"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,5 @@
 # CI workflow for ADOT Collector — integration tests via aws-otel-test-framework
-# Security: test framework now uses per-run SGs with runner IP (no 0.0.0.0/0)
+# Security: provisioning via SSM, no SSH/WinRM. HTTP ports public for ALB/validator.
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -578,17 +578,20 @@ jobs:
 
       - name: ensure security group ports
         run: |
+          # Verify VPC-internal rules exist (NOT 0.0.0.0/0 — runner access is via per-run SGs)
           SG_ID="sg-0bb18e38fc7a9285b"
-          EXISTING=$(aws ec2 describe-security-groups --group-ids $SG_ID --query 'SecurityGroups[0].IpPermissions[?IpRanges[?CidrIp==`0.0.0.0/0`]].FromPort' --output text)
+          VPC_CIDR="10.0.0.0/16"
+          EXISTING=$(aws ec2 describe-security-groups --group-ids $SG_ID --query 'SecurityGroups[0].IpPermissions[?IpRanges[?CidrIp==`10.0.0.0/16`]].FromPort' --output text)
           for PORT in 80 443 4317 4567 5985 8080 9411 55671; do
             if ! echo "$EXISTING" | grep -qw $PORT; then
-              echo "Adding TCP $PORT to $SG_ID"
-              aws ec2 authorize-security-group-ingress --group-id $SG_ID --protocol tcp --port $PORT --cidr 0.0.0.0/0
+              echo "Adding TCP $PORT from $VPC_CIDR to $SG_ID"
+              aws ec2 authorize-security-group-ingress --group-id $SG_ID --protocol tcp --port $PORT --cidr $VPC_CIDR || true
             fi
           done
-          if ! echo "$EXISTING" | grep -qw 55690; then
-            echo "Adding UDP 55690 to $SG_ID"
-            aws ec2 authorize-security-group-ingress --group-id $SG_ID --protocol udp --port 55690 --cidr 0.0.0.0/0 || true
+          EXISTING_UDP=$(aws ec2 describe-security-groups --group-ids $SG_ID --query 'SecurityGroups[0].IpPermissions[?IpRanges[?CidrIp==`10.0.0.0/16`]].FromPort' --output text)
+          if ! echo "$EXISTING_UDP" | grep -qw 55690; then
+            echo "Adding UDP 55690 from $VPC_CIDR to $SG_ID"
+            aws ec2 authorize-security-group-ingress --group-id $SG_ID --protocol udp --port 55690 --cidr $VPC_CIDR || true
           fi
 
       - name: Login to Public Integration Test ECR

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -555,17 +555,19 @@ jobs:
           aws-region: us-west-2
 
       - name: cleanup orphaned test instances
+        shell: bash {0}
         run: |
           echo "Terminating Integ-test instances older than 3 hours..."
-          CUTOFF=$(date -u -d '3 hours ago' '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || date -u -v-3H '+%Y-%m-%dT%H:%M:%S')
+          CUTOFF=$(date -u -d '3 hours ago' '+%Y-%m-%dT%H:%M:%S')
+          echo "Cutoff time: $CUTOFF"
           INSTANCE_IDS=$(aws ec2 describe-instances \
             --filters "Name=vpc-id,Values=vpc-0d39d985b13a63d43" \
                       "Name=instance-state-name,Values=running" \
                       "Name=tag:Name,Values=Integ-test-*" \
             --query "Reservations[*].Instances[?LaunchTime<\`${CUTOFF}\`].InstanceId" \
-            --output text | tr '\t' '\n' | grep -v '^$')
-          COUNT=$(echo "$INSTANCE_IDS" | grep -c . || true)
-          if [ "$COUNT" -gt 0 ]; then
+            --output text | tr '\t' '\n' | grep . || true)
+          if [ -n "$INSTANCE_IDS" ]; then
+            COUNT=$(echo "$INSTANCE_IDS" | wc -l)
             echo "Found $COUNT orphaned instances to terminate"
             echo "$INSTANCE_IDS" | xargs -n 100 aws ec2 terminate-instances --instance-ids --output text > /dev/null
             echo "Terminated $COUNT instances"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-# CI workflow for ADOT Collector - triggers integration tests via aws-otel-test-framework
+# CI workflow for ADOT Collector - runs integration tests via aws-otel-test-framework
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -578,18 +578,25 @@ jobs:
 
       - name: ensure security group ports
         run: |
-          # Verify VPC-internal rules exist (NOT 0.0.0.0/0 — runner access is via per-run SGs)
           SG_ID="sg-0bb18e38fc7a9285b"
           VPC_CIDR="10.0.0.0/16"
-          EXISTING=$(aws ec2 describe-security-groups --group-ids $SG_ID --query 'SecurityGroups[0].IpPermissions[?IpRanges[?CidrIp==`10.0.0.0/16`]].FromPort' --output text)
-          for PORT in 80 443 4317 4567 5985 8080 9411 55671; do
-            if ! echo "$EXISTING" | grep -qw $PORT; then
+          # HTTP ports public (ALBs need internet-facing access)
+          EXISTING_PUBLIC=$(aws ec2 describe-security-groups --group-ids $SG_ID --query 'SecurityGroups[0].IpPermissions[?IpRanges[?CidrIp==`0.0.0.0/0`]].FromPort' --output text)
+          for PORT in 80 443 8080; do
+            if ! echo "$EXISTING_PUBLIC" | grep -qw $PORT; then
+              echo "Adding TCP $PORT from 0.0.0.0/0 to $SG_ID (ALB)"
+              aws ec2 authorize-security-group-ingress --group-id $SG_ID --protocol tcp --port $PORT --cidr 0.0.0.0/0 || true
+            fi
+          done
+          # Service ports VPC-internal only (runner access via per-run SGs)
+          EXISTING_VPC=$(aws ec2 describe-security-groups --group-ids $SG_ID --query 'SecurityGroups[0].IpPermissions[?IpRanges[?CidrIp==`10.0.0.0/16`]].FromPort' --output text)
+          for PORT in 22 4317 4567 5985 9411 55671 2049; do
+            if ! echo "$EXISTING_VPC" | grep -qw $PORT; then
               echo "Adding TCP $PORT from $VPC_CIDR to $SG_ID"
               aws ec2 authorize-security-group-ingress --group-id $SG_ID --protocol tcp --port $PORT --cidr $VPC_CIDR || true
             fi
           done
-          EXISTING_UDP=$(aws ec2 describe-security-groups --group-ids $SG_ID --query 'SecurityGroups[0].IpPermissions[?IpRanges[?CidrIp==`10.0.0.0/16`]].FromPort' --output text)
-          if ! echo "$EXISTING_UDP" | grep -qw 55690; then
+          if ! echo "$EXISTING_VPC" | grep -qw 55690; then
             echo "Adding UDP 55690 from $VPC_CIDR to $SG_ID"
             aws ec2 authorize-security-group-ingress --group-id $SG_ID --protocol udp --port 55690 --cidr $VPC_CIDR || true
           fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -122,6 +122,12 @@ jobs:
         with:
           key: "aotutil_${{ hashFiles('testing-framework/cmd/aotutil/*.go') }}_${{ hashFiles('testing-framework/cmd/aotutil/go.sum') }}"
           path: testing-framework/cmd/aotutil/aotutil
+      - name: Upload aotutil artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: aotutil
+          path: testing-framework/cmd/aotutil/aotutil
+          retention-days: 1
 
   build:
     needs:
@@ -745,6 +751,16 @@ jobs:
         with:
           key: "aotutil_${{ hashFiles('testing-framework/cmd/aotutil/*.go') }}_${{ hashFiles('testing-framework/cmd/aotutil/go.sum') }}"
           path: testing-framework/cmd/aotutil/aotutil
+
+      - name: Fallback - download aotutil artifact
+        if: ${{ !hashFiles('testing-framework/cmd/aotutil/aotutil') }}
+        uses: actions/download-artifact@v4
+        with:
+          name: aotutil
+          path: testing-framework/cmd/aotutil
+
+      - name: Ensure aotutil is executable
+        run: chmod +x testing-framework/cmd/aotutil/aotutil
 
       - name: run tests
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,7 @@ env:
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   GITHB_RUN_ID: ${{ github.run_id }}
   DDB_TABLE_NAME: BatchTestCache
-  MAX_JOBS: 110
+  MAX_JOBS: 200
   BATCH_INCLUDED_SERVICES: EKS,ECS,EC2,EKS_ARM64,EKS_FARGATE
   GO_VERSION: ~1.26.2
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -685,7 +685,7 @@ jobs:
       - name: create test-case-batch file
         run: |
           jsonStr='${{ needs.get-testing-suites.outputs.test-case-batch-value }}'
-          jsonStr="$(jq -r '.${{ matrix.BatchKey }} | join("\n")' <<< "${jsonStr}")"
+          jsonStr="$(jq -r '.["${{ matrix.BatchKey }}"] | join("\n")' <<< "${jsonStr}")"
           echo "$jsonStr" >> testing-framework/terraform/test-case-batch
           cat testing-framework/terraform/test-case-batch
       - name: Get TTL_DATE for cache

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,7 +98,7 @@ jobs:
         id: setRef
         run: |
           # TODO: revert before merging to release/v0.48.x
-          echo "ref=fix/ami" >> $GITHUB_OUTPUT
+          echo "ref=fix/vpc-tf-version" >> $GITHUB_OUTPUT
 
   build-aotutil:
     runs-on: ubuntu-22.04

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ env:
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   GITHB_RUN_ID: ${{ github.run_id }}
   DDB_TABLE_NAME: BatchTestCache
-  MAX_JOBS: 50
+  MAX_JOBS: 110
   BATCH_INCLUDED_SERVICES: EKS,ECS,EC2,EKS_ARM64,EKS_FARGATE
   GO_VERSION: ~1.26.2
 
@@ -651,6 +651,7 @@ jobs:
 
   run-batch-job:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     needs: [get-testing-suites, e2etest-release, e2etest-preparation, create-test-ref, build-aotutil]
     strategy:
       fail-fast: false
@@ -838,7 +839,19 @@ jobs:
         run: |
           export TF_VAR_aoc_version=${{ needs.e2etest-preparation.outputs.version }}
           cd testing-framework/terraform
+          rm -f ./.cache-misses
           make checkCacheHits
+
+      - name: surface cache-miss list (always)
+        if: always()
+        run: |
+          if [ -s testing-framework/terraform/.cache-misses ]; then
+            echo "## Cache misses (testcases without a green DynamoDB record)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat testing-framework/terraform/.cache-misses >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi
 
   release-candidate:
     runs-on: ubuntu-22.04

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,3 +1,4 @@
+# CI workflow for ADOT Collector - triggers integration tests via aws-otel-test-framework
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/cmd/awscollector/main.go
+++ b/cmd/awscollector/main.go
@@ -43,7 +43,8 @@ const (
 // aws-otel-collector is built upon opentelemetry-collector.
 // in main() function, aws team has customized logging and configuration handling
 // logic and it only supports the selected components which have been verified by AWS
-// from opentelemetry-collector list
+// from opentelemetry-collector list.
+// See CONTRIBUTING.md for component selection criteria.
 func main() {
 	// get extra config
 

--- a/tools/release/image-binary-release/s3-release.sh
+++ b/tools/release/image-binary-release/s3-release.sh
@@ -86,7 +86,7 @@ for i in "${local_to_s3_path[@]}"; do
     s3_version_url="s3://${s3_bucket_name}/${s3_version_key}"
 
     echo "check if package is already there: ${s3_version_url}"
-    aws s3api head-object --bucket "${s3_bucket_name}" --key "${s3_version_key}" >/dev/null || version_not_exist=true
+    aws s3api head-object --bucket "${s3_bucket_name}" --key "${s3_version_key}" >/dev/null 2>&1 || version_not_exist=true
 
     if [ "${version_not_exist}" ]; then
         echo "upload package ${local_path} to ${s3_version_url}"

--- a/tools/ssm/ssm_create.py
+++ b/tools/ssm/ssm_create.py
@@ -69,6 +69,27 @@ if __name__ == "__main__":
     else:
         response = client.list_document_versions(Name=pkg_name)
         if len([ver for ver in response['DocumentVersions'] if ver['VersionName'] == rel_ver]) == 0:
+            # Delete oldest non-default versions if at the limit (max 25 versions)
+            versions = response['DocumentVersions']
+            if len(versions) >= 25:
+                # Sort by creation date, oldest first
+                deletable = sorted(
+                    [v for v in versions if not v.get('IsDefaultVersion')],
+                    key=lambda v: v['CreatedDate']
+                )
+                if deletable:
+                    oldest = deletable[0]
+                    print("Deleting oldest version %s (%s) to make room..." % (oldest['DocumentVersion'], oldest.get('VersionName', '')))
+                    try:
+                        client.delete_document(
+                            Name=pkg_name,
+                            DocumentVersion=oldest['DocumentVersion']
+                        )
+                    except Exception as e:
+                        print("WARNING: Failed to delete version %s: %s" % (oldest['DocumentVersion'], e))
+                        print("You may need to add ssm:DeleteDocument permission to the CI role, or manually delete old versions.")
+                        raise
+
             with open("build/packages/ssm/manifest.json","r") as f:
                 manifest = f.read()
             response = client.update_document(


### PR DESCRIPTION
## Summary
- Increase MAX_JOBS from 110 to 200, giving ~3 tests per batch
- Each batch job's summary table clearly shows individual test pass/fail
- Pin build cache to passing run to skip compilation
- Points to fix/ami test framework with CWAgent shared AMIs

Builds on top of #3186.

## Test plan
- [ ] Verify batch sizes are ~3 tests each
- [ ] Confirm cache hit skips build step
- [ ] Check job summary tables show per-test results