### PR TITLE
ci: remove perf validator pre-build step

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -184,9 +184,6 @@ jobs:
           path: testing-framework/cmd/aotutil/aotutil
           fail-on-cache-miss: true
 
-      - name: Build validator image
-        run: docker build -t aoc-validator:local testing-framework/validator
-
       - name: Run Performance test
         run: |
           if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; else opts="" ; fi


### PR DESCRIPTION
## Change

Remove the `Build validator image` step from the `run-perf-test` job in `.github/workflows/perf.yml`.

The validator config for perf is generated during `terraform apply` and baked into the image at build time, so the image must be built after config generation. That build now lives in the perf terraform module (aws-otel-test-framework `terraform/performance/main.tf`). A workflow pre-step ran before the config existed and produced a stale image, so it is removed here.

Depends on the framework change landing first.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
