### PR TITLE
fix: quote batch key for jq compatibility with platform-grouped names

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Set testRef output
         id: setRef
         run: |
-          if [[ ${{ github.ref_name }} == release/v* ]]; then 
+          if [[ ${{ github.ref_name }} == release/v* ]]; then
             echo "ref=${{github.ref_name}}" >> $GITHUB_OUTPUT
           else
             echo "ref=terraform" >> $GITHUB_OUTPUT

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -687,7 +687,7 @@ jobs:
       - name: create test-case-batch file
         run: |
           jsonStr='${{ needs.get-testing-suites.outputs.test-case-batch-value }}'
-          jsonStr="$(jq -r '.${{ matrix.BatchKey }} | join("\n")' <<< "${jsonStr}")"
+          jsonStr="$(jq -r '.["${{ matrix.BatchKey }}"] | join("\n")' <<< "${jsonStr}")"
           echo "$jsonStr" >> testing-framework/terraform/test-case-batch
           cat testing-framework/terraform/test-case-batch
       - name: Get TTL_DATE for cache


### PR DESCRIPTION
**Details:**
The batch generator now produces keys with slashes (e.g., EC2/amazonlinux2/3). The jq expression .${{ matrix.BatchKey }} fails on these because jq interprets / as division. 

**Fix:**
Use .["${{ matrix.BatchKey }}"] bracket notation.

Pairs with aws-observability/aws-otel-test-framework#1836 which adds the platform-grouped batch generator and log improvements.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.