### PR TITLE
Support branch matching for test repo in CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,12 +94,29 @@ jobs:
     steps:
       - name: Set testRef output
         id: setRef
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [[ ${{ github.ref_name }} == release/v* ]]; then
-            echo "ref=${{github.ref_name}}" >> $GITHUB_OUTPUT
-          else
-            echo "ref=terraform" >> $GITHUB_OUTPUT
+          ref=terraform
+          encoded_ref="${REF_NAME//\//%2F}"
+          if [[ $REF_NAME == release/v* ]]; then
+            if ! gh api repos/${{ env.TESTING_FRAMEWORK_REPO }}/branches/$encoded_ref --silent 2>/dev/null; then
+              echo "::error::Release branch '$REF_NAME' not found in ${{ env.TESTING_FRAMEWORK_REPO }}"
+              exit 1
+            fi
+            ref=$REF_NAME
+          elif [[ $REF_NAME == test/* ]] && \
+              gh api repos/${{ env.TESTING_FRAMEWORK_REPO }}/branches/$encoded_ref \
+              --silent 2>/dev/null; then
+            ref=$REF_NAME
           fi
+          if [[ $ref == terraform ]]; then
+            echo "::notice::Using default 'terraform' branch for test framework"
+          else
+            echo "::notice::Using test framework branch '$ref'"
+          fi
+          echo "ref=$ref" >> $GITHUB_OUTPUT
 
   build-aotutil:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
**Description:** Add logic to attempt branch matching for the test framework repo if the collector branch is `test/*`. Also enforces the `release/v*` branch for the test framework repo.

**Link to tracking Issue:** N/A

**Testing:** 
Without a matching branch
https://github.com/aws-observability/aws-otel-collector/actions/runs/25944514368/job/76269714156
```
Notice: Using default 'terraform' branch for test framework
```

After creating the matching branch
https://github.com/aws-observability/aws-otel-collector/actions/runs/25944514368/job/76269946119
```
Notice: Using test framework branch 'test/branch-match'
```

**Documentation:** N/A


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
