### PR TITLE
ci: trigger release validation run

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# v0.48.0 release validation
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.


### PR DESCRIPTION
Trigger CI on release/v0.48.x for final validation.