### PR TITLE
ci: build aoc-validator:local in canary workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -127,6 +127,11 @@ jobs:
           key: "aotutil_${{ github.run_id }}"
           path: testing-framework/cmd/aotutil/aotutil
 
+      - name: Build validator image
+        run: |
+          cd testing-framework
+          docker build -t aoc-validator:local ./validator
+
       - name: Run Canary test
         uses: nick-fields/retry@v2
         with:


### PR DESCRIPTION
## Summary
- Build `aoc-validator:local` in the canary job before `terraform apply`. The C/I path builds it via `terraform/executeTerraformTest.sh:83`, but the canary path uses `terraform/canary` directly without that script, so the image never exists. When `validator_docker_compose.yml` is later torn down, docker tries to pull it from a registry and fails.

## Test plan
- [x] YAML parses cleanly (`python3 -c "yaml.safe_load(...)"`)
- [ ] Workflow run on this branch
- [x] Local repro: confirmed every Canary Test run since at least 2026-06-04 has failed with `pull access denied for aoc-validator, repository does not exist or may require docker login` ([example](https://github.com/aws-observability/aws-otel-collector/actions/workflows/canary.yml))

## Background
Surfaced while auditing why daily test-account spend hasn't dropped further despite [#3210](https://github.com/aws-observability/aws-otel-collector/pull/3210) and the cleanup work earlier this cycle. The canary has been failing every 3 hours for at least the last 24h, which means continuous resource churn from never-completing tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
