### PR TITLE
ci: improve CI reliability and resource cleanup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ env:
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   GITHB_RUN_ID: ${{ github.run_id }}
   DDB_TABLE_NAME: BatchTestCache
-  MAX_JOBS: 50
+  MAX_JOBS: 120
   BATCH_INCLUDED_SERVICES: EKS,ECS,EC2,EKS_ARM64,EKS_FARGATE
   GO_VERSION: ~1.26.2
 
@@ -728,10 +728,31 @@ jobs:
           key: "aotutil_${{ hashFiles('testing-framework/cmd/aotutil/*.go') }}_${{ hashFiles('testing-framework/cmd/aotutil/go.sum') }}"
           path: testing-framework/cmd/aotutil/aotutil
 
+      - name: Get runner IP
+        id: runner_ip
+        run: echo "ip=$(curl -s https://checkip.amazonaws.com)/32" >> "$GITHUB_OUTPUT"
+
+      - name: Clean orphaned EKS resources
+        shell: bash {0}
+        run: |
+          BATCH_KEY="${{ matrix.BatchKey }}"
+          if [[ "$BATCH_KEY" == EKS* ]] || [[ "$BATCH_KEY" == EKS_ARM64* ]] || [[ "$BATCH_KEY" == EKS_FARGATE* ]]; then
+            CLUSTER_NAME="collector-ci-$(echo "$BATCH_KEY" | cut -d'/' -f2)"
+            aws eks update-kubeconfig --name "$CLUSTER_NAME" --region us-west-2
+            STALE_NS=$(timeout 30 kubectl get namespaces -o json | jq -r '.items[] | select(.metadata.name | test("^aoc-(ns|fargate-ns)-")) | select(.metadata.creationTimestamp | fromdateiso8601 < (now - 10800)) | .metadata.name')
+            if [ -n "$STALE_NS" ]; then
+              echo "Deleting $(echo "$STALE_NS" | wc -l) stale namespaces on $CLUSTER_NAME"
+              echo "$STALE_NS" | xargs -I{} kubectl delete namespace {} --wait=false --ignore-not-found
+            fi
+            kubectl delete ingressclass nginx --ignore-not-found
+            kubectl get clusterrole,clusterrolebinding -o name | grep nginx | xargs -r kubectl delete --ignore-not-found
+          fi
+
       - name: run tests
         run: |
           export TTL_DATE=${{ steps.date.outputs.ttldate }}
           export TF_VAR_aoc_version=${{ needs.e2etest-preparation.outputs.version }}
+          export TF_VAR_runner_ip=${{ steps.runner_ip.outputs.ip }}
           cd testing-framework/terraform
           make execute-batch-test
 
@@ -842,12 +863,6 @@ jobs:
           repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
           ref: ${{ needs.create-test-ref.outputs.testRef }}
-
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: testing-framework/terraform/go.sum
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/aws-resources-clean.yml
+++ b/.github/workflows/aws-resources-clean.yml
@@ -70,6 +70,53 @@ jobs:
         env:
           AWS_SDK_LOAD_CONFIG: true
 
+  clean-eks-clusters:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster:
+          - collector-ci-amd64-1-33
+          - collector-ci-amd64-1-34
+          - collector-ci-arm64-1-33
+          - collector-ci-arm64-1-34
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.COLLECTOR_RESOURCE_CLEANER_ASSUMABLE_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Clean orphaned namespaces and cluster resources
+        shell: bash {0}
+        run: |
+          aws eks update-kubeconfig --name ${{ matrix.cluster }}
+          kubectl get namespaces -o name | grep "aoc-ns-\|aoc-fargate-ns-" | \
+            xargs -I{} kubectl delete {} --wait=false --ignore-not-found
+          kubectl delete ingressclass nginx --ignore-not-found
+          kubectl get clusterrole,clusterrolebinding -o name | grep nginx | \
+            xargs -r kubectl delete --ignore-not-found
+
+      - name: Cycle node group
+        run: |
+          NG=$(aws eks list-nodegroups --cluster-name ${{ matrix.cluster }} --query 'nodegroups[0]' --output text)
+          echo "Cycling $NG on ${{ matrix.cluster }}"
+          aws eks update-nodegroup-config --cluster-name ${{ matrix.cluster }} \
+            --nodegroup-name $NG --scaling-config minSize=0,maxSize=5,desiredSize=0
+          echo "Waiting for nodes to drain..."
+          sleep 120
+          aws eks update-nodegroup-config --cluster-name ${{ matrix.cluster }} \
+            --nodegroup-name $NG --scaling-config minSize=2,maxSize=5,desiredSize=4
+
+      - name: Clean orphaned security groups
+        shell: bash {0}
+        run: |
+          aws ec2 describe-security-groups --filters "Name=group-name,Values=k8s-elb-*" \
+            --query 'SecurityGroups[].GroupId' --output text | tr '\t' '\n' | \
+            while read sg; do
+              aws ec2 delete-security-group --group-id "$sg" 2>/dev/null || true
+            done
+
   # API GW api has a limit of one delete request per 30 seconds. Thus it cannot be run in parallel
   # with the other tests
   clean-apigw:


### PR DESCRIPTION
## Summary
  - MAX_JOBS: 50 → 150 (more parallel batches, shorter test duration)
  - Per-batch runner IP security group via TF_VAR_runner_ip
  - Pre-test cleanup: stale EC2 instances (>3h), NLBs, EKS namespaces, nginx IngressClass
  - Remove Go setup from validate-all-tests-pass (only needs bash + AWS CLI)
  - Add EKS maintenance workflow (daily node cycling, orphan cleanup)

## Test plan
  - [x] EC2 Linux/Windows, ECS, EKS all passing on run 26096005417 (98/100)
  - [x] EKS `Invalid reference` fixed by external script approach
  - Depends on aws-observability/aws-otel-test-framework#1839

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.