### PR TITLE
ci: build and share aotutil via run-scoped artifact instead of cache

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -104,21 +104,23 @@ jobs:
           repository: ${{ env.TESTING_FRAMEWORK_REPO }}
           path: testing-framework
           ref: ${{ needs.create-test-ref.outputs.testRef }}
-      - name: Cache aotutil
-        id: cached_aotutil
-        uses: actions/cache@v3
-        with:
-          key: "aotutil_${{ hashFiles('testing-framework/cmd/aotutil/*.go') }}_${{ hashFiles('testing-framework/cmd/aotutil/go.sum') }}"
-          path: testing-framework/cmd/aotutil/aotutil
       - name: Set up Go 1.x
-        if: steps.cached_aotutil.outputs.cache-hit != 'true'
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: testing-framework/cmd/aotutil/go.sum
       - name: Build aotutil
-        if: steps.cached_aotutil.outputs.cache-hit != 'true'
         run: cd testing-framework/cmd/aotutil && make build
+      # Share the binary via a run-scoped artifact instead of actions/cache.
+      # Caches are branch-scoped and LRU-evicted, so run-batch-job on a feature
+      # branch frequently missed the cache and left aotutil absent; artifacts are
+      # visible to every job in the same run regardless of branch.
+      - name: Upload aotutil
+        uses: actions/upload-artifact@v4
+        with:
+          name: aotutil
+          path: testing-framework/cmd/aotutil/aotutil
+          retention-days: 1
 
   build:
     runs-on: ${{ vars.ADOTLARGERUNNERS || 'ubuntu-22.04' }}
@@ -723,11 +725,13 @@ jobs:
         id: date
         run: echo "ttldate=$(date -u -d "+7 days" +%s)" >> $GITHUB_OUTPUT
 
-      - name: Restore aotutil
-        uses: actions/cache@v3
+      - name: Download aotutil
+        uses: actions/download-artifact@v4
         with:
-          key: "aotutil_${{ hashFiles('testing-framework/cmd/aotutil/*.go') }}_${{ hashFiles('testing-framework/cmd/aotutil/go.sum') }}"
-          path: testing-framework/cmd/aotutil/aotutil
+          name: aotutil
+          path: testing-framework/cmd/aotutil
+      - name: Make aotutil executable
+        run: chmod +x testing-framework/cmd/aotutil/aotutil
 
       - name: Get runner IP
         id: runner_ip


### PR DESCRIPTION
## Title: ci: build and share aotutil via run-scoped artifact instead of cache

## Problem

- All 32 ECS jobs (ECS/EC2 and ECS/FARGATE) fail at terraform apply with local-exec provisioner error on aotutil ssm wait-patch; EC2/EKS jobs pass.
- Only ECS runs check_patch (terraform/ecs sets patch = true; ec2/eks default false), so only ECS invokes the aotutil binary.
- run-batch-job restored aotutil from actions/cache, but that cache is branch-scoped and LRU-evicted. On feature branches the entry was missing, leaving the binary absent, and there was no build fallback.

## Change

- build-aotutil: always build, then upload the binary as a run-scoped artifact (drop actions/cache).
- run-batch-job: download the artifact (already needs: build-aotutil) and chmod +x it, since artifact zips do not preserve the executable bit.

#### Why artifacts
- Visible to every job in the same run regardless of branch, and not subject to the 10 GB branch-scoped cache eviction. Build happens once; each job pulls ~8 MB.

## Testing

- YAML validated; workflow logic verified against the failing run.
- Full CI validation happens on push (branch matches the test/* trigger).


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
