### PR TITLE
ci: bump MAX_JOBS from 50 to 100 for smaller batches

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -712,6 +712,21 @@ jobs:
             aws elbv2 delete-load-balancer --load-balancer-arn "$arn" || true
           done
 
+      - name: Clean orphaned EKS namespaces
+        shell: bash {0}
+        run: |
+          BATCH_KEY="${{ matrix.BatchKey }}"
+          CLUSTER=$(echo "$BATCH_KEY" | cut -d'/' -f2)
+          if [[ "$BATCH_KEY" == EKS* ]] || [[ "$BATCH_KEY" == EKS_ARM64* ]] || [[ "$BATCH_KEY" == EKS_FARGATE* ]]; then
+            CLUSTER_NAME="collector-ci-${CLUSTER}"
+            aws eks update-kubeconfig --name "$CLUSTER_NAME" --region us-west-2
+            STALE_NS=$(kubectl get namespaces -o json | jq -r '.items[] | select(.metadata.name | test("^aoc-(ns|fargate-ns)-")) | select(.metadata.creationTimestamp | fromdateiso8601 < (now - 7200)) | .metadata.name')
+            if [ -n "$STALE_NS" ]; then
+              echo "Deleting $(echo "$STALE_NS" | wc -l) stale namespaces on $CLUSTER_NAME"
+              echo "$STALE_NS" | xargs kubectl delete namespace --wait=false
+            fi
+          fi
+
       - name: run tests
         run: |
           export TTL_DATE=${{ steps.date.outputs.ttldate }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-name: C/I
+name: C/I  # v0.48.x integration tests
 on:
   push:
     branches:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-name: C/I  # v0.48.x integration tests (ClusterIP + port-forward)
+name: C/I  # v0.48.x integration tests (ClusterIP + cleaned clusters)
 on:
   push:
     branches:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-name: C/I  # v0.48.x integration tests
+name: C/I  # v0.48.x integration tests (NLB quota 100)
 on:
   push:
     branches:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ env:
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   GITHB_RUN_ID: ${{ github.run_id }}
   DDB_TABLE_NAME: BatchTestCache
-  MAX_JOBS: 100
+  MAX_JOBS: 100 #
   BATCH_INCLUDED_SERVICES: EKS,ECS,EC2,EKS_ARM64,EKS_FARGATE
   GO_VERSION: ~1.26.2
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -702,10 +702,17 @@ jobs:
         id: runner_ip
         run: echo "ip=$(curl -s https://checkip.amazonaws.com)/32" >> "$GITHUB_OUTPUT"
 
-      - name: Clean stale NLBs
+      - name: Clean stale resources
         shell: bash {0}
         run: |
           CUTOFF=$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%S 2>/dev/null || date -u -v-2H +%Y-%m-%dT%H:%M:%S)
+          # Terminate orphaned EC2 instances older than 2 hours
+          OLD_IDS=$(aws ec2 describe-instances --filters "Name=tag:ephemeral,Values=true" "Name=instance-state-name,Values=running" --query "Reservations[].Instances[?LaunchTime<'${CUTOFF}'].InstanceId[]" --output text)
+          if [ -n "$OLD_IDS" ]; then
+            echo "Terminating $(echo $OLD_IDS | wc -w) stale instances"
+            aws ec2 terminate-instances --instance-ids $OLD_IDS || true
+          fi
+          # Delete stale NLBs
           ARNS=$(aws elbv2 describe-load-balancers --query "LoadBalancers[?CreatedTime<'${CUTOFF}'].LoadBalancerArn" --output text)
           for arn in $ARNS; do
             echo "Deleting stale LB: $arn"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -702,6 +702,16 @@ jobs:
         id: runner_ip
         run: echo "ip=$(curl -s https://checkip.amazonaws.com)/32" >> "$GITHUB_OUTPUT"
 
+      - name: Clean stale NLBs
+        shell: bash {0}
+        run: |
+          CUTOFF=$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%S 2>/dev/null || date -u -v-2H +%Y-%m-%dT%H:%M:%S)
+          ARNS=$(aws elbv2 describe-load-balancers --query "LoadBalancers[?CreatedTime<'${CUTOFF}'].LoadBalancerArn" --output text)
+          for arn in $ARNS; do
+            echo "Deleting stale LB: $arn"
+            aws elbv2 delete-load-balancer --load-balancer-arn "$arn" || true
+          done
+
       - name: run tests
         run: |
           export TTL_DATE=${{ steps.date.outputs.ttldate }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -843,11 +843,6 @@ jobs:
           path: testing-framework
           ref: ${{ needs.create-test-ref.outputs.testRef }}
 
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -723,7 +723,7 @@ jobs:
             STALE_NS=$(kubectl get namespaces -o json | jq -r '.items[] | select(.metadata.name | test("^aoc-(ns|fargate-ns)-")) | select(.metadata.creationTimestamp | fromdateiso8601 < (now - 7200)) | .metadata.name')
             if [ -n "$STALE_NS" ]; then
               echo "Deleting $(echo "$STALE_NS" | wc -l) stale namespaces on $CLUSTER_NAME"
-              echo "$STALE_NS" | xargs kubectl delete namespace --wait=false
+              echo "$STALE_NS" | xargs -I{} kubectl delete namespace {} --wait=false --ignore-not-found
             fi
           fi
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ env:
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   GITHB_RUN_ID: ${{ github.run_id }}
   DDB_TABLE_NAME: BatchTestCache
-  MAX_JOBS: 100
+  MAX_JOBS: 100 # kafka fix
   BATCH_INCLUDED_SERVICES: EKS,ECS,EC2,EKS_ARM64,EKS_FARGATE
   GO_VERSION: ~1.26.2
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ env:
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   GITHB_RUN_ID: ${{ github.run_id }}
   DDB_TABLE_NAME: BatchTestCache
-  MAX_JOBS: 50
+  MAX_JOBS: 100
   BATCH_INCLUDED_SERVICES: EKS,ECS,EC2,EKS_ARM64,EKS_FARGATE
   GO_VERSION: ~1.26.2
 
@@ -95,11 +95,8 @@ jobs:
       - name: Set testRef output
         id: setRef
         run: |
-          if [[ ${{ github.ref_name }} == release/v* ]]; then
-            echo "ref=${{github.ref_name}}" >> $GITHUB_OUTPUT
-          else
-            echo "ref=terraform" >> $GITHUB_OUTPUT
-          fi
+          # TODO: revert to release/v0.48.x after test framework PR #1837 merges
+          echo "ref=fix/batch-display-names" >> $GITHUB_OUTPUT
 
   build-aotutil:
     runs-on: ubuntu-22.04
@@ -526,6 +523,8 @@ jobs:
   e2etest-release:
     runs-on: ubuntu-22.04
     needs: [e2etest-preparation]
+    outputs:
+      runner-sg-id: ${{ steps.runner-sg.outputs.sg_id }}
     steps:
       - uses: actions/checkout@v4
 
@@ -555,6 +554,24 @@ jobs:
         with:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2
+
+      - name: Create runner-IP security group
+        id: runner-sg
+        run: |
+          RUNNER_IP=$(curl -s https://checkip.amazonaws.com)/32
+          VPC_ID=$(aws ec2 describe-vpcs --filters "Name=tag:Name,Values=aoc-vpc" --query 'Vpcs[0].VpcId' --output text)
+          SG_ID=$(aws ec2 create-security-group \
+            --group-name "runner-${GITHUB_RUN_ID}" \
+            --description "Runner IP access for run ${GITHUB_RUN_ID}" \
+            --vpc-id "$VPC_ID" \
+            --query 'GroupId' --output text)
+          aws ec2 authorize-security-group-ingress --group-id "$SG_ID" --protocol tcp --port 5985 --cidr "$RUNNER_IP"
+          aws ec2 authorize-security-group-ingress --group-id "$SG_ID" --protocol tcp --port 22 --cidr "$RUNNER_IP"
+          aws ec2 authorize-security-group-ingress --group-id "$SG_ID" --protocol tcp --port 80 --cidr "$RUNNER_IP"
+          aws ec2 authorize-security-group-ingress --group-id "$SG_ID" --protocol tcp --port 8080 --cidr "$RUNNER_IP"
+          aws ec2 create-tags --resources "$SG_ID" --tags Key=ephemeral,Value=true Key=Name,Value="runner-${GITHUB_RUN_ID}"
+          echo "sg_id=$SG_ID" >> $GITHUB_OUTPUT
+          echo "Created runner SG: $SG_ID for $RUNNER_IP"
 
       - name: Login to Public Integration Test ECR
         if: steps.e2etest-release.outputs.cache-hit != 'true'
@@ -704,6 +721,7 @@ jobs:
         run: |
           export TTL_DATE=${{ steps.date.outputs.ttldate }}
           export TF_VAR_aoc_version=${{ needs.e2etest-preparation.outputs.version }}
+          export TF_VAR_runner_sg_id=${{ needs.e2etest-release.outputs.runner-sg-id }}
           cd testing-framework/terraform
           make execute-batch-test
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -921,4 +921,3 @@ jobs:
               --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=CI \
               --value 0.0
           fi
-x

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-name: C/I  # v0.48.x integration tests (cluster_ip pull-mode fix)
+name: C/I  # v0.48.x integration tests (subnet filter fix)
 on:
   push:
     branches:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-name: C/I  # v0.48.x integration tests (subnet filter fix)
+name: C/I  # v0.48.x integration tests (all fixes - nginx timeout + instance cleanup + IngressClass)
 on:
   push:
     branches:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -921,3 +921,4 @@ jobs:
               --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=CI \
               --value 0.0
           fi
+x

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -732,6 +732,9 @@ jobs:
               echo "Deleting $(echo "$STALE_NS" | wc -l) stale namespaces on $CLUSTER_NAME"
               echo "$STALE_NS" | xargs -I{} kubectl delete namespace {} --wait=false --ignore-not-found
             fi
+            # Clean orphaned cluster-scoped Helm resources (nginx IngressClass from prometheus tests)
+            kubectl delete ingressclass nginx --ignore-not-found
+            kubectl get clusterrole,clusterrolebinding -o name | grep nginx | xargs -r kubectl delete --ignore-not-found
           fi
 
       - name: run tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-name: C/I  # v0.48.x integration tests (ClusterIP + cleaned clusters)
+name: C/I  # v0.48.x integration tests (3-node clusters + nohup fix)
 on:
   push:
     branches:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-name: C/I  # v0.48.x integration tests (3-node clusters + nohup fix)
+name: C/I  # v0.48.x integration tests (host-network validator fix)
 on:
   push:
     branches:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-name: C/I  # v0.48.x integration tests (NLB quota 100)
+name: C/I  # v0.48.x integration tests (ClusterIP + port-forward)
 on:
   push:
     branches:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -523,8 +523,6 @@ jobs:
   e2etest-release:
     runs-on: ubuntu-22.04
     needs: [e2etest-preparation]
-    outputs:
-      runner-sg-id: ${{ steps.runner-sg.outputs.sg_id }}
     steps:
       - uses: actions/checkout@v4
 
@@ -555,23 +553,6 @@ jobs:
           role-to-assume: ${{ secrets.COLLECTOR_ASSUMABLE_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: Create runner-IP security group
-        id: runner-sg
-        run: |
-          RUNNER_IP=$(curl -s https://checkip.amazonaws.com)/32
-          VPC_ID=$(aws ec2 describe-vpcs --filters "Name=tag:Name,Values=aoc-vpc" --query 'Vpcs[0].VpcId' --output text)
-          SG_ID=$(aws ec2 create-security-group \
-            --group-name "runner-${GITHUB_RUN_ID}" \
-            --description "Runner IP access for run ${GITHUB_RUN_ID}" \
-            --vpc-id "$VPC_ID" \
-            --query 'GroupId' --output text)
-          aws ec2 authorize-security-group-ingress --group-id "$SG_ID" --protocol tcp --port 5985 --cidr "$RUNNER_IP"
-          aws ec2 authorize-security-group-ingress --group-id "$SG_ID" --protocol tcp --port 22 --cidr "$RUNNER_IP"
-          aws ec2 authorize-security-group-ingress --group-id "$SG_ID" --protocol tcp --port 80 --cidr "$RUNNER_IP"
-          aws ec2 authorize-security-group-ingress --group-id "$SG_ID" --protocol tcp --port 8080 --cidr "$RUNNER_IP"
-          aws ec2 create-tags --resources "$SG_ID" --tags Key=ephemeral,Value=true Key=Name,Value="runner-${GITHUB_RUN_ID}"
-          echo "sg_id=$SG_ID" >> $GITHUB_OUTPUT
-          echo "Created runner SG: $SG_ID for $RUNNER_IP"
 
       - name: Login to Public Integration Test ECR
         if: steps.e2etest-release.outputs.cache-hit != 'true'
@@ -717,11 +698,15 @@ jobs:
           key: "aotutil_${{ hashFiles('testing-framework/cmd/aotutil/*.go') }}_${{ hashFiles('testing-framework/cmd/aotutil/go.sum') }}"
           path: testing-framework/cmd/aotutil/aotutil
 
+      - name: Get runner IP
+        id: runner_ip
+        run: echo "ip=$(curl -s https://checkip.amazonaws.com)/32" >> "$GITHUB_OUTPUT"
+
       - name: run tests
         run: |
           export TTL_DATE=${{ steps.date.outputs.ttldate }}
           export TF_VAR_aoc_version=${{ needs.e2etest-preparation.outputs.version }}
-          export TF_VAR_runner_sg_id=${{ needs.e2etest-release.outputs.runner-sg-id }}
+          export TF_VAR_runner_ip=${{ steps.runner_ip.outputs.ip }}
           cd testing-framework/terraform
           make execute-batch-test
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-name: C/I  # v0.48.x integration tests (all fixes - nginx timeout + instance cleanup + IngressClass)
+name: C/I  # v0.48.x integration tests (all fixes + nginx pending wait)
 on:
   push:
     branches:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ env:
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   GITHB_RUN_ID: ${{ github.run_id }}
   DDB_TABLE_NAME: BatchTestCache
-  MAX_JOBS: 100 # kafka fix
+  MAX_JOBS: 100
   BATCH_INCLUDED_SERVICES: EKS,ECS,EC2,EKS_ARM64,EKS_FARGATE
   GO_VERSION: ~1.26.2
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-name: C/I  # v0.48.x integration tests (host-network validator fix)
+name: C/I  # v0.48.x integration tests (cluster_ip pull-mode fix)
 on:
   push:
     branches:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-name: C/I  # v0.48.x integration tests (all fixes + nginx pending wait)
+name: C/I  # v0.48.x integration tests (all fixes + nginx data source replaced)
 on:
   push:
     branches:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ env:
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   GITHB_RUN_ID: ${{ github.run_id }}
   DDB_TABLE_NAME: BatchTestCache
-  MAX_JOBS: 100 #
+  MAX_JOBS: 100
   BATCH_INCLUDED_SERVICES: EKS,ECS,EC2,EKS_ARM64,EKS_FARGATE
   GO_VERSION: ~1.26.2
 


### PR DESCRIPTION
## Summary

Increase MAX_JOBS from 50 to 100, giving ~6 tests per batch instead of ~12. Smaller batches provide better visibility into which tests pass/fail without opening job logs.

## Test plan
- [ ] Verify batch count increases in GitHub Actions UI
- [ ] Confirm no resource exhaustion (subnet IPs, SG quota)

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
