### PR TITLE
build aoc-validator image before performance test

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -184,6 +184,9 @@ jobs:
           path: testing-framework/cmd/aotutil/aotutil
           fail-on-cache-miss: true
 
+      - name: Build validator image
+        run: docker build -t aoc-validator:local testing-framework/validator
+
       - name: Run Performance test
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi


### PR DESCRIPTION
## Change

Add a `Build validator image` step to the `run-perf-test` job so `aoc-validator:local` exists before `terraform apply`.

The perf workflow runs `terraform apply` on `terraform/performance` directly, bypassing `executeTerraformTest.sh`, which is the only place that builds the validator image. Without a local image the validator step tries to pull `aoc-validator` and fails with access-denied.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
