### PR TITLE
Match test framework ref to a test/* branch's PR release base

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,16 +76,25 @@ jobs:
         run: |
           ref=terraform
           encoded_ref="${REF_NAME//\//%2F}"
+          fw_has() { gh api repos/${{ env.TESTING_FRAMEWORK_REPO }}/branches/"$1" --silent 2>/dev/null; }
           if [[ $REF_NAME == release/v* ]]; then
-            if ! gh api repos/${{ env.TESTING_FRAMEWORK_REPO }}/branches/$encoded_ref --silent 2>/dev/null; then
+            if ! fw_has "$encoded_ref"; then
               echo "::error::Release branch '$REF_NAME' not found in ${{ env.TESTING_FRAMEWORK_REPO }}"
               exit 1
             fi
             ref=$REF_NAME
-          elif [[ $REF_NAME == test/* ]] && \
-              gh api repos/${{ env.TESTING_FRAMEWORK_REPO }}/branches/$encoded_ref \
-              --silent 2>/dev/null; then
-            ref=$REF_NAME
+          elif [[ $REF_NAME == test/* ]]; then
+            if fw_has "$encoded_ref"; then
+              # Same-named framework branch wins.
+              ref=$REF_NAME
+            else
+              # Else match the framework branch to the PR's release base.
+              base=$(gh pr list --repo ${{ github.repository }} --head "$REF_NAME" \
+                --state open --json baseRefName --jq '.[0].baseRefName' 2>/dev/null)
+              if [[ $base == release/v* ]] && fw_has "${base//\//%2F}"; then
+                ref=$base
+              fi
+            fi
           fi
           if [[ $ref == terraform ]]; then
             echo "::notice::Using default 'terraform' branch for test framework"


### PR DESCRIPTION
## Problem

For a `test/*` collector branch with no same-named `aws-otel-test-framework` branch, `create-test-ref` falls back to `terraform`, even when the branch's PR targets `release/v*`.

The run then tests against `terraform` instead of the release branch the change ships on.

## Change

For `test/*` with no same-named framework branch, resolve the framework ref from the branch's open PR base:

- same-named framework branch -> use it (unchanged)
- else PR base is `release/v*` and framework has it -> use that release branch
- else -> `terraform` (unchanged)

`release/v*` and default behavior are unchanged.

## Notes

- Uses `gh pr list --head` with `github.token` (read-only on PRs). A push before the PR is opened has no base to resolve and falls back to `terraform`.
- Validated by YAML parse and a local resolver sim (test/bump-otel-v0.156.0 -> release/v0.49.x).

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
