### PR TITLE
Update systemd detection

### DIFF
--- a/tools/ctl/linux/aws-otel-collector-ctl.sh
+++ b/tools/ctl/linux/aws-otel-collector-ctl.sh
@@ -216,7 +216,7 @@ main() {
     # detect which init system is in use
     if [ "$(/sbin/init --version 2>/dev/null | grep -c upstart)" = 1 ]; then
         SYSTEMD='false'
-    elif [ "$(systemctl | grep -c '\-\.mount')" = 1 ]; then
+    elif [ -d /run/systemd/system ]; then
         SYSTEMD='true'
     elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
         echo "sysv-init is not supported" >&2


### PR DESCRIPTION


**Description:** The existing init system detection would not detect systemd if additional -mount were present on the system. This fixes the issue but using the detection method recommended in https://www.freedesktop.org/software/systemd/man/latest/sd_booted.html

**Link to tracking Issue:** #3194

**Testing:** I haven't done any testing of this. Let me know how I should validate it.

**Documentation:** N/A


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
