### PR TITLE
drop eks resourcedetection detector for Fargate container insights

### DIFF
--- a/deployment-template/eks/otel-fargate-container-insights.yaml
+++ b/deployment-template/eks/otel-fargate-container-insights.yaml
@@ -437,9 +437,8 @@ data:
             action: update
             new_name: container_$$1
 
-      # add cluster name from env variable and EKS metadata
       resourcedetection:
-        detectors: [env, eks]
+        detectors: [env]
 
       batch:
         timeout: 60s


### PR DESCRIPTION
## Change

`deployment-template/eks/otel-fargate-container-insights.yaml`: drop the `eks` resource-detection detector, leaving `detectors: [env]`.

The `eks` detector fatally fails on Fargate (no IMDS, `K8S_NODE_NAME` unset). This mirrors the test-framework config map fixed in aws-observability/aws-otel-test-framework#1829, keeping the customer-facing template in sync with the tested config.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
