### PR TITLE
ci(canary): pass TF_VAR_runner_ip so runner_access SG is created

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -132,12 +132,17 @@ jobs:
           cd testing-framework
           docker build -t aoc-validator:local ./validator
 
+      - name: Get runner IP
+        id: runner_ip
+        run: echo "ip=$(curl -s https://checkip.amazonaws.com)/32" >> "$GITHUB_OUTPUT"
+
       - name: Run Canary test
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
           timeout_minutes: 60
           command: |
+            export TF_VAR_runner_ip=${{ steps.runner_ip.outputs.ip }}
             opts=""
             if [[ -f testing-framework/terraform/testcases/${{ matrix.testcase }}/parameters.tfvars ]] ; then opts="-var-file=../testcases/${{ matrix.testcase }}/parameters.tfvars" ; fi
             cd testing-framework/terraform/canary
@@ -147,4 +152,5 @@ jobs:
       - name: Destroy terraform resources
         if: ${{ always() }}
         run: |
+          export TF_VAR_runner_ip=${{ steps.runner_ip.outputs.ip }}
           cd testing-framework/terraform/canary && terraform destroy -auto-approve -var="region=us-west-2"


### PR DESCRIPTION
**Description:**  The test framework (aws-otel-test-framework ab61804f) moved SSH/WinRM/ HTTP/8080 ingress into a per-run runner_access security group that is only created when TF_VAR_runner_ip is set. CI.yml was updated to pass it but canary.yml was not, so canary instances have no runner ingress: Windows testcases fail with WinRM (5985) i/o timeouts and Linux validators cannot reach the sample app on 8080.

Mirror the CI.yml pattern: resolve the runner public IP via checkip.amazonaws.com and export TF_VAR_runner_ip for both apply and destroy.

Requires the companion test-framework change forwarding runner_ip from the canary root module to the ec2 module.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
