### PR TITLE
ci: improve CI reliability, resource cleanup, and EKS maintenance

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -746,6 +746,7 @@ jobs:
             fi
             kubectl delete ingressclass nginx --ignore-not-found
             kubectl get clusterrole,clusterrolebinding -o name | grep nginx | xargs -r kubectl delete --ignore-not-found
+            kubectl get validatingwebhookconfiguration -o name | grep nginx | xargs -r kubectl delete --ignore-not-found
           fi
 
       - name: run tests
@@ -848,9 +849,10 @@ jobs:
           ssm_package_name=${{ env.SSM_PACKAGE_NAME }} version=${{ steps.versioning.outputs.ssm_pkg_version }} bash tools/ssm/ssm_rollback_default_version.sh
       - name: clean up SSM test package
         if: steps.cache_packages.outputs.cache-hit == 'true'
+        shell: bash {0}
         run: |
           aws ssm describe-document --name ${{ env.SSM_PACKAGE_NAME }} --version-name ${{ steps.versioning.outputs.ssm_pkg_version }} >/dev/null 2>&1 && \
-            aws ssm delete-document --name ${{ env.SSM_PACKAGE_NAME }} --version-name ${{ steps.versioning.outputs.ssm_pkg_version }}
+            aws ssm delete-document --name ${{ env.SSM_PACKAGE_NAME }} --version-name ${{ steps.versioning.outputs.ssm_pkg_version }} || true
 
   validate-all-tests-pass:
     runs-on: ubuntu-22.04
@@ -947,3 +949,5 @@ jobs:
               --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=CI \
               --value 0.0
           fi
+
+

--- a/.github/workflows/aws-resources-clean.yml
+++ b/.github/workflows/aws-resources-clean.yml
@@ -96,6 +96,8 @@ jobs:
           kubectl delete ingressclass nginx --ignore-not-found
           kubectl get clusterrole,clusterrolebinding -o name | grep nginx | \
             xargs -r kubectl delete --ignore-not-found
+          kubectl get validatingwebhookconfiguration -o name | grep nginx | \
+            xargs -r kubectl delete --ignore-not-found
 
       - name: Cycle node group
         run: |


### PR DESCRIPTION
## Summary
  - Add EKS maintenance job to aws-resources-clean.yml (daily node cycling, orphaned
  namespace/webhook/SG cleanup)
  - SSM cleanup: non-fatal (`|| true`) to prevent post-test step from failing the run

  ## Test plan
  - [x] 165/165 (100%) on run 26140055699
  - [x] 164/165 (99.4%) consistent on runs 26133627595, 26161456883
  - Depends on aws-observability/aws-otel-test-framework#1839 (merged)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.