### PR TITLE
test: fix datadog_exporter_metric_mock flakiness via batch processor tuning

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,7 +98,7 @@ jobs:
           if [[ ${{ github.ref_name }} == release/v* ]]; then 
             echo "ref=${{github.ref_name}}" >> $GITHUB_OUTPUT
           else
-            echo "ref=terraform" >> $GITHUB_OUTPUT
+            echo "ref=fix/datadog-integ-flaky" >> $GITHUB_OUTPUT
           fi
 
   build-aotutil:


### PR DESCRIPTION
**Description:** Points CI at test-framework branch `fix/datadog-integ-flaky` which tunes the batch processor config for `datadog_exporter_metric_mock` test case.

The test is flaky across all 6 platforms (EC2, ECS, EKS, EKS_ARM64, LOCAL, PERF) because the default batch processor settings delay the first metric export, causing the mock server validator to time out (10 retries × 20s = 200s window).

Fix: set `send_batch_size: 1` and `timeout: 1s` in the test otconfig template so metrics flush immediately to the mock server.

**Link to tracking Issue:** Pre-existing flaky test (~14 known failures per CI run)

**Testing:** This PR triggers a CI run using the fixed test-framework branch. If datadog_exporter_metric_mock passes consistently, the fix will be PR'd into the test-framework `terraform` branch and this CI override reverted.

**Documentation:** N/A

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.