### PR TITLE
ci: clean up Classic ELBs + orphan target groups, build validator image in canary and PR-build

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -377,6 +377,12 @@ jobs:
         env:
           AWS_REGION: us-east-1
 
+      - name: Build validator image
+        if: ${{ needs.changes.outputs.changed == 'true' }}
+        run: |
+          cd testing-framework
+          docker build -t aoc-validator:local ./validator
+
       - name: Run test
         if: ${{ needs.changes.outputs.changed == 'true' }}
         uses: nick-invision/retry@v2

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -127,6 +127,11 @@ jobs:
           key: "aotutil_${{ github.run_id }}"
           path: testing-framework/cmd/aotutil/aotutil
 
+      - name: Build validator image
+        run: |
+          cd testing-framework
+          docker build -t aoc-validator:local ./validator
+
       - name: Run Canary test
         uses: nick-fields/retry@v2
         with:

--- a/tools/workflow/cleaner/go.mod
+++ b/tools/workflow/cleaner/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-observability/aws-otel-collector/tools/workflow/cleaner
 go 1.24.11
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.41.0
+	github.com/aws/aws-sdk-go-v2 v1.41.12
 	github.com/aws/aws-sdk-go-v2/config v1.32.6
 	github.com/aws/aws-sdk-go-v2/service/amp v1.42.4
 	github.com/aws/aws-sdk-go-v2/service/apigateway v1.38.3
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.279.0
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.70.0
 	github.com/aws/aws-sdk-go-v2/service/efs v1.41.9
+	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.34.3
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.5
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.1
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.87.0
@@ -21,8 +22,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.6 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.28 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.28 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.16 // indirect
@@ -30,7 +31,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.5 // indirect
-	github.com/aws/smithy-go v1.24.0 // indirect
+	github.com/aws/smithy-go v1.27.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/tools/workflow/cleaner/go.sum
+++ b/tools/workflow/cleaner/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go-v2 v1.41.0 h1:tNvqh1s+v0vFYdA1xq0aOJH+Y5cRyZ5upu6roPgPKd4=
-github.com/aws/aws-sdk-go-v2 v1.41.0/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
+github.com/aws/aws-sdk-go-v2 v1.41.12 h1:DIKX2c31ekm9RA2D9FBj1EWXx++9AdAqRw+e78Tq2Ck=
+github.com/aws/aws-sdk-go-v2 v1.41.12/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4/go.mod h1:IOAPF6oT9KCsceNTvvYMNHy0+kMF8akOjeDvPENWxp4=
 github.com/aws/aws-sdk-go-v2/config v1.32.6 h1:hFLBGUKjmLAekvi1evLi5hVvFQtSo3GYwi+Bx4lpJf8=
@@ -8,10 +8,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.6 h1:F9vWao2TwjV2MyiyVS+duza0NIRt
 github.com/aws/aws-sdk-go-v2/credentials v1.19.6/go.mod h1:SgHzKjEVsdQr6Opor0ihgWtkWdfRAIwxYzSJ8O85VHY=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16 h1:80+uETIWS1BqjnN9uJ0dBUaETh+P1XwFy5vwHwK5r9k=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16/go.mod h1:wOOsYuxYuB/7FlnVtzeBYRcjSRtQpAW0hCP7tIULMwo=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16 h1:rgGwPzb82iBYSvHMHXc8h9mRoOUBZIGFgKb9qniaZZc=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16/go.mod h1:L/UxsGeKpGoIj6DxfhOWHWQ/kGKcd4I1VncE4++IyKA=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16 h1:1jtGzuV7c82xnqOVfx2F0xmJcOw5374L7N6juGW6x6U=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16/go.mod h1:M2E5OQf+XLe+SZGmmpaI2yy+J326aFf6/+54PoxSANc=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.28 h1:Xf2j7NdVcUKomlZ4iihOP4AZ3Fzlr8h4yKpXeP+OFPg=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.28/go.mod h1:O8cDo1dW63jU7ki//kRe1z+tLGcpnD1jrouitsQddDw=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.28 h1:KqIfN9kpkKkcBqBbNpNGTIrXO6ExTUvFKvXkC+YAzVo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.28/go.mod h1:uxtQiKvLtNS4iXVsH2McVD/ls8FKN/uUhe1hGxPjrw0=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEGm0OUEZqm4K/Gcfk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/service/amp v1.42.4 h1:CHe6MxF6jDoy9KP2gTq7x9AqLgpsfyYN1XXR7j2VZ0k=
@@ -26,6 +26,8 @@ github.com/aws/aws-sdk-go-v2/service/ecs v1.70.0 h1:IZpZatHsscdOKjwmDXC6idsCXmm3
 github.com/aws/aws-sdk-go-v2/service/ecs v1.70.0/go.mod h1:LQMlcWBoiFVD3vUVEz42ST0yTiaDujv2dRE6sXt1yPE=
 github.com/aws/aws-sdk-go-v2/service/efs v1.41.9 h1:uHir2myVtdCfpe6ZcmOgmkUFRTUq2mKfhvfQpBcrry4=
 github.com/aws/aws-sdk-go-v2/service/efs v1.41.9/go.mod h1:qOhKklI/Hn44U8oZPT16hdCAAjap4PWmCkwDm5YNVPY=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.34.3 h1:6VzJULpLj7w7GQVpHqMm2UuPXHgfo0Mg259qi970iO8=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.34.3/go.mod h1:qQRGWMXDdy/rLGTzJWFlUM+GMs1KLSq/Uw8GnDLzIbo=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.5 h1:JjKuK9zbAVv6X44ia/OZrRS8ngOx3QfvtQTN0poJdPw=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.5/go.mod h1:qZnMTI+Q9S/C2dNbIMhIH8XMMR3UpO1dgpM4FnH8ZOY=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.1 h1:xNCUk9XN6Pa9PyzbEfzgRpvEIVlqtth402yjaWvNMu4=
@@ -44,8 +46,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.12 h1:AHDr0DaHIAo8c9t1emrzAlV
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.12/go.mod h1:GQ73XawFFiWxyWXMHWfhiomvP3tXtdNar/fi8z18sx0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.5 h1:SciGFVNZ4mHdm7gpD1dgZYnCuVdX1s+lFTg4+4DOy70=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.5/go.mod h1:iW40X4QBmUxdP+fZNOpfmkdMZqsovezbAeO+Ubiv2pk=
-github.com/aws/smithy-go v1.24.0 h1:LpilSUItNPFr1eY85RYgTIg5eIEPtvFbskaFcmmIUnk=
-github.com/aws/smithy-go v1.24.0/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
+github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
+github.com/aws/smithy-go v1.27.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tools/workflow/cleaner/loadbalancer/clean.go
+++ b/tools/workflow/cleaner/loadbalancer/clean.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing"
+	classictypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing/types"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 )
@@ -37,6 +39,18 @@ var logger = log.New(os.Stdout, fmt.Sprintf("[%s] ", Type), log.LstdFlags)
 
 func Clean(ctx context.Context, cfg aws.Config, expirationDate time.Time) error {
 	logger.Printf("Begin to clean Load Balancer resources")
+	if err := cleanV2LoadBalancers(ctx, cfg, expirationDate); err != nil {
+		return err
+	}
+	if err := cleanClassicLoadBalancers(ctx, cfg, expirationDate); err != nil {
+		return err
+	}
+	return cleanOrphanTargetGroups(ctx, cfg)
+}
+
+// cleanV2LoadBalancers deletes ALB/NLB load balancers whose name contains
+// "aoc-lb" and whose CreatedTime is older than expirationDate.
+func cleanV2LoadBalancers(ctx context.Context, cfg aws.Config, expirationDate time.Time) error {
 	elbv2client := elasticloadbalancingv2.NewFromConfig(cfg)
 
 	//Allow to load all the load balancers since the default respond is paginated load balancers.
@@ -69,10 +83,94 @@ func Clean(ctx context.Context, cfg aws.Config, expirationDate time.Time) error 
 	return nil
 }
 
+// cleanClassicLoadBalancers deletes Classic ELBs with no registered backends
+// older than expirationDate. Kubernetes-provisioned ELBs have auto-generated
+// names, so this matches by zero-backends + age rather than by name.
+func cleanClassicLoadBalancers(ctx context.Context, cfg aws.Config, expirationDate time.Time) error {
+	client := elasticloadbalancing.NewFromConfig(cfg)
+
+	paginator := elasticloadbalancing.NewDescribeLoadBalancersPaginator(client, &elasticloadbalancing.DescribeLoadBalancersInput{})
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, lb := range output.LoadBalancerDescriptions {
+			if !shouldDeleteClassicLoadBalancer(lb, expirationDate) {
+				continue
+			}
+
+			logger.Printf("Trying to delete classic lb %s with launch-date %v", *lb.LoadBalancerName, lb.CreatedTime)
+			_, err = client.DeleteLoadBalancer(ctx, &elasticloadbalancing.DeleteLoadBalancerInput{LoadBalancerName: lb.LoadBalancerName})
+			if err != nil {
+				return err
+			}
+			logger.Printf("Deleted classic lb %s successfully", *lb.LoadBalancerName)
+		}
+	}
+	return nil
+}
+
+// cleanOrphanTargetGroups deletes "aoc-lb" target groups whose parent LB
+// has been deleted. DescribeTargetGroups doesn't expose CreatedTime, so
+// empty LoadBalancerArns is the orphan signal.
+func cleanOrphanTargetGroups(ctx context.Context, cfg aws.Config) error {
+	elbv2client := elasticloadbalancingv2.NewFromConfig(cfg)
+
+	paginator := elasticloadbalancingv2.NewDescribeTargetGroupsPaginator(elbv2client, &elasticloadbalancingv2.DescribeTargetGroupsInput{})
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, tg := range output.TargetGroups {
+			if !shouldDeleteTargetGroup(tg) {
+				continue
+			}
+
+			logger.Printf("Trying to delete orphan target group %s", *tg.TargetGroupName)
+			_, err = elbv2client.DeleteTargetGroup(ctx, &elasticloadbalancingv2.DeleteTargetGroupInput{TargetGroupArn: tg.TargetGroupArn})
+			if err != nil {
+				return err
+			}
+			logger.Printf("Deleted orphan target group %s successfully", *tg.TargetGroupName)
+		}
+	}
+	return nil
+}
+
 // shouldDeleteLoadBalancer returns true if the load balancer name contains "aoc-lb" and is older than the expiration date.
 func shouldDeleteLoadBalancer(lb types.LoadBalancer, expirationDate time.Time) bool {
 	if lb.LoadBalancerName == nil || lb.CreatedTime == nil {
 		return false
 	}
 	return strings.Contains(*lb.LoadBalancerName, containLbName) && expirationDate.After(*lb.CreatedTime)
+}
+
+// shouldDeleteClassicLoadBalancer returns true if the ELB has no registered
+// backends and is older than expirationDate.
+func shouldDeleteClassicLoadBalancer(lb classictypes.LoadBalancerDescription, expirationDate time.Time) bool {
+	if lb.LoadBalancerName == nil || lb.CreatedTime == nil {
+		return false
+	}
+	if len(lb.Instances) > 0 {
+		return false
+	}
+	return expirationDate.After(*lb.CreatedTime)
+}
+
+// shouldDeleteTargetGroup returns true if the target group name contains
+// "aoc-lb" and has no parent load balancer.
+func shouldDeleteTargetGroup(tg types.TargetGroup) bool {
+	if tg.TargetGroupName == nil {
+		return false
+	}
+	if len(tg.LoadBalancerArns) > 0 {
+		return false
+	}
+	return strings.Contains(*tg.TargetGroupName, containLbName)
 }

--- a/tools/workflow/cleaner/loadbalancer/clean_test.go
+++ b/tools/workflow/cleaner/loadbalancer/clean_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	classictypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing/types"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -86,6 +87,108 @@ func TestShouldDeleteLoadBalancer(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result := shouldDeleteLoadBalancer(tc.lb, tc.expirationDate)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestShouldDeleteClassicLoadBalancer(t *testing.T) {
+	now := time.Now()
+	oldTime := now.Add(-10 * 24 * time.Hour)
+	newTime := now.Add(-1 * 24 * time.Hour)
+	expirationDate := now.Add(-5 * 24 * time.Hour)
+
+	tests := []struct {
+		name           string
+		lb             classictypes.LoadBalancerDescription
+		expirationDate time.Time
+		expected       bool
+	}{
+		{
+			name: "old zero-backend lb (k8s leak) should be deleted",
+			lb: classictypes.LoadBalancerDescription{
+				LoadBalancerName: aws.String("a1b2c3d4e5f6g7h8i9j0"),
+				CreatedTime:      &oldTime,
+				Instances:        nil,
+			},
+			expirationDate: expirationDate,
+			expected:       true,
+		},
+		{
+			name: "young zero-backend lb should not be deleted",
+			lb: classictypes.LoadBalancerDescription{
+				LoadBalancerName: aws.String("a1b2c3d4e5f6g7h8i9j0"),
+				CreatedTime:      &newTime,
+				Instances:        nil,
+			},
+			expirationDate: expirationDate,
+			expected:       false,
+		},
+		{
+			name: "old lb with backends should not be deleted",
+			lb: classictypes.LoadBalancerDescription{
+				LoadBalancerName: aws.String("production-elb"),
+				CreatedTime:      &oldTime,
+				Instances: []classictypes.Instance{
+					{InstanceId: aws.String("i-0123456789abcdef0")},
+				},
+			},
+			expirationDate: expirationDate,
+			expected:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := shouldDeleteClassicLoadBalancer(tc.lb, tc.expirationDate)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestShouldDeleteTargetGroup(t *testing.T) {
+	tests := []struct {
+		name     string
+		tg       types.TargetGroup
+		expected bool
+	}{
+		{
+			name: "aoc-lb orphan tg should be deleted",
+			tg: types.TargetGroup{
+				TargetGroupName:  aws.String("aoc-lbtg-0124db2f4f513571"),
+				LoadBalancerArns: []string{},
+			},
+			expected: true,
+		},
+		{
+			name: "aoc-lb tg with parent lb should not be deleted",
+			tg: types.TargetGroup{
+				TargetGroupName:  aws.String("aoc-lbtg-0124db2f4f513571"),
+				LoadBalancerArns: []string{"arn:aws:elasticloadbalancing:us-west-2:111122223333:loadbalancer/app/aoc-lb-x/abc"},
+			},
+			expected: false,
+		},
+		{
+			name: "non-aoc orphan tg should not be deleted",
+			tg: types.TargetGroup{
+				TargetGroupName:  aws.String("production-tg"),
+				LoadBalancerArns: []string{},
+			},
+			expected: false,
+		},
+		{
+			name: "tg with nil name should not be deleted",
+			tg: types.TargetGroup{
+				TargetGroupName:  nil,
+				LoadBalancerArns: []string{},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := shouldDeleteTargetGroup(tc.tg)
 			assert.Equal(t, tc.expected, result)
 		})
 	}


### PR DESCRIPTION
## Summary
Two small CI fixes in this repo.

**1. Resource cleaner — Classic ELBs + orphan target groups.** The cleaner only described ALB/NLBs, so Classic ELBs were never reclaimed. Target groups whose parent LB was deleted (e.g. on cancelled runs) also accumulated. Two new passes:

- Classic ELBs: delete when zero registered backends and `CreatedTime` older than `DAYS_TO_KEEP`.
- Orphan target groups: delete when the name contains `aoc-lb` and `LoadBalancerArns` is empty.

No change to the existing v2 ALB/NLB code path.

**2. Canary + PR-build workflows — build `aoc-validator:local`.** Both workflows run `terraform/canary` or `terraform/mock` directly without going through `executeTerraformTest.sh`, which is what builds the validator image. `terraform destroy` then tries to pull it from a registry and fails. Build the image explicitly before `terraform apply` in both workflows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.